### PR TITLE
refactor!: don't index stake by reward currency id

### DIFF
--- a/crates/nomination/src/ext.rs
+++ b/crates/nomination/src/ext.rs
@@ -88,11 +88,10 @@ pub(crate) mod staking {
     }
 
     pub fn compute_stake<T: vault_registry::Config>(
-        currency_id: CurrencyId<T>,
         vault_id: &T::AccountId,
         nominator_id: &T::AccountId,
     ) -> Result<SignedInner<T>, DispatchError> {
-        <staking::Pallet<T>>::compute_stake(currency_id, vault_id, nominator_id)
+        <staking::Pallet<T>>::compute_stake(vault_id, nominator_id)
     }
 
     pub fn force_refund<T: crate::Config>(

--- a/crates/nomination/src/lib.rs
+++ b/crates/nomination/src/lib.rs
@@ -322,7 +322,7 @@ impl<T: Config> Pallet<T> {
         vault_id: &T::AccountId,
         nominator_id: &T::AccountId,
     ) -> Result<Amount<T>, DispatchError> {
-        let collateral = ext::staking::compute_stake::<T>(T::GetWrappedCurrencyId::get(), vault_id, nominator_id)?;
+        let collateral = ext::staking::compute_stake::<T>(vault_id, nominator_id)?;
 
         let amount = collateral.try_into().map_err(|_| Error::<T>::TryIntoIntError)?;
 

--- a/crates/staking/src/mock.rs
+++ b/crates/staking/src/mock.rs
@@ -1,7 +1,7 @@
 use crate as staking;
 use crate::{Config, Error};
 use frame_support::parameter_types;
-pub use primitives::CurrencyId;
+pub use primitives::{CurrencyId, DOT};
 use sp_arithmetic::FixedI128;
 use sp_core::H256;
 use sp_runtime::{
@@ -60,9 +60,6 @@ impl frame_system::Config for Test {
     type SS58Prefix = SS58Prefix;
     type OnSetCode = ();
 }
-
-pub const DOT: CurrencyId = CurrencyId::DOT;
-// pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
 
 impl Config for Test {
     type Event = TestEvent;

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -61,18 +61,14 @@ pub(crate) mod staking {
     }
 
     pub fn compute_stake<T: crate::Config>(
-        currency_id: CurrencyId<T>,
         vault_id: &T::AccountId,
         nominator_id: &T::AccountId,
     ) -> Result<SignedInner<T>, DispatchError> {
-        <staking::Pallet<T>>::compute_stake(currency_id, vault_id, nominator_id)
+        <staking::Pallet<T>>::compute_stake(vault_id, nominator_id)
     }
 
-    pub fn total_current_stake<T: crate::Config>(
-        currency_id: CurrencyId<T>,
-        vault_id: &T::AccountId,
-    ) -> Result<SignedInner<T>, DispatchError> {
-        <staking::Pallet<T>>::total_current_stake(currency_id, vault_id)
+    pub fn total_current_stake<T: crate::Config>(vault_id: &T::AccountId) -> Result<SignedInner<T>, DispatchError> {
+        <staking::Pallet<T>>::total_current_stake(vault_id)
     }
 }
 

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -662,7 +662,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn get_backing_collateral(vault_id: &T::AccountId) -> Result<Amount<T>, DispatchError> {
-        let stake = ext::staking::total_current_stake::<T>(T::GetWrappedCurrencyId::get(), vault_id)?
+        let stake = ext::staking::total_current_stake::<T>(vault_id)?
             .try_into()
             .map_err(|_| Error::<T>::TryIntoIntError)?;
         Ok(Amount::new(stake, Self::get_collateral_currency(vault_id)?))
@@ -1608,7 +1608,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn compute_collateral(vault_id: &T::AccountId) -> Result<Amount<T>, DispatchError> {
-        let collateral = ext::staking::compute_stake::<T>(T::GetWrappedCurrencyId::get(), vault_id, vault_id)?;
+        let collateral = ext::staking::compute_stake::<T>(vault_id, vault_id)?;
         let amount = collateral.try_into().map_err(|_| Error::<T>::TryIntoIntError)?;
         Ok(Amount::new(amount, Self::get_collateral_currency(vault_id)?))
     }

--- a/standalone/runtime/tests/test_nomination.rs
+++ b/standalone/runtime/tests/test_nomination.rs
@@ -175,7 +175,7 @@ mod spec_based_tests {
                 NominationPallet::get_nominator_collateral(&account_of(VAULT), &account_of(USER)).unwrap(),
                 Amount::new(0, currency_id)
             );
-            let nonce: u32 = VaultStakingPallet::nonce(INTERBTC, &account_of(VAULT));
+            let nonce: u32 = VaultStakingPallet::nonce(&account_of(VAULT));
             assert_eq!(nonce, 1);
             assert_eq!(
                 VaultStakingPallet::compute_reward_at_index(nonce - 1, INTERBTC, &account_of(VAULT), &account_of(USER))
@@ -550,7 +550,7 @@ fn integration_test_vault_opt_out_must_refund_nomination() {
             NominationPallet::get_nominator_collateral(&account_of(VAULT), &account_of(USER)).unwrap(),
             Amount::new(0, currency_id)
         );
-        let nonce: u32 = VaultStakingPallet::nonce(INTERBTC, &account_of(VAULT));
+        let nonce: u32 = VaultStakingPallet::nonce(&account_of(VAULT));
         assert_eq!(nonce, 1);
         assert_eq!(
             VaultStakingPallet::compute_reward_at_index(nonce - 1, INTERBTC, &account_of(VAULT), &account_of(USER))
@@ -565,7 +565,7 @@ fn integration_test_banning_a_vault_does_not_force_refund() {
     test_with_nomination_enabled_and_vault_opted_in(|currency_id| {
         assert_nominate_collateral(VAULT, USER, default_nomination(currency_id));
         VaultRegistryPallet::ban_vault(account_of(VAULT)).unwrap();
-        let nonce: u32 = VaultStakingPallet::nonce(INTERBTC, &account_of(VAULT));
+        let nonce: u32 = VaultStakingPallet::nonce(&account_of(VAULT));
         assert_eq!(nonce, 0);
     })
 }
@@ -575,7 +575,7 @@ fn integration_test_liquidating_a_vault_does_not_force_refund() {
     test_with_nomination_enabled_and_vault_opted_in(|currency_id| {
         assert_nominate_collateral(VAULT, USER, default_nomination(currency_id));
         VaultRegistryPallet::liquidate_vault(&account_of(VAULT)).unwrap();
-        let nonce: u32 = VaultStakingPallet::nonce(INTERBTC, &account_of(VAULT));
+        let nonce: u32 = VaultStakingPallet::nonce(&account_of(VAULT));
         assert_eq!(nonce, 0);
     })
 }


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

### Breaking Changes
- Storage fields related to stake are no longer indexed by the currency id
- The following events have changed:
  - `DepositStake`
  - `WithdrawStake`
  - `ForceRefund`
  - `IncreaseNonce`