### PR TITLE
[BREAKING] fix: do not remove newly added blocks from main in swap_main_blockchain 

### DIFF
--- a/crates/btc-relay/src/lib.rs
+++ b/crates/btc-relay/src/lib.rs
@@ -510,7 +510,7 @@ impl<T: Config> Pallet<T> {
         let current_block_height = prev_block_height.checked_add(1).ok_or(Error::<T>::ArithmeticOverflow)?;
 
         // get the block chain of the previous header
-        let prev_blockchain = Self::get_block_chain_from_id(prev_header.chain_ref)?;
+        let prev_blockchain = Self::get_block_chain_from_id(prev_header.chain_id)?;
 
         // ensure the block header is valid
         Self::verify_block_header(&basic_block_header, current_block_height, prev_header)?;
@@ -680,7 +680,7 @@ impl<T: Config> Pallet<T> {
 
         let rich_header = Self::get_block_header_from_hash(block_hash)?;
 
-        ensure!(rich_header.chain_ref == MAIN_CHAIN_ID, Error::<T>::InvalidChainID);
+        ensure!(rich_header.chain_id == MAIN_CHAIN_ID, Error::<T>::InvalidChainID);
 
         let block_height = rich_header.block_height;
 
@@ -1010,7 +1010,7 @@ impl<T: Config> Pallet<T> {
         block_height: u32,
     ) -> Result<U256, DispatchError> {
         // get time of last retarget
-        let last_retarget_time = Self::get_last_retarget_time(prev_block_header.chain_ref, block_height)?;
+        let last_retarget_time = Self::get_last_retarget_time(prev_block_header.chain_id, block_height)?;
         // Compute new target
         let actual_timespan = if ((prev_block_header.block_header.timestamp as u64 - last_retarget_time) as u32)
             < (TARGET_TIMESPAN / TARGET_TIMESPAN_DIVISOR)
@@ -1039,10 +1039,10 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `chain_ref` - BlockChain identifier
+    /// * `chain_id` - BlockChain identifier
     /// * `block_height` - current block height
-    fn get_last_retarget_time(chain_ref: u32, block_height: u32) -> Result<u64, DispatchError> {
-        let block_chain = Self::get_block_chain_from_id(chain_ref)?;
+    fn get_last_retarget_time(chain_id: u32, block_height: u32) -> Result<u64, DispatchError> {
+        let block_chain = Self::get_block_chain_from_id(chain_id)?;
         let last_retarget_header =
             Self::get_block_header_from_height(&block_chain, block_height - DIFFICULTY_ADJUSTMENT_INTERVAL)?;
         Ok(last_retarget_header.block_header.timestamp as u64)
@@ -1076,8 +1076,8 @@ impl<T: Config> Pallet<T> {
             let (child, parent) = pair?;
 
             // if we reached a different fork, we need to update it
-            if parent.chain_ref != child.chain_ref {
-                let mut new_fork = Self::get_block_chain_from_id(parent.chain_ref)?;
+            if parent.chain_id != child.chain_id {
+                let mut new_fork = Self::get_block_chain_from_id(parent.chain_id)?;
                 // update the start height of the parent's chain. There is guaranteed to be at least
                 // one block in this chain that is not becoming part of the new main chain, because
                 // if there were not, then the child would have been added directly to this chain,
@@ -1088,7 +1088,7 @@ impl<T: Config> Pallet<T> {
                     .ok_or(Error::<T>::ArithmeticOverflow)?;
                 // If we reached the main chain, we store the remaining forked old main chain where
                 // the longest chain used to be.
-                if parent.chain_ref == MAIN_CHAIN_ID {
+                if parent.chain_id == MAIN_CHAIN_ID {
                     new_fork.chain_id = fork.chain_id;
                 }
 
@@ -1101,7 +1101,7 @@ impl<T: Config> Pallet<T> {
             Self::swap_block_to_mainchain(child, fork.chain_id)?;
 
             // main chain reached, stop iterating
-            if parent.chain_ref == MAIN_CHAIN_ID {
+            if parent.chain_id == MAIN_CHAIN_ID {
                 break;
             }
         }
@@ -1151,17 +1151,17 @@ impl<T: Config> Pallet<T> {
         let replaced_block_hash = ChainsHashes::<T>::try_get(MAIN_CHAIN_ID, block_height);
 
         // remove from old chain and insert into the new one
-        ChainsHashes::<T>::remove(block.chain_ref, block_height);
+        ChainsHashes::<T>::remove(block.chain_id, block_height);
         ChainsHashes::<T>::insert(MAIN_CHAIN_ID, block_height, block.block_header.hash);
 
         // update the chainref of the block
-        BlockHeaders::<T>::mutate(&block.block_header.hash, |header| header.chain_ref = MAIN_CHAIN_ID);
+        BlockHeaders::<T>::mutate(&block.block_header.hash, |header| header.chain_id = MAIN_CHAIN_ID);
 
         // if there was a block at block_height in the mainchain, we need to move it
         if let Ok(replaced_block_hash) = replaced_block_hash {
             ChainsHashes::<T>::insert(chain_id_for_old_main_blocks, block_height, replaced_block_hash);
             BlockHeaders::<T>::mutate(&replaced_block_hash, |header| {
-                header.chain_ref = chain_id_for_old_main_blocks
+                header.chain_id = chain_id_for_old_main_blocks
             });
         }
 

--- a/crates/btc-relay/src/types.rs
+++ b/crates/btc-relay/src/types.rs
@@ -13,7 +13,7 @@ pub struct RichBlockHeader<BlockNumber> {
     /// height of the block in the bitcoin chain
     pub block_height: u32,
     /// id if the chain that this block belongs to
-    pub chain_ref: u32,
+    pub chain_id: u32,
     /// active_block_number of the parachain at the time this block was submitted
     pub para_height: BlockNumber,
 }
@@ -24,15 +24,15 @@ impl<BlockNumber> RichBlockHeader<BlockNumber> {
     /// # Arguments
     ///
     /// * `block_header` - Bitcoin block header
-    /// * `chain_ref` - chain reference
+    /// * `chain_id` - chain reference
     /// * `block_height` - chain height
     /// * `account_id` - submitter
     /// * `para_height` - height of the parachain at submission
-    pub fn new(block_header: BlockHeader, chain_ref: u32, block_height: u32, para_height: BlockNumber) -> Self {
+    pub fn new(block_header: BlockHeader, chain_id: u32, block_height: u32, para_height: BlockNumber) -> Self {
         RichBlockHeader {
             block_header,
             block_height,
-            chain_ref,
+            chain_id,
             para_height,
         }
     }


### PR DESCRIPTION
The way `swap_main_blockchain` worked, was by traversing from the fork tip to the main chain by following the `prev_hash`es. It would move the blocks one by one to the main chain. When it reached the main chain, it moved all blocks that had a height higher than the first reached main block into the original fork. The problem is, it would move also the newly added blocks. As a result, blocks from the fork that overtakes main were unable to be used by transactions. 

With this PR, when a block is transferred to the main chain, the existing block is moved to into the fork. I also added some new invariants for `swap_main_blockchain`, basically checking that the blocks are moved correctly and agree with ChainsIndex metadata. My initial fix would simply swap the block of the main block chain with the block being traversed over, but this is incorrect: if C is a fork of B, which is a fork of A, then when blocks from B are moved to A, any preexisting block in A must be moved to C, **not** B. The new invariant caught that mistake.


Also added a test with real world fork data, which triggered the original bug.

As suggested by Greg, includes this **breaking change**:
- renamed RichBlockHeader.chain_ref -> chain_id