### PR TITLE
fix: ensure vault is not banned in mint_tokens_for_reimbursed_redeem

### DIFF
--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -603,6 +603,7 @@ impl<T: Config> Pallet<T> {
         );
 
         ensure!(redeem.vault == vault_id, Error::<T>::UnauthorizedUser);
+        ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
 
         let reimbursed_amount = redeem
             .amount_btc

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -654,7 +654,7 @@ fn test_mint_tokens_for_reimbursed_redeem() {
         Security::<Test>::set_active_block_number(100);
         assert_noop!(
             Redeem::mint_tokens_for_reimbursed_redeem(Origin::signed(BOB), H256([0u8; 32])),
-            VaultRegistryError::ExceedingVaultLimit
+            VaultRegistryError::VaultBanned
         );
         Security::<Test>::set_active_block_number(101);
         ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(move |vault_id, amount| {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Fix for IF-INTERLAY2-07