### PR TITLE
test: spec-based postcondition tests of security module

### DIFF
--- a/crates/security/src/tests.rs
+++ b/crates/security/src/tests.rs
@@ -108,15 +108,6 @@ fn test_recover_from_oracle_offline_succeeds() {
 }
 
 #[test]
-fn test_get_nonce() {
-    run_test(|| {
-        let left = Security::get_nonce();
-        let right = Security::get_nonce();
-        assert_eq!(right, left + 1);
-    })
-}
-
-#[test]
 fn testget_secure_id() {
     run_test(|| {
         frame_system::Pallet::<Test>::set_parent_hash(H256::zero());
@@ -127,15 +118,6 @@ fn testget_secure_id() {
                 1, 13, 46, 37, 138, 95, 245, 117, 109
             ])
         );
-    })
-}
-
-#[test]
-fn testget_secure_ids_not_equal() {
-    run_test(|| {
-        let left = Security::get_secure_id(&1);
-        let right = Security::get_secure_id(&1);
-        assert_ne!(left, right);
     })
 }
 
@@ -164,4 +146,74 @@ fn testget_active_block_not_incremented_if_not_running() {
         Security::increment_active_block();
         assert_eq!(Security::active_block_number(), initial_active_block);
     })
+}
+
+mod spec_based_tests {
+    use super::*;
+    use sp_core::U256;
+
+    #[test]
+    fn test_generate_secure_id() {
+        run_test(|| {
+            let get_secure_id_with = |account, nonce: u32, parent| {
+                crate::Nonce::<Test>::set(U256::from(nonce));
+
+                frame_system::Pallet::<Test>::set_parent_hash(H256::from_slice(&[parent; 32]));
+                Security::get_secure_id(&account)
+            };
+
+            let test_secure_id_with = |account, nonce: u32, parent| {
+                let result1 = get_secure_id_with(account, nonce, parent);
+                let result2 = get_secure_id_with(account, nonce, parent);
+                // test that the result ONLY depend on account, nonce and parent
+                assert_eq!(result1, result2);
+                result1
+            };
+
+            let mut results = vec![];
+
+            for i in 0..2 {
+                for j in 0..2 {
+                    for k in 0..2 {
+                        let result = test_secure_id_with(i, j, k);
+                        results.push(result);
+                    }
+                }
+            }
+            results.sort(); // required because dedup only remove duplicate _consecutive_ values
+            results.dedup();
+
+            // postcondition: MUST return the 256-bit hash of the account, nonce, and parent_hash
+            // test that each combination of account, nonce, and parent_hash gives a unique result
+            assert_eq!(results.len(), 8);
+
+            // postcondition: Nonce MUST be incremented by one.
+            let initial = crate::Nonce::<Test>::get();
+            Security::get_secure_id(&1);
+            assert_eq!(crate::Nonce::<Test>::get(), initial + 1);
+        })
+    }
+
+    #[test]
+    fn test_has_expired() {
+        run_test(|| {
+            let test_parachain_block_expired_postcondition = |opentime, period, active_block_count| {
+                // postcondition: MUST return True if opentime + period < ActiveBlockCount, False otherwise.
+                let expected = opentime + period < active_block_count;
+
+                crate::ActiveBlockCount::<Test>::set(active_block_count);
+
+                assert_eq!(expected, Security::parachain_block_expired(opentime, period).unwrap())
+            };
+
+            for i in 0..4 {
+                for j in 0..4 {
+                    for k in 1..3 {
+                        // precondition: The ActiveBlockCount MUST be greater than 0.
+                        test_parachain_block_expired_postcondition(i, j, k);
+                    }
+                }
+            }
+        })
+    }
 }


### PR DESCRIPTION
Based on the postconditions described [here](https://github.com/interlay/interbtc-spec/blob/master/interbtc-spec/docs/source/spec/security.rst)