### PR TITLE
fix: zero-cost base extrinsic weight, to be able to do runtime upgrade without fees

### DIFF
--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -137,7 +137,7 @@ parameter_types! {
     pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
         .base_block(BlockExecutionWeight::get())
         .for_class(DispatchClass::all(), |weights| {
-            weights.base_extrinsic = ExtrinsicBaseWeight::get();
+            weights.base_extrinsic = 0; // TODO: this is 0 so that we can do runtime upgrade without fees. Restore value afterwards!
         })
         .for_class(DispatchClass::Normal, |weights| {
             weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
@@ -213,7 +213,7 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 parameter_types! {
-    pub const TransactionByteFee: Balance = 1;
+    pub const TransactionByteFee: Balance = 0;  // TODO: this is 0 so that we can do runtime upgrade without fees. Restore value afterwards!
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -124,7 +124,7 @@ parameter_types! {
     pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
         .base_block(BlockExecutionWeight::get())
         .for_class(DispatchClass::all(), |weights| {
-            weights.base_extrinsic = ExtrinsicBaseWeight::get();
+            weights.base_extrinsic = 0;  // TODO: this is 0 so that we can do runtime upgrade without fees. Restore value afterwards!
         })
         .for_class(DispatchClass::Normal, |weights| {
             weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
@@ -211,7 +211,7 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 parameter_types! {
-    pub const TransactionByteFee: Balance = 1;
+    pub const TransactionByteFee: Balance = 0;  // TODO: this is 0 so that we can do runtime upgrade without fees. Restore value afterwards!
 }
 
 impl pallet_transaction_payment::Config for Runtime {


### PR DESCRIPTION
This change is required to be able to do runtime upgrades as sudo without fees. As I understand it, the cost of a transaction is `TransactionByteFee * number_of_bytes_in_extrinsic + weights.base_extrinsic + weight_of_function`. While `sudo_unchecked_weight` can set the last part to zero, we need the other parts to be zero as well. Eventually we will want to revert this change for better spam protection.

One thing to note is that subxt hangs when trying to execute a no-cost function, so we have to use polkadot.js.

Finally, I had to compile with `--release` in order to get this to work, otherwise the block production took too long. We have to make sure that the kusama node is fast enough to execute in the allowed block time. 