### PR TITLE
fix: use runtime_version attribute macro

### DIFF
--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -83,6 +83,7 @@ impl_opaque_keys! {
 }
 
 /// This runtime version.
+#[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("kintsugi-parachain"),
     impl_name: create_runtime_str!("kintsugi-parachain"),

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -68,6 +68,7 @@ impl_opaque_keys! {
 }
 
 /// This runtime version.
+#[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("interbtc-standalone"),
     impl_name: create_runtime_str!("interbtc-standalone"),


### PR DESCRIPTION
[Apparently](https://github.com/paritytech/cumulus/issues/474) this macro is required for cumulus runtime upgrades 