### PR TITLE
chore: disable incremental building to prevent triggering a compiler bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,16 @@ members = [
 ]
 
 resolver = "2"
+
+
+# disable incremental compilation to work around a compiler bug.
+# See https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html
+# When we upgrade compiler versions, we may be able to reenable incremental.
+[profile.test]
+incremental = false
+
+[profile.dev]
+incremental = false
+
+[profile.release]
+incremental = false


### PR DESCRIPTION
For the bug, see [the Rust blog](https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html). In short: incremental building sometimes resulted in a compiler crash, which would necessitate a `cargo clean` to recover.

When we upgrade compiler versions, we may be able to reenable incremental.