### PR TITLE
fix!: use a separate liquidation vault for each currency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11762,6 +11762,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "staking",
+ "visibility",
 ]
 
 [[package]]
@@ -11781,6 +11782,17 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "visibility"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8881d5cc0ae34e3db2f1de5af81e5117a420d2f937506c2dc20d6f4cfb069051"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "void"

--- a/crates/vault-registry/Cargo.toml
+++ b/crates/vault-registry/Cargo.toml
@@ -11,6 +11,8 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 fixed-hash = { version = "0.7.0", default-features = false, features = ["byteorder"] }
 log = { version = "0.4.14", default-features = false }
 
+visibility = { version = "0.0.1", optional = true }
+
 # Substrate dependencies
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false }
@@ -77,4 +79,7 @@ runtime-benchmarks = [
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
+]
+integration-tests = [
+  "visibility"
 ]

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -16,19 +16,6 @@ pub(crate) mod currency {
 }
 
 #[cfg_attr(test, mockable)]
-pub(crate) mod treasury {
-    use currency::{Amount, ParachainCurrency};
-    use frame_support::traits::Get;
-
-    pub fn total_issued<T: crate::Config>() -> Amount<T> {
-        Amount::new(
-            <T as crate::Config>::Wrapped::get_total_supply(),
-            T::GetWrappedCurrencyId::get(),
-        )
-    }
-}
-
-#[cfg_attr(test, mockable)]
 pub(crate) mod security {
     use frame_support::dispatch::DispatchResult;
 

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -469,9 +469,6 @@ pub mod pallet {
     pub(super) type LiquidationVault<T: Config> =
         StorageMap<_, Blake2_128Concat, CurrencyId<T>, DefaultSystemVault<T>, OptionQuery>;
 
-    #[pallet::storage]
-    pub(super) type WrappedDebt<T: Config> = StorageValue<_, Wrapped<T>, ValueQuery>;
-
     /// Mapping of Vaults, using the respective Vault account identifier as key.
     #[pallet::storage]
     pub(super) type Vaults<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, DefaultVault<T>>;
@@ -600,10 +597,6 @@ impl<T: Config> Pallet<T> {
             Error::<T>::VaultNotFound
         );
         Ok(vault)
-    }
-
-    fn get_wrapped_debt() -> Amount<T> {
-        Amount::new(WrappedDebt::<T>::get(), T::GetWrappedCurrencyId::get())
     }
 
     /// Deposit an `amount` of collateral to be used for collateral tokens
@@ -1214,15 +1207,6 @@ impl<T: Config> Pallet<T> {
         TotalUserVaultCollateral::<T>::set(new);
 
         Ok(())
-    }
-
-    /// returns the total number of issued tokens
-    pub fn get_total_issued_tokens(include_liquidation_vault: bool) -> Result<Amount<T>, DispatchError> {
-        if include_liquidation_vault {
-            Ok(ext::treasury::total_issued::<T>())
-        } else {
-            ext::treasury::total_issued::<T>().checked_sub(&Self::get_wrapped_debt())
-        }
     }
 
     /// returns the total locked collateral, _

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -479,7 +479,7 @@ fn redeem_tokens_premium_fails_with_insufficient_tokens() {
 #[test]
 fn redeem_tokens_liquidation_succeeds() {
     run_test(|| {
-        let mut liquidation_vault = VaultRegistry::get_rich_liquidation_vault();
+        let mut liquidation_vault = VaultRegistry::get_rich_liquidation_vault(DEFAULT_TESTING_CURRENCY);
         let user_id = 5;
 
         // TODO: emulate assert_called
@@ -500,7 +500,7 @@ fn redeem_tokens_liquidation_succeeds() {
             &user_id,
             &wrapped(50)
         ));
-        let liquidation_vault = VaultRegistry::get_rich_liquidation_vault();
+        let liquidation_vault = VaultRegistry::get_rich_liquidation_vault(DEFAULT_TESTING_CURRENCY);
         assert_eq!(liquidation_vault.data.issued_tokens, 0);
         assert_emitted!(Event::RedeemTokensLiquidation(user_id, 50, 500));
     });
@@ -509,7 +509,7 @@ fn redeem_tokens_liquidation_succeeds() {
 #[test]
 fn redeem_tokens_liquidation_does_not_call_recover_when_unnecessary() {
     run_test(|| {
-        let mut liquidation_vault = VaultRegistry::get_rich_liquidation_vault();
+        let mut liquidation_vault = VaultRegistry::get_rich_liquidation_vault(DEFAULT_TESTING_CURRENCY);
         let user_id = 5;
 
         VaultRegistry::transfer_funds.mock_safe(move |sender, receiver, _amount| {
@@ -529,7 +529,7 @@ fn redeem_tokens_liquidation_does_not_call_recover_when_unnecessary() {
             &user_id,
             &wrapped(10)
         ));
-        let liquidation_vault = VaultRegistry::get_rich_liquidation_vault();
+        let liquidation_vault = VaultRegistry::get_rich_liquidation_vault(DEFAULT_TESTING_CURRENCY);
         assert_eq!(liquidation_vault.data.issued_tokens, 15);
         assert_emitted!(Event::RedeemTokensLiquidation(user_id, 10, (1000 * 10) / 50));
     });
@@ -625,7 +625,7 @@ fn liquidate_at_most_secure_threshold() {
             dummy_public_key(),
             CurrencyId::DOT
         ));
-        let liquidation_vault_before = VaultRegistry::get_rich_liquidation_vault();
+        let liquidation_vault_before = VaultRegistry::get_rich_liquidation_vault(DEFAULT_TESTING_CURRENCY);
 
         VaultRegistry::set_secure_collateral_threshold(
             DEFAULT_TESTING_CURRENCY,
@@ -668,7 +668,7 @@ fn liquidate_at_most_secure_threshold() {
             backing_collateral - liquidated_collateral
         ));
 
-        let liquidation_vault_after = VaultRegistry::get_rich_liquidation_vault();
+        let liquidation_vault_after = VaultRegistry::get_rich_liquidation_vault(DEFAULT_TESTING_CURRENCY);
         let liquidated_vault = <crate::Vaults<Test>>::get(&vault_id).unwrap();
         assert!(matches!(liquidated_vault.status, VaultStatus::Liquidated));
         assert_emitted!(Event::LiquidateVault(

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -1,4 +1,4 @@
-use crate::{ext, Config, Error, Pallet, WrappedDebt};
+use crate::{ext, Config, Error, Pallet};
 use codec::{Decode, Encode, HasCompact};
 use currency::Amount;
 use frame_support::{
@@ -669,10 +669,6 @@ impl<T: Config> UpdatableVault<T> for RichSystemVault<T> {
         self.update(|v| {
             v.issued_tokens = new_value;
             Ok(())
-        })?;
-        WrappedDebt::<T>::try_mutate(|x| {
-            *x = x.checked_add(&tokens.amount()).ok_or(Error::<T>::ArithmeticOverflow)?;
-            Ok(())
         })
     }
 
@@ -696,10 +692,6 @@ impl<T: Config> UpdatableVault<T> for RichSystemVault<T> {
         let new_value = self.issued_tokens().checked_sub(&tokens)?.amount();
         self.update(|v| {
             v.issued_tokens = new_value;
-            Ok(())
-        })?;
-        WrappedDebt::<T>::try_mutate(|x| {
-            *x = x.checked_sub(&tokens.amount()).ok_or(Error::<T>::ArithmeticOverflow)?;
             Ok(())
         })
     }

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -85,6 +85,9 @@ serde_json = "1.0"
 
 bitcoin = { path = "../../crates/bitcoin", default-features = false }
 
+vault-registry = { path = "../../crates/vault-registry", default-features = false, features = ["integration-tests"]}
+
+
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 

--- a/standalone/runtime/tests/mock/reward_testing_utils.rs
+++ b/standalone/runtime/tests/mock/reward_testing_utils.rs
@@ -1,13 +1,14 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 type AccountId = [u8; 32];
 type Balance = f64;
 
 #[derive(Debug, Default)]
 pub struct BasicRewardPool {
-    stake: HashMap<AccountId, Balance>,
+    // note: we use BTreeMaps such that the debug print output is sorted, for easier diffing
+    stake: BTreeMap<AccountId, Balance>,
+    reward_tally: BTreeMap<AccountId, Balance>,
     total_stake: Balance,
-    reward_tally: HashMap<AccountId, Balance>,
     reward_per_token: Balance,
 }
 

--- a/standalone/runtime/tests/test_nomination.rs
+++ b/standalone/runtime/tests/test_nomination.rs
@@ -9,6 +9,7 @@ fn test_with<R>(execute: impl Fn(CurrencyId) -> R) {
         ExtBuilder::build().execute_with(|| {
             SecurityPallet::set_active_block_number(1);
             assert_ok!(OraclePallet::_set_exchange_rate(currency_id, FixedU128::one()));
+            LiquidationVaultData::force_to(default_liquidation_vault_state(currency_id));
             UserData::force_to(USER, default_user_state());
             CoreVaultData::force_to(VAULT, default_vault_state(currency_id));
             execute(currency_id)

--- a/standalone/runtime/tests/test_replace.rs
+++ b/standalone/runtime/tests/test_replace.rs
@@ -23,6 +23,7 @@ fn test_with<R>(execute: impl Fn(CurrencyId) -> R) {
             UserData::force_to(USER, default_user_state());
             CoreVaultData::force_to(OLD_VAULT, default_vault_state(currency_id));
             CoreVaultData::force_to(NEW_VAULT, default_vault_state(currency_id));
+            LiquidationVaultData::force_to(default_liquidation_vault_state(currency_id));
             execute(currency_id)
         })
     };
@@ -878,6 +879,8 @@ fn integration_test_replace_execute_replace_old_vault_liquidated() {
         assert_eq!(
             ParachainTwoVaultState::get(),
             pre_execution_state.with_changes(|old_vault, new_vault, liquidation_vault| {
+                let liquidation_vault = liquidation_vault.with_currency(&currency_id);
+
                 liquidation_vault.issued -= wrapped(1000);
                 liquidation_vault.to_be_redeemed -= wrapped(1000);
 
@@ -908,6 +911,8 @@ fn integration_test_replace_execute_replace_new_vault_liquidated() {
         assert_eq!(
             ParachainTwoVaultState::get(),
             pre_execution_state.with_changes(|old_vault, _new_vault, liquidation_vault| {
+                let liquidation_vault = liquidation_vault.with_currency(&currency_id);
+
                 liquidation_vault.to_be_issued -= wrapped(1000);
                 liquidation_vault.issued += wrapped(1000);
 
@@ -941,6 +946,8 @@ fn integration_test_replace_execute_replace_both_vaults_liquidated() {
         assert_eq!(
             ParachainTwoVaultState::get(),
             pre_execution_state.with_changes(|old_vault, _new_vault, liquidation_vault| {
+                let liquidation_vault = liquidation_vault.with_currency(&currency_id);
+
                 liquidation_vault.to_be_redeemed -= wrapped(1000);
                 liquidation_vault.to_be_issued -= wrapped(1000);
 
@@ -997,6 +1004,8 @@ fn integration_test_replace_cancel_replace_old_vault_liquidated() {
         assert_eq!(
             ParachainTwoVaultState::get(),
             pre_cancellation_state.with_changes(|old_vault, new_vault, liquidation_vault| {
+                let liquidation_vault = liquidation_vault.with_currency(&currency_id);
+
                 old_vault.to_be_redeemed -= wrapped(1000);
                 old_vault.griefing_collateral -= replace.griefing_collateral();
                 old_vault.liquidated_collateral -= collateral_for_replace;
@@ -1007,7 +1016,7 @@ fn integration_test_replace_cancel_replace_old_vault_liquidated() {
                 *new_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
 
                 liquidation_vault.to_be_redeemed -= wrapped(1000);
-                *liquidation_vault.funds.get_mut(&currency_id).unwrap() += collateral_for_replace;
+                liquidation_vault.collateral += collateral_for_replace;
             })
         );
     });
@@ -1027,6 +1036,8 @@ fn integration_test_replace_cancel_replace_new_vault_liquidated() {
         assert_eq!(
             ParachainTwoVaultState::get(),
             pre_cancellation_state.with_changes(|old_vault, new_vault, liquidation_vault| {
+                let liquidation_vault = liquidation_vault.with_currency(&currency_id);
+
                 old_vault.to_be_redeemed -= wrapped(1000);
                 old_vault.griefing_collateral -= replace.griefing_collateral();
 
@@ -1057,6 +1068,8 @@ fn integration_test_replace_cancel_replace_both_vaults_liquidated() {
         assert_eq!(
             ParachainTwoVaultState::get(),
             pre_cancellation_state.with_changes(|old_vault, new_vault, liquidation_vault| {
+                let liquidation_vault = liquidation_vault.with_currency(&currency_id);
+
                 old_vault.to_be_redeemed -= wrapped(1000);
                 old_vault.griefing_collateral -= replace.griefing_collateral();
                 old_vault.liquidated_collateral -= collateral_for_replace;
@@ -1065,7 +1078,7 @@ fn integration_test_replace_cancel_replace_both_vaults_liquidated() {
 
                 liquidation_vault.to_be_redeemed -= wrapped(1000);
                 liquidation_vault.to_be_issued -= wrapped(1000);
-                *liquidation_vault.funds.get_mut(&currency_id).unwrap() += collateral_for_replace;
+                liquidation_vault.collateral += collateral_for_replace;
             })
         );
     });

--- a/standalone/runtime/tests/test_staked_relayers.rs
+++ b/standalone/runtime/tests/test_staked_relayers.rs
@@ -72,6 +72,8 @@ fn integration_test_report_vault_theft() {
         assert_eq!(
             ParachainState::get(),
             pre_liquidation_state.with_changes(|user, vault, liquidation_vault, _fee_pool| {
+                let liquidation_vault = liquidation_vault.with_currency(&currency_id);
+
                 (*user.balances.get_mut(&currency_id).unwrap()).free += theft_fee;
 
                 vault.issued -= issued_tokens;
@@ -79,7 +81,7 @@ fn integration_test_report_vault_theft() {
                 vault.backing_collateral -= theft_fee;
 
                 liquidation_vault.issued += issued_tokens;
-                *liquidation_vault.funds.get_mut(&currency_id).unwrap() += confiscated_collateral;
+                liquidation_vault.collateral += confiscated_collateral;
             })
         );
     });


### PR DESCRIPTION
- There is now a separate liquidation vault per currency. This fixes a problem where the amount of collateral associated with liquidated tokens was calculated incorrectly.
- ~~Added a `WrappedDebt` storage field that keeps track of the total number of wrapped tokens in all of the liquidation vaults. This is required to do `get_total_issued_tokens` without iteration.~~
- Introduced a new dependency on the `visibility` crate, which allows us to expose functions/types only when the `integration-tests` feature is enabled.

**BREAKING CHANGES**
- Storage
  - `LiquidationVault` is now a map, indexed by currencyId
- Types
  - `SystemVault` now has a `currencyId` field