### PR TITLE
refactor!: merge duplicate numerical generics on vault struct

### DIFF
--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -43,7 +43,7 @@ pub(crate) mod btc_relay {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod vault_registry {
-    use crate::types::{Collateral, Wrapped};
+    use crate::types::{BalanceOf, Collateral, Wrapped};
     use btc_relay::BtcAddress;
     use frame_support::dispatch::{DispatchError, DispatchResult};
     use sp_core::H256;
@@ -63,7 +63,7 @@ pub(crate) mod vault_registry {
 
     pub fn get_active_vault_from_id<T: crate::Config>(
         vault_id: &T::AccountId,
-    ) -> Result<Vault<T::AccountId, T::BlockNumber, Wrapped<T>, Collateral<T>>, DispatchError> {
+    ) -> Result<Vault<T::AccountId, T::BlockNumber, BalanceOf<T>>, DispatchError> {
         <vault_registry::Pallet<T>>::get_active_vault_from_id(vault_id)
     }
 

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{ext, mock::*, Collateral, Config, Event, Wrapped};
+use crate::{ext, mock::*, BalanceOf, Config, Event};
 
 use bitcoin::types::{MerkleProof, Transaction};
 use btc_relay::{BtcAddress, BtcPublicKey};
@@ -61,7 +61,7 @@ fn cancel_issue(origin: AccountId, issue_id: &H256) -> Result<(), DispatchError>
     Issue::_cancel_issue(origin, *issue_id)
 }
 
-fn init_zero_vault<T: Config>(id: T::AccountId) -> Vault<T::AccountId, T::BlockNumber, Wrapped<T>, Collateral<T>> {
+fn init_zero_vault<T: Config>(id: T::AccountId) -> Vault<T::AccountId, T::BlockNumber, BalanceOf<T>> {
     let mut vault = Vault::default();
     vault.id = id;
     vault

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -48,7 +48,7 @@ pub(crate) mod btc_relay {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod vault_registry {
-    use crate::types::{Collateral, Wrapped};
+    use crate::types::{BalanceOf, Collateral, Wrapped};
     use frame_support::dispatch::{DispatchError, DispatchResult};
     use vault_registry::types::{CurrencySource, Vault};
 
@@ -76,7 +76,7 @@ pub(crate) mod vault_registry {
 
     pub fn get_vault_from_id<T: crate::Config>(
         vault_id: &T::AccountId,
-    ) -> Result<Vault<T::AccountId, T::BlockNumber, Wrapped<T>, Collateral<T>>, DispatchError> {
+    ) -> Result<Vault<T::AccountId, T::BlockNumber, BalanceOf<T>>, DispatchError> {
         <vault_registry::Pallet<T>>::get_vault_from_id(vault_id)
     }
 

--- a/crates/relay/src/ext.rs
+++ b/crates/relay/src/ext.rs
@@ -3,14 +3,14 @@ use mocktopus::macros::mockable;
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod vault_registry {
-    use crate::{Collateral, Wrapped};
+    use crate::types::BalanceOf;
     use ::vault_registry::VaultStatus;
     use frame_support::dispatch::{DispatchError, DispatchResult};
     use vault_registry::types::Vault;
 
     pub fn get_active_vault_from_id<T: crate::Config>(
         vault_id: &T::AccountId,
-    ) -> Result<Vault<T::AccountId, T::BlockNumber, Wrapped<T>, Collateral<T>>, DispatchError> {
+    ) -> Result<Vault<T::AccountId, T::BlockNumber, BalanceOf<T>>, DispatchError> {
         <vault_registry::Pallet<T>>::get_active_vault_from_id(vault_id)
     }
 

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -28,7 +28,7 @@ use mocktopus::macros::mockable;
 
 pub use security;
 
-use crate::types::{Collateral, Wrapped};
+use crate::types::Wrapped;
 use bitcoin::{parser::parse_transaction, types::*};
 
 use btc_relay::{types::OpReturnPaymentData, BtcAddress};

--- a/crates/relay/src/tests.rs
+++ b/crates/relay/src/tests.rs
@@ -36,7 +36,7 @@ fn dummy_merkle_proof() -> MerkleProof {
 }
 
 /// Mocking functions
-fn init_zero_vault(id: AccountId, btc_address: Option<BtcAddress>) -> Vault<AccountId, BlockNumber, Balance, Balance> {
+fn init_zero_vault(id: AccountId, btc_address: Option<BtcAddress>) -> Vault<AccountId, BlockNumber, Balance> {
     let mut vault = Vault::default();
     vault.id = id;
     vault.wallet = Wallet::new(dummy_public_key());

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -458,17 +458,12 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn liquidation_vault)]
-    pub(super) type LiquidationVault<T: Config> = StorageValue<_, SystemVault<Wrapped<T>>, ValueQuery>;
+    pub(super) type LiquidationVault<T: Config> = StorageValue<_, SystemVault<BalanceOf<T>>, ValueQuery>;
 
     /// Mapping of Vaults, using the respective Vault account identifier as key.
     #[pallet::storage]
-    pub(super) type Vaults<T: Config> = StorageMap<
-        _,
-        Blake2_128Concat,
-        T::AccountId,
-        Vault<T::AccountId, T::BlockNumber, Wrapped<T>, Collateral<T>>,
-        ValueQuery,
-    >;
+    pub(super) type Vaults<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::AccountId, Vault<T::AccountId, T::BlockNumber, BalanceOf<T>>, ValueQuery>;
 
     /// Mapping of reserved BTC addresses to the registered account
     #[pallet::storage]
@@ -1231,7 +1226,7 @@ impl<T: Config> Pallet<T> {
         Ok(total)
     }
 
-    pub fn insert_vault(id: &T::AccountId, vault: Vault<T::AccountId, T::BlockNumber, Wrapped<T>, Collateral<T>>) {
+    pub fn insert_vault(id: &T::AccountId, vault: Vault<T::AccountId, T::BlockNumber, BalanceOf<T>>) {
         Vaults::<T>::insert(id, vault)
     }
 
@@ -1264,7 +1259,7 @@ impl<T: Config> Pallet<T> {
 
     /// check if the vault is below the liquidation threshold.
     pub fn is_vault_below_liquidation_threshold(
-        vault: &Vault<T::AccountId, T::BlockNumber, Wrapped<T>, Collateral<T>>,
+        vault: &Vault<T::AccountId, T::BlockNumber, BalanceOf<T>>,
         liquidation_threshold: UnsignedFixedPoint<T>,
     ) -> Result<bool, DispatchError> {
         Self::is_collateral_below_threshold(

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -844,7 +844,7 @@ mod liquidation_threshold_tests {
 
     use super::*;
 
-    fn setup() -> Vault<AccountId, BlockNumber, Balance, Balance> {
+    fn setup() -> Vault<AccountId, BlockNumber, Balance> {
         let id = create_sample_vault();
 
         assert_ok!(VaultRegistry::try_increase_to_be_issued_tokens(&id, 50),);

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -136,7 +136,7 @@ impl Default for VaultStatus {
 
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct Vault<AccountId, BlockNumber, Wrapped, Collateral> {
+pub struct Vault<AccountId, BlockNumber, Balance> {
     /// Account identifier of the Vault
     pub id: AccountId,
     /// Bitcoin address of this Vault (P2PKH, P2SH, P2WPKH, P2WSH)
@@ -147,41 +147,37 @@ pub struct Vault<AccountId, BlockNumber, Wrapped, Collateral> {
     /// Issue, Redeem (except during automatic liquidation) and Replace.
     pub banned_until: Option<BlockNumber>,
     /// Number of tokens pending issue
-    pub to_be_issued_tokens: Wrapped,
+    pub to_be_issued_tokens: Balance,
     /// Number of issued tokens
-    pub issued_tokens: Wrapped,
+    pub issued_tokens: Balance,
     /// Number of tokens pending redeem
-    pub to_be_redeemed_tokens: Wrapped,
+    pub to_be_redeemed_tokens: Balance,
     /// Number of tokens that have been requested for a replace through
     /// `request_replace`, but that have not been accepted yet by a new_vault.
-    pub to_be_replaced_tokens: Wrapped,
+    pub to_be_replaced_tokens: Balance,
     /// Amount of collateral that is locked as griefing collateral to be payed out if
     /// the old_vault fails to call execute_replace
-    pub replace_collateral: Collateral,
+    pub replace_collateral: Balance,
     /// Amount of collateral that is locked for remaining to_be_redeemed
     /// tokens upon liquidation.
-    pub liquidated_collateral: Collateral,
+    pub liquidated_collateral: Balance,
 }
 
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug, serde::Serialize, serde::Deserialize))]
-pub struct SystemVault<Wrapped> {
+pub struct SystemVault<Balance> {
     // Number of tokens pending issue
-    pub to_be_issued_tokens: Wrapped,
+    pub to_be_issued_tokens: Balance,
     // Number of issued tokens
-    pub issued_tokens: Wrapped,
+    pub issued_tokens: Balance,
     // Number of tokens pending redeem
-    pub to_be_redeemed_tokens: Wrapped,
+    pub to_be_redeemed_tokens: Balance,
 }
 
-impl<
-        AccountId: Default + Ord,
-        BlockNumber: Default,
-        Wrapped: HasCompact + Default,
-        Collateral: HasCompact + Default,
-    > Vault<AccountId, BlockNumber, Wrapped, Collateral>
+impl<AccountId: Default + Ord, BlockNumber: Default, Balance: HasCompact + Default>
+    Vault<AccountId, BlockNumber, Balance>
 {
-    pub(crate) fn new(id: AccountId, public_key: BtcPublicKey) -> Vault<AccountId, BlockNumber, Wrapped, Collateral> {
+    pub(crate) fn new(id: AccountId, public_key: BtcPublicKey) -> Vault<AccountId, BlockNumber, Balance> {
         let wallet = Wallet::new(public_key);
         Vault {
             id,
@@ -198,9 +194,9 @@ impl<
 }
 
 pub type DefaultVault<T> =
-    Vault<<T as frame_system::Config>::AccountId, <T as frame_system::Config>::BlockNumber, Wrapped<T>, Collateral<T>>;
+    Vault<<T as frame_system::Config>::AccountId, <T as frame_system::Config>::BlockNumber, BalanceOf<T>>;
 
-pub type DefaultSystemVault<T> = SystemVault<Wrapped<T>>;
+pub type DefaultSystemVault<T> = SystemVault<BalanceOf<T>>;
 
 pub(crate) trait UpdatableVault<T: Config> {
     fn id(&self) -> T::AccountId;


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

`Collateral<T>` and `Wrapped<T>` are type aliases to the `Balance` type (typically `u128`), there is no need for both to be specified on the `Vault` struct.