### PR TITLE
refactor!: remove unused Bitcoin fee estimates

### DIFF
--- a/crates/exchange-rate-oracle/src/lib.rs
+++ b/crates/exchange-rate-oracle/src/lib.rs
@@ -35,10 +35,7 @@ use frame_support::{
     weights::Weight,
 };
 use frame_system::{ensure_root, ensure_signed};
-pub use primitives::{
-    oracle::{BitcoinInclusionTime, Key as OracleKey},
-    CurrencyId,
-};
+pub use primitives::{oracle::Key as OracleKey, CurrencyId};
 use security::{ErrorCode, StatusCode};
 use sp_runtime::{
     traits::{UniqueSaturatedInto, *},

--- a/crates/exchange-rate-oracle/src/tests.rs
+++ b/crates/exchange-rate-oracle/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     mock::{run_test, ExchangeRateOracle, Origin, System, Test, TestError, TestEvent},
-    BitcoinInclusionTime, CurrencyId, OracleKey,
+    CurrencyId, OracleKey,
 };
 use frame_support::{assert_err, assert_ok, dispatch::DispatchError};
 use mocktopus::mocking::*;
@@ -222,11 +222,7 @@ fn set_btc_tx_fees_per_byte_succeeds() {
     run_test(|| {
         ExchangeRateOracle::is_authorized.mock_safe(|_| MockResult::Return(true));
 
-        let keys = vec![
-            OracleKey::FeeEstimation(BitcoinInclusionTime::Fast),
-            OracleKey::FeeEstimation(BitcoinInclusionTime::Half),
-            OracleKey::FeeEstimation(BitcoinInclusionTime::Hour),
-        ];
+        let keys = vec![OracleKey::FeeEstimation];
 
         let values: Vec<_> = keys
             .iter()

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -49,16 +49,8 @@ fn initialize_oracle<T: crate::Config>() {
                 <T as exchange_rate_oracle::Config>::UnsignedFixedPoint::checked_from_rational(1, 1).unwrap(),
             ),
             (
-                OracleKey::FeeEstimation(BitcoinInclusionTime::Fast),
+                OracleKey::FeeEstimation,
                 <T as exchange_rate_oracle::Config>::UnsignedFixedPoint::checked_from_rational(3, 1).unwrap(),
-            ),
-            (
-                OracleKey::FeeEstimation(BitcoinInclusionTime::Half),
-                <T as exchange_rate_oracle::Config>::UnsignedFixedPoint::checked_from_rational(2, 1).unwrap(),
-            ),
-            (
-                OracleKey::FeeEstimation(BitcoinInclusionTime::Hour),
-                <T as exchange_rate_oracle::Config>::UnsignedFixedPoint::checked_from_rational(1, 1).unwrap(),
             ),
         ],
     )

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::types::{RedeemRequest, RedeemRequestStatus};
 
 use crate::types::{BalanceOf, Collateral, Version, Wrapped};
 use btc_relay::BtcAddress;
-use exchange_rate_oracle::{BitcoinInclusionTime, OracleKey};
+use exchange_rate_oracle::OracleKey;
 use frame_support::{
     dispatch::{DispatchError, DispatchResult},
     ensure,
@@ -647,7 +647,7 @@ impl<T: Config> Pallet<T> {
     pub fn get_current_inclusion_fee() -> Result<Wrapped<T>, DispatchError> {
         {
             let size: u32 = Self::redeem_transaction_size();
-            let satoshi_per_bytes = ext::oracle::get_price::<T>(OracleKey::FeeEstimation(BitcoinInclusionTime::Fast))?;
+            let satoshi_per_bytes = ext::oracle::get_price::<T>(OracleKey::FeeEstimation)?;
 
             let fee = satoshi_per_bytes
                 .checked_mul_int(size)

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -1,6 +1,6 @@
 use crate as redeem;
 use crate::{Config, Error};
-pub use exchange_rate_oracle::{BitcoinInclusionTime, CurrencyId, OracleKey};
+pub use exchange_rate_oracle::{CurrencyId, OracleKey};
 use frame_support::{assert_ok, parameter_types, traits::GenesisBuild, PalletId};
 use mocktopus::mocking::clear_mocks;
 use orml_tokens::CurrencyAdapter;
@@ -301,9 +301,7 @@ where
             Origin::signed(ALICE),
             vec![
                 (OracleKey::ExchangeRate(CurrencyId::DOT), FixedU128::from(1)),
-                (OracleKey::FeeEstimation(BitcoinInclusionTime::Fast), FixedU128::from(3)),
-                (OracleKey::FeeEstimation(BitcoinInclusionTime::Half), FixedU128::from(2)),
-                (OracleKey::FeeEstimation(BitcoinInclusionTime::Hour), FixedU128::from(1)),
+                (OracleKey::FeeEstimation, FixedU128::from(3)),
             ]
         ));
         <exchange_rate_oracle::Pallet<Test>>::begin_block(0);

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -262,19 +262,9 @@ pub mod oracle {
     use super::*;
 
     #[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
-    pub enum BitcoinInclusionTime {
-        /// fee to include a BTC transaction within the next block
-        Fast,
-        /// fee to include a BTC transaction within the next three blocks (~30 min)
-        Half,
-        /// fee to include a BTC transaction within the six blocks (~60 min)
-        Hour,
-    }
-
-    #[derive(Encode, Decode, Clone, Eq, PartialEq, Debug)]
     pub enum Key {
         ExchangeRate(CurrencyId),
-        FeeEstimation(BitcoinInclusionTime),
+        FeeEstimation,
     }
 }
 

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -25,7 +25,7 @@ pub use sp_runtime::traits::{Dispatchable, One, Zero};
 pub use sp_std::convert::TryInto;
 pub use vault_registry::CurrencySource;
 
-pub use exchange_rate_oracle::{BitcoinInclusionTime, OracleKey};
+pub use exchange_rate_oracle::OracleKey;
 pub use issue::{IssueRequest, IssueRequestStatus};
 pub use redeem::RedeemRequest;
 pub use refund::RefundRequest;
@@ -1069,9 +1069,7 @@ impl ExtBuilder {
             );
             assert_ok!(Call::ExchangeRateOracle(ExchangeRateOracleCall::feed_values(vec![
                 (OracleKey::ExchangeRate(CurrencyId::DOT), FixedU128::from(1)),
-                (OracleKey::FeeEstimation(BitcoinInclusionTime::Fast), FixedU128::from(3)),
-                (OracleKey::FeeEstimation(BitcoinInclusionTime::Half), FixedU128::from(2)),
-                (OracleKey::FeeEstimation(BitcoinInclusionTime::Hour), FixedU128::from(1)),
+                (OracleKey::FeeEstimation, FixedU128::from(3)),
             ]))
             .dispatch(origin_of(account_of(ALICE))));
             ExchangeRateOraclePallet::begin_block(0);


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

This is more of a discussion PR (but ready to merge if agreed); removes the unused Bitcoin fee rates `Half` and `Hour` since the redeem protocol only needs one input. I realize this will also need to be updated in the specification.