### PR TITLE
fix: disallow bitcoin blocks with version < 4

### DIFF
--- a/crates/bitcoin/src/error.rs
+++ b/crates/bitcoin/src/error.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     MalformedMerkleProof,
     InvalidMerkleProof,

--- a/crates/bitcoin/src/types.rs
+++ b/crates/bitcoin/src/types.rs
@@ -421,7 +421,9 @@ impl Default for BlockBuilder {
 
 impl BlockBuilder {
     pub fn new() -> BlockBuilder {
-        Self::default()
+        let mut ret = Self::default();
+        ret.block.header.version = 4;
+        ret
     }
 
     pub fn with_timestamp(&mut self, timestamp: u32) -> &mut Self {
@@ -981,12 +983,12 @@ mod tests {
         clear_mocks();
         let address = Address::P2PKH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&address, 50, 3)
             .with_timestamp(1588814835)
             .mine(U256::from(2).pow(254.into()))
             .unwrap();
-        assert_eq!(block.header.version, 2);
+        assert_eq!(block.header.version, 4);
         assert_eq!(block.header.merkle_root, block.transactions[0].tx_id());
         // should be 3, might change if block is changed
         assert_eq!(block.header.nonce, 3);
@@ -1005,7 +1007,7 @@ mod tests {
             .build();
 
         let block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&address, 50, 3)
             .with_timestamp(1588814835)
             .add_transaction(transaction.clone())

--- a/crates/btc-relay/src/benchmarking.rs
+++ b/crates/btc-relay/src/benchmarking.rs
@@ -15,7 +15,7 @@ use sp_std::prelude::*;
 
 fn mine_genesis<T: Config>(account_id: T::AccountId, address: &BtcAddress, height: u32) -> Block {
     let block = BlockBuilder::new()
-        .with_version(2)
+        .with_version(4)
         .with_coinbase(address, 50, 3)
         .with_timestamp(1588813835)
         .mine(U256::from(2).pow(254.into()))
@@ -60,7 +60,7 @@ fn mine_block_with_one_tx<T: Config>(
 
     let block = BlockBuilder::new()
         .with_previous_hash(prev_block_hash)
-        .with_version(2)
+        .with_version(4)
         .with_coinbase(address, 50, 3)
         .with_timestamp(1588813835)
         .add_transaction(transaction.clone())

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -34,7 +34,7 @@ fn mine_blocks<T: crate::Config>() {
     mint_collateral::<T>(&relayer_id, (1u32 << 31).into());
     let height = 0;
     let block = BlockBuilder::new()
-        .with_version(2)
+        .with_version(4)
         .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
         .with_timestamp(1588813835)
         .mine(U256::from(2).pow(254.into()))
@@ -68,7 +68,7 @@ fn mine_blocks<T: crate::Config>() {
     for _ in 0..100 {
         let block = BlockBuilder::new()
             .with_previous_hash(prev_hash)
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())
@@ -103,7 +103,7 @@ benchmarks! {
 
         let height = 0;
         let block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
@@ -140,7 +140,7 @@ benchmarks! {
 
         let block = BlockBuilder::new()
             .with_previous_hash(block_hash)
-            .with_version(2)
+            .with_version(4)
             .with_timestamp(1588813835)
             .add_transaction(transaction)
             .mine(U256::from(2).pow(254.into())).unwrap();
@@ -174,7 +174,7 @@ benchmarks! {
 
         let height = 0;
         let block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&vault_btc_address, 50, 3)
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
@@ -210,7 +210,7 @@ benchmarks! {
 
         let block = BlockBuilder::new()
             .with_previous_hash(block_hash)
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&vault_btc_address, 50, 4)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -39,7 +39,7 @@ fn mine_blocks<T: crate::Config>() {
     mint_collateral::<T>(&relayer_id, (1u32 << 31).into());
     let height = 0;
     let block = BlockBuilder::new()
-        .with_version(2)
+        .with_version(4)
         .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
         .with_timestamp(1588813835)
         .mine(U256::from(2).pow(254.into()))
@@ -73,7 +73,7 @@ fn mine_blocks<T: crate::Config>() {
     for _ in 0..100 {
         let block = BlockBuilder::new()
             .with_previous_hash(prev_hash)
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())
@@ -131,7 +131,7 @@ benchmarks! {
 
         let height = 0;
         let block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&origin_btc_address, 50, 3)
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
@@ -168,7 +168,7 @@ benchmarks! {
 
         let block = BlockBuilder::new()
             .with_previous_hash(block_hash)
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&origin_btc_address, 50, 3)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())

--- a/crates/relay/src/benchmarking.rs
+++ b/crates/relay/src/benchmarking.rs
@@ -36,7 +36,7 @@ benchmarks! {
 
         let address = BtcAddress::P2PKH(H160::from([0; 20]));
         let block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&address, 50, 3)
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
@@ -51,7 +51,7 @@ benchmarks! {
         let stake = 100u32;
 
         let init_block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&address, 50, 3)
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
@@ -65,7 +65,7 @@ benchmarks! {
 
         let block = BlockBuilder::new()
             .with_previous_hash(init_block_hash)
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&address, 50, 3)
             .with_timestamp(1588814835)
             .mine(U256::from(2).pow(254.into())).unwrap();
@@ -101,7 +101,7 @@ benchmarks! {
 
         let height = 0;
         let block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&address, 50, 3)
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
@@ -139,7 +139,7 @@ benchmarks! {
 
         let block = BlockBuilder::new()
             .with_previous_hash(block_hash)
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&address, 50, 3)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -37,7 +37,7 @@ fn mine_blocks<T: crate::Config>() {
     mint_collateral::<T>(&relayer_id, (1u32 << 31).into());
     let height = 0;
     let block = BlockBuilder::new()
-        .with_version(2)
+        .with_version(4)
         .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
         .with_timestamp(1588813835)
         .mine(U256::from(2).pow(254.into()))
@@ -71,7 +71,7 @@ fn mine_blocks<T: crate::Config>() {
     for _ in 0..100 {
         let block = BlockBuilder::new()
             .with_previous_hash(prev_hash)
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())
@@ -185,7 +185,7 @@ benchmarks! {
 
         let height = 0;
         let block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&new_vault_btc_address, 50, 3)
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
@@ -222,7 +222,7 @@ benchmarks! {
 
         let block = BlockBuilder::new()
             .with_previous_hash(block_hash)
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&new_vault_btc_address, 50, 3)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -666,7 +666,7 @@ impl TransactionGenerator {
 
         // initialize BTC Relay with one block
         let init_block = BlockBuilder::new()
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&self.address, 50, 3)
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into()))
@@ -704,7 +704,7 @@ impl TransactionGenerator {
         let prev_hash = BTCRelayPallet::get_best_block();
         let block = BlockBuilder::new()
             .with_previous_hash(prev_hash)
-            .with_version(2)
+            .with_version(4)
             .with_coinbase(&self.address, 50, 3)
             .with_timestamp(1588814835)
             .add_transaction(transaction.clone())
@@ -730,7 +730,7 @@ impl TransactionGenerator {
             timestamp += 1000;
             let conf_block = BlockBuilder::new()
                 .with_previous_hash(prev_block_hash)
-                .with_version(2)
+                .with_version(4)
                 .with_coinbase(&self.address, 50, 3)
                 .with_timestamp(timestamp)
                 .mine(U256::from(2).pow(254.into()))


### PR DESCRIPTION
According to [this spec change](https://github.com/interlay/interbtc-spec/pull/5)