### PR TITLE
refactor: remove unused disable_op_return_check genesis config

### DIFF
--- a/crates/btc-relay/src/lib.rs
+++ b/crates/btc-relay/src/lib.rs
@@ -375,11 +375,6 @@ pub mod pallet {
     #[pallet::getter(fn disable_inclusion_check)]
     pub(super) type DisableInclusionCheck<T: Config> = StorageValue<_, bool, ValueQuery>;
 
-    /// Whether the module should perform OP_RETURN checks.
-    #[pallet::storage]
-    #[pallet::getter(fn disable_op_return_check)]
-    pub(super) type DisableOpReturnCheck<T: Config> = StorageValue<_, bool, ValueQuery>;
-
     #[pallet::genesis_config]
     pub struct GenesisConfig<T: Config> {
         /// Global security parameter k for stable Bitcoin transactions
@@ -390,8 +385,6 @@ pub mod pallet {
         pub disable_difficulty_check: bool,
         /// Whether the module should perform inclusion checks.
         pub disable_inclusion_check: bool,
-        /// Whether the module should perform OP_RETURN checks.
-        pub disable_op_return_check: bool,
     }
 
     #[cfg(feature = "std")]
@@ -402,7 +395,6 @@ pub mod pallet {
                 parachain_confirmations: Default::default(),
                 disable_difficulty_check: Default::default(),
                 disable_inclusion_check: Default::default(),
-                disable_op_return_check: Default::default(),
             }
         }
     }
@@ -414,7 +406,6 @@ pub mod pallet {
             StableParachainConfirmations::<T>::put(self.parachain_confirmations);
             DisableDifficultyCheck::<T>::put(self.disable_difficulty_check);
             DisableInclusionCheck::<T>::put(self.disable_inclusion_check);
-            DisableOpReturnCheck::<T>::put(self.disable_op_return_check);
         }
     }
 }

--- a/crates/btc-relay/src/mock.rs
+++ b/crates/btc-relay/src/mock.rs
@@ -106,7 +106,6 @@ impl ExtBuilder {
             parachain_confirmations: PARACHAIN_CONFIRMATIONS,
             disable_difficulty_check: false,
             disable_inclusion_check: false,
-            disable_op_return_check: false,
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -313,7 +313,6 @@ fn testnet_genesis(
             parachain_confirmations: bitcoin_confirmations.saturating_mul(BITCOIN_BLOCK_SPACING),
             disable_difficulty_check: true,
             disable_inclusion_check: false,
-            disable_op_return_check: false,
         },
         issue: IssueConfig {
             issue_period: DAYS,
@@ -507,7 +506,6 @@ fn mainnet_genesis(
             parachain_confirmations: bitcoin_confirmations.saturating_mul(BITCOIN_BLOCK_SPACING),
             disable_difficulty_check: false,
             disable_inclusion_check: false,
-            disable_op_return_check: false,
         },
         issue: IssueConfig {
             issue_period: DAYS,

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -1064,7 +1064,6 @@ impl ExtBuilder {
             parachain_confirmations: CONFIRMATIONS,
             disable_difficulty_check: false,
             disable_inclusion_check: false,
-            disable_op_return_check: false,
         }
         .assimilate_storage(&mut storage)
         .unwrap();

--- a/standalone/src/chain_spec.rs
+++ b/standalone/src/chain_spec.rs
@@ -245,7 +245,6 @@ fn testnet_genesis(
             parachain_confirmations: bitcoin_confirmations.saturating_mul(BITCOIN_BLOCK_SPACING),
             disable_difficulty_check: true,
             disable_inclusion_check: false,
-            disable_op_return_check: false,
         },
         issue: IssueConfig {
             issue_period: DAYS,


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>