### PR TITLE
Refactor: transaction input

### DIFF
--- a/crates/bitcoin/examples/parse-transaction.rs
+++ b/crates/bitcoin/examples/parse-transaction.rs
@@ -8,7 +8,6 @@ use bitcoin::parser::parse_transaction;
 fn main() {
     let raw_tx = hex::decode(RAW_TRANSACTION).unwrap();
     let tx = parse_transaction(&raw_tx).unwrap();
-    println!("height {}", &tx.inputs[0].height.unwrap());
     println!("ouptut 1 script {}", tx.outputs[0].script.as_hex());
     println!("ouptut 2 script {}", tx.outputs[1].script.as_hex());
 }

--- a/crates/bitcoin/src/parser.rs
+++ b/crates/bitcoin/src/parser.rs
@@ -367,7 +367,7 @@ fn parse_transaction_input(raw_input: &[u8], version: i32) -> Result<(Transactio
     let mut script_size: u64 = parser.parse::<CompactUint>()?.value;
     let source = if is_coinbase {
         let height = if version != 2 {
-            // version 1 does not include have height
+            // version 1 does not include height
             None
         } else {
             // version 2 transactions include a height as the first 4 bytes, see

--- a/crates/bitcoin/src/types.rs
+++ b/crates/bitcoin/src/types.rs
@@ -885,14 +885,15 @@ mod tests {
 
     #[test]
     fn test_transaction_input_builder() {
+        let source = TransactionInputSource::FromOutput(H256Le::from_bytes_le(&[5; 32]), 123);
         let input = TransactionInputBuilder::new()
             .with_sequence(10)
-            .with_previous_hash(100.into())
+            .with_source(source.clone())
             .build();
         assert_eq!(input.sequence, 10);
         let mut bytes: [u8; 32] = Default::default();
         bytes[0] = 100;
-        assert_eq!(input.previous_hash, H256Le::from_bytes_le(&bytes));
+        assert_eq!(input.source, source);
     }
 
     #[test]
@@ -901,7 +902,7 @@ mod tests {
         let return_data = hex::decode("01a0").unwrap();
         let transaction = TransactionBuilder::new()
             .with_version(2)
-            .add_input(TransactionInputBuilder::new().with_coinbase(false).build())
+            .add_input(TransactionInputBuilder::new().build())
             .add_output(TransactionOutput::payment(100, &address))
             .add_output(TransactionOutput::op_return(0, &return_data))
             .build();
@@ -999,7 +1000,7 @@ mod tests {
 
         let transaction = TransactionBuilder::new()
             .with_version(2)
-            .add_input(TransactionInputBuilder::new().with_coinbase(false).build())
+            .add_input(TransactionInputBuilder::new().build())
             .add_output(TransactionOutput::payment(100, &address))
             .build();
 

--- a/crates/btc-relay/src/benchmarking.rs
+++ b/crates/btc-relay/src/benchmarking.rs
@@ -4,7 +4,7 @@ use bitcoin::{
     formatter::{Formattable, TryFormattable},
     types::{
         Block, BlockBuilder, RawBlockHeader, Transaction, TransactionBuilder, TransactionInputBuilder,
-        TransactionOutput,
+        TransactionInputSource, TransactionOutput,
     },
 };
 use frame_benchmarking::{account, benchmarks};
@@ -42,8 +42,7 @@ fn mine_block_with_one_tx<T: Config>(
         .with_version(2)
         .add_input(
             TransactionInputBuilder::new()
-                .with_coinbase(false)
-                .with_previous_hash(prev.transactions[0].hash())
+                .with_source(TransactionInputSource::FromOutput(prev.transactions[0].hash(), 0))
                 .with_script(&[
                     0, 71, 48, 68, 2, 32, 91, 128, 41, 150, 96, 53, 187, 63, 230, 129, 53, 234, 210, 186, 21, 187, 98,
                     38, 255, 112, 30, 27, 228, 29, 132, 140, 155, 62, 123, 216, 232, 168, 2, 32, 72, 126, 179, 207,

--- a/crates/btc-relay/src/tests.rs
+++ b/crates/btc-relay/src/tests.rs
@@ -2117,13 +2117,9 @@ fn sample_transaction_parsed(outputs: &Vec<TransactionOutput>) -> Transaction {
     let spent_output_txid =
         hex::decode("b28f1e58af1d4db02d1b9f0cf8d51ece3dd5f5013fd108647821ea255ae5daff".to_owned()).unwrap();
     let input = TransactionInput {
-        previous_hash: H256Le::from_bytes_le(&spent_output_txid),
-        previous_index: 0,
-        coinbase: false,
-        height: None,
+        source: TransactionInputSource::FromOutput(H256Le::from_bytes_le(&spent_output_txid), 0),
         script: hex::decode("16001443feac9ca9d20883126e30e962ca11fda07f808b".to_owned()).unwrap(),
         sequence: 4294967295,
-        flags: 0,
         witness: vec![],
     };
 

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -2,7 +2,10 @@ use super::*;
 use crate::Pallet as Issue;
 use bitcoin::{
     formatter::{Formattable, TryFormattable},
-    types::{BlockBuilder, RawBlockHeader, TransactionBuilder, TransactionInputBuilder, TransactionOutput},
+    types::{
+        BlockBuilder, RawBlockHeader, TransactionBuilder, TransactionInputBuilder, TransactionInputSource,
+        TransactionOutput,
+    },
 };
 use btc_relay::{BtcAddress, BtcPublicKey, Pallet as BtcRelay};
 use currency::ParachainCurrency;
@@ -47,8 +50,7 @@ fn mine_blocks<T: crate::Config>() {
         .with_version(2)
         .add_input(
             TransactionInputBuilder::new()
-                .with_coinbase(false)
-                .with_previous_hash(block.transactions[0].hash())
+                .with_source(TransactionInputSource::FromOutput(block.transactions[0].hash(), 0))
                 .with_script(&[
                     0, 71, 48, 68, 2, 32, 91, 128, 41, 150, 96, 53, 187, 63, 230, 129, 53, 234, 210, 186, 21, 187, 98,
                     38, 255, 112, 30, 27, 228, 29, 132, 140, 155, 62, 123, 216, 232, 168, 2, 32, 72, 126, 179, 207,
@@ -118,8 +120,7 @@ benchmarks! {
         .with_version(2)
         .add_input(
             TransactionInputBuilder::new()
-                .with_coinbase(false)
-                .with_previous_hash(block.transactions[0].hash())
+                .with_source(TransactionInputSource::FromOutput(block.transactions[0].hash(), 0))
                 .with_script(&[
                     0, 71, 48, 68, 2, 32, 91, 128, 41, 150, 96, 53, 187, 63, 230, 129, 53, 234,
                     210, 186, 21, 187, 98, 38, 255, 112, 30, 27, 228, 29, 132, 140, 155, 62, 123,
@@ -189,8 +190,7 @@ benchmarks! {
             .with_version(2)
             .add_input(
                 TransactionInputBuilder::new()
-                    .with_coinbase(false)
-                    .with_previous_hash(block.transactions[0].hash())
+                    .with_source(TransactionInputSource::FromOutput(block.transactions[0].hash(), 0))
                     .with_script(&[
                         0, 71, 48, 68, 2, 32, 91, 128, 41, 150, 96, 53, 187, 63, 230, 129, 53, 234,
                         210, 186, 21, 187, 98, 38, 255, 112, 30, 27, 228, 29, 132, 140, 155, 62, 123,

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -2,7 +2,10 @@ use super::*;
 use crate::Pallet as Redeem;
 use bitcoin::{
     formatter::{Formattable, TryFormattable},
-    types::{BlockBuilder, RawBlockHeader, TransactionBuilder, TransactionInputBuilder, TransactionOutput},
+    types::{
+        BlockBuilder, RawBlockHeader, TransactionBuilder, TransactionInputBuilder, TransactionInputSource,
+        TransactionOutput,
+    },
 };
 use btc_relay::{BtcAddress, BtcPublicKey, Pallet as BtcRelay};
 use currency::ParachainCurrency;
@@ -52,8 +55,7 @@ fn mine_blocks<T: crate::Config>() {
         .with_version(2)
         .add_input(
             TransactionInputBuilder::new()
-                .with_coinbase(false)
-                .with_previous_hash(block.transactions[0].hash())
+                .with_source(TransactionInputSource::FromOutput(block.transactions[0].hash(), 0))
                 .with_script(&[
                     0, 71, 48, 68, 2, 32, 91, 128, 41, 150, 96, 53, 187, 63, 230, 129, 53, 234, 210, 186, 21, 187, 98,
                     38, 255, 112, 30, 27, 228, 29, 132, 140, 155, 62, 123, 216, 232, 168, 2, 32, 72, 126, 179, 207,
@@ -146,8 +148,7 @@ benchmarks! {
             .with_version(2)
             .add_input(
                 TransactionInputBuilder::new()
-                    .with_coinbase(false)
-                    .with_previous_hash(block.transactions[0].hash())
+                    .with_source(TransactionInputSource::FromOutput(block.transactions[0].hash(), 0))
                     .with_script(&[
                         0, 71, 48, 68, 2, 32, 91, 128, 41, 150, 96, 53, 187, 63, 230, 129, 53, 234,
                         210, 186, 21, 187, 98, 38, 255, 112, 30, 27, 228, 29, 132, 140, 155, 62, 123,

--- a/crates/relay/src/benchmarking.rs
+++ b/crates/relay/src/benchmarking.rs
@@ -2,7 +2,10 @@ use super::*;
 use crate::Pallet as Relay;
 use bitcoin::{
     formatter::{Formattable, TryFormattable},
-    types::{BlockBuilder, H256Le, RawBlockHeader, TransactionBuilder, TransactionInputBuilder, TransactionOutput},
+    types::{
+        BlockBuilder, H256Le, RawBlockHeader, TransactionBuilder, TransactionInputBuilder, TransactionInputSource,
+        TransactionOutput,
+    },
 };
 use btc_relay::{BtcAddress, BtcPublicKey, Pallet as BtcRelay};
 use currency::ParachainCurrency;
@@ -115,13 +118,11 @@ benchmarks! {
             .with_version(2)
             .add_input(
                 TransactionInputBuilder::new()
-                    .with_coinbase(false)
-                    .with_sequence(4294967295)
-                    .with_previous_index(1)
-                    .with_previous_hash(H256Le::from_bytes_le(&[
-                        193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76,
-                        226, 9, 127, 8, 96, 200, 246, 66, 16, 91, 186, 217, 210, 155, 224, 42,
-                    ]))
+                                        .with_sequence(4294967295)
+                    .with_source(TransactionInputSource::FromOutput(H256Le::from_bytes_le(&[
+                            193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76,
+                            226, 9, 127, 8, 96, 200, 246, 66, 16, 91, 186, 217, 210, 155, 224, 42,
+                        ]), 1))
                     .with_script(&[
                         73, 48, 70, 2, 33, 0, 207, 210, 162, 211, 50, 178, 154, 220, 225, 25, 197,
                         90, 159, 173, 211, 192, 115, 51, 32, 36, 183, 226, 114, 81, 62, 81, 98, 60,

--- a/crates/relay/src/tests.rs
+++ b/crates/relay/src/tests.rs
@@ -3,7 +3,8 @@ use crate::{ext, mock::*};
 use bitcoin::{
     formatter::Formattable,
     types::{
-        BlockHeader, H256Le, MerkleProof, Transaction, TransactionBuilder, TransactionInputBuilder, TransactionOutput,
+        BlockHeader, H256Le, MerkleProof, Transaction, TransactionBuilder, TransactionInputBuilder,
+        TransactionInputSource, TransactionOutput,
     },
 };
 use btc_relay::{BtcAddress, BtcPublicKey, Error as BtcRelayError, OpReturnPaymentData};
@@ -148,13 +149,14 @@ fn build_dummy_transaction_with(output_addresses: Vec<BtcAddress>) -> Transactio
     let mut builder = TransactionBuilder::new();
     builder.with_version(1).add_input(
         TransactionInputBuilder::new()
-            .with_coinbase(false)
             .with_sequence(4294967295)
-            .with_previous_index(1)
-            .with_previous_hash(H256Le::from_bytes_le(&[
-                193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76, 226, 9, 127, 8, 96, 200, 246,
-                66, 16, 91, 186, 217, 210, 155, 224, 42,
-            ]))
+            .with_source(TransactionInputSource::FromOutput(
+                H256Le::from_bytes_le(&[
+                    193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76, 226, 9, 127, 8, 96, 200,
+                    246, 66, 16, 91, 186, 217, 210, 155, 224, 42,
+                ]),
+                1,
+            ))
             .with_script(&[
                 73, 48, 70, 2, 33, 0, 207, 210, 162, 211, 50, 178, 154, 220, 225, 25, 197, 90, 159, 173, 211, 192, 115,
                 51, 32, 36, 183, 226, 114, 81, 62, 81, 98, 60, 161, 89, 147, 72, 2, 33, 0, 155, 72, 45, 127, 123, 77,
@@ -216,13 +218,14 @@ fn build_dummy2_transaction_with(output_addresses: Vec<(i64, BtcAddress)>, op_re
     let mut builder = TransactionBuilder::new();
     builder.with_version(1).add_input(
         TransactionInputBuilder::new()
-            .with_coinbase(false)
             .with_sequence(4294967295)
-            .with_previous_index(1)
-            .with_previous_hash(H256Le::from_bytes_le(&[
-                193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76, 226, 9, 127, 8, 96, 200, 246,
-                66, 16, 91, 186, 217, 210, 155, 224, 42,
-            ]))
+            .with_source(TransactionInputSource::FromOutput(
+                H256Le::from_bytes_le(&[
+                    193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76, 226, 9, 127, 8, 96, 200,
+                    246, 66, 16, 91, 186, 217, 210, 155, 224, 42,
+                ]),
+                1,
+            ))
             .with_script(&[
                 73, 48, 70, 2, 33, 0, 207, 210, 162, 211, 50, 178, 154, 220, 225, 25, 197, 90, 159, 173, 211, 192, 115,
                 51, 32, 36, 183, 226, 114, 81, 62, 81, 98, 60, 161, 89, 147, 72, 2, 33, 0, 155, 72, 45, 127, 123, 77,
@@ -356,13 +359,14 @@ fn test_is_transaction_invalid_fails_with_valid_merge_transaction() {
             .with_version(1)
             .add_input(
                 TransactionInputBuilder::new()
-                    .with_coinbase(false)
                     .with_sequence(4294967295)
-                    .with_previous_index(1)
-                    .with_previous_hash(H256Le::from_bytes_le(&[
-                        193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76, 226, 9, 127, 8, 96,
-                        200, 246, 66, 16, 91, 186, 217, 210, 155, 224, 42,
-                    ]))
+                    .with_source(TransactionInputSource::FromOutput(
+                        H256Le::from_bytes_le(&[
+                            193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76, 226, 9, 127, 8,
+                            96, 200, 246, 66, 16, 91, 186, 217, 210, 155, 224, 42,
+                        ]),
+                        1,
+                    ))
                     .with_script(&[
                         73, 48, 70, 2, 33, 0, 207, 210, 162, 211, 50, 178, 154, 220, 225, 25, 197, 90, 159, 173, 211,
                         192, 115, 51, 32, 36, 183, 226, 114, 81, 62, 81, 98, 60, 161, 89, 147, 72, 2, 33, 0, 155, 72,
@@ -430,10 +434,9 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
             .with_version(1)
             .add_input(
                 TransactionInputBuilder::new()
-                    .with_coinbase(false)
-                    .with_previous_index(1)
-                    .with_previous_hash(H256Le::from_hex_le(
-                        "40d43a99926d43eb0e619bf0b3d83b4a31f60c176beecfb9d35bf45e54d0f742",
+                    .with_source(TransactionInputSource::FromOutput(
+                        H256Le::from_hex_le("40d43a99926d43eb0e619bf0b3d83b4a31f60c176beecfb9d35bf45e54d0f742"),
+                        1,
                     ))
                     .with_sequence(4294967295)
                     .with_script(&[
@@ -502,13 +505,14 @@ fn test_is_transaction_invalid_succeeds() {
             .with_version(1)
             .add_input(
                 TransactionInputBuilder::new()
-                    .with_coinbase(false)
                     .with_sequence(4294967295)
-                    .with_previous_index(1)
-                    .with_previous_hash(H256Le::from_bytes_le(&[
-                        193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76, 226, 9, 127, 8, 96,
-                        200, 246, 66, 16, 91, 186, 217, 210, 155, 224, 42,
-                    ]))
+                    .with_source(TransactionInputSource::FromOutput(
+                        H256Le::from_bytes_le(&[
+                            193, 80, 65, 160, 109, 235, 107, 56, 24, 176, 34, 250, 197, 88, 218, 76, 226, 9, 127, 8,
+                            96, 200, 246, 66, 16, 91, 186, 217, 210, 155, 224, 42,
+                        ]),
+                        1,
+                    ))
                     .with_script(&[
                         73, 48, 70, 2, 33, 0, 207, 210, 162, 211, 50, 178, 154, 220, 225, 25, 197, 90, 159, 173, 211,
                         192, 115, 51, 32, 36, 183, 226, 114, 81, 62, 81, 98, 60, 161, 89, 147, 72, 2, 33, 0, 155, 72,

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -2,7 +2,10 @@ use super::*;
 use crate::{types::ReplaceRequest, Pallet as Replace};
 use bitcoin::{
     formatter::{Formattable, TryFormattable},
-    types::{BlockBuilder, RawBlockHeader, TransactionBuilder, TransactionInputBuilder, TransactionOutput},
+    types::{
+        BlockBuilder, RawBlockHeader, TransactionBuilder, TransactionInputBuilder, TransactionInputSource,
+        TransactionOutput,
+    },
 };
 use btc_relay::{BtcAddress, BtcPublicKey, Pallet as BtcRelay};
 use currency::ParachainCurrency;
@@ -50,8 +53,7 @@ fn mine_blocks<T: crate::Config>() {
         .with_version(2)
         .add_input(
             TransactionInputBuilder::new()
-                .with_coinbase(false)
-                .with_previous_hash(block.transactions[0].hash())
+                .with_source(TransactionInputSource::FromOutput(block.transactions[0].hash(), 0))
                 .with_script(&[
                     0, 71, 48, 68, 2, 32, 91, 128, 41, 150, 96, 53, 187, 63, 230, 129, 53, 234, 210, 186, 21, 187, 98,
                     38, 255, 112, 30, 27, 228, 29, 132, 140, 155, 62, 123, 216, 232, 168, 2, 32, 72, 126, 179, 207,
@@ -200,8 +202,7 @@ benchmarks! {
             .with_version(2)
             .add_input(
                 TransactionInputBuilder::new()
-                    .with_coinbase(false)
-                    .with_previous_hash(block.transactions[0].hash())
+                    .with_source(TransactionInputSource::FromOutput(block.transactions[0].hash(), 0))
                     .with_script(&[
                         0, 71, 48, 68, 2, 32, 91, 128, 41, 150, 96, 53, 187, 63, 230, 129, 53, 234,
                         210, 186, 21, 187, 98, 38, 255, 112, 30, 27, 228, 29, 132, 140, 155, 62, 123,

--- a/parachain/runtime/tests/mock/mod.rs
+++ b/parachain/runtime/tests/mock/mod.rs
@@ -2,6 +2,7 @@
 
 extern crate hex;
 
+use bitcoin::types::TransactionInputSource;
 pub use bitcoin::{
     formatter::{Formattable, TryFormattable},
     types::*,
@@ -688,9 +689,8 @@ impl TransactionGenerator {
         transaction_builder.with_version(2);
         transaction_builder.add_input(
             TransactionInputBuilder::new()
-                .with_coinbase(false)
                 .with_script(&self.script)
-                .with_previous_hash(init_block.transactions[0].hash())
+                .with_source(TransactionInputSource::FromOutput(init_block.transactions[0].hash(), 0))
                 .build(),
         );
 


### PR DESCRIPTION
- removed `flags` from transaction input - its value was not used, and can be deduced from the witness length, "If present, always 0001, and indicates the presence of witness data " ([source](https://en.bitcoin.it/wiki/Transaction))
- Added `TransactionInputSource` enum, to explicitly distinguish between coinbase and normal transactions. It cleans it up a little bit, although I had hoped to make `height` non-optional in coinbase transactions, but it turns out the inclusion depends on the transaction version

For ease of reviewing, I separated the functional changes from the changes to the tests