### PR TITLE
chore: remove unused vault querying rpcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,6 @@ dependencies = [
  "hex",
  "itertools 0.10.1",
  "mocktopus",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "security",
@@ -2330,7 +2329,6 @@ dependencies = [
  "mocktopus",
  "orml-tokens",
  "orml-traits",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "reward",
@@ -3566,7 +3564,6 @@ dependencies = [
  "pallet-collective",
  "pallet-democracy",
  "pallet-membership",
- "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-society",
  "pallet-sudo",
@@ -3643,7 +3640,6 @@ dependencies = [
  "pallet-balances",
  "pallet-grandpa",
  "pallet-membership",
- "pallet-randomness-collective-flip",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -3779,7 +3775,6 @@ dependencies = [
  "oracle",
  "orml-tokens",
  "orml-traits",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "refund",
@@ -5331,7 +5326,6 @@ dependencies = [
  "oracle",
  "orml-tokens",
  "orml-traits",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "reward",
@@ -6069,19 +6063,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-randomness-collective-flip"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.9#91061a7d925b5bc597804293da283477512ba4ff"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "safe-mix",
  "sp-runtime",
  "sp-std",
 ]
@@ -8344,7 +8325,6 @@ dependencies = [
  "oracle",
  "orml-tokens",
  "orml-traits",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "reward",
@@ -8433,7 +8413,6 @@ dependencies = [
  "oracle",
  "orml-tokens",
  "orml-traits",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "reward",
@@ -8516,7 +8495,6 @@ dependencies = [
  "oracle",
  "orml-tokens",
  "orml-traits",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "redeem",
@@ -8578,7 +8556,6 @@ dependencies = [
  "oracle",
  "orml-tokens",
  "orml-traits",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "reward",
@@ -8618,7 +8595,6 @@ dependencies = [
  "frame-system",
  "interbtc-primitives",
  "mocktopus",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "rand 0.8.4",
@@ -8859,15 +8835,6 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "safe-mix"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
-dependencies = [
- "rustc_version 0.2.3",
-]
 
 [[package]]
 name = "salsa20"
@@ -11069,7 +11036,6 @@ dependencies = [
  "frame-system",
  "interbtc-primitives",
  "mocktopus",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "rand 0.8.4",
@@ -12140,7 +12106,6 @@ dependencies = [
  "oracle",
  "orml-tokens",
  "orml-traits",
- "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
  "reward",

--- a/crates/btc-relay/Cargo.toml
+++ b/crates/btc-relay/Cargo.toml
@@ -27,7 +27,6 @@ security = { path = "../security", default-features = false }
 mocktopus = "0.7.0"
 hex = "0.4.2"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 itertools = "0.10.0"
 
 [features]

--- a/crates/fee/Cargo.toml
+++ b/crates/fee/Cargo.toml
@@ -29,7 +29,6 @@ staking = { path = "../staking", default-features = false }
 [dev-dependencies]
 mocktopus = "0.7.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 
 # Orml dependencies

--- a/crates/issue/Cargo.toml
+++ b/crates/issue/Cargo.toml
@@ -40,7 +40,6 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 [dev-dependencies]
 mocktopus = "0.7.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
 
 # Parachain dependencies
 reward = { path = "../reward" }

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -25,7 +25,6 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
 
         // Tokens & Balances
         Tokens: orml_tokens::{Pallet, Storage, Config<T>, Event<T>},
@@ -87,8 +86,6 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-impl pallet_randomness_collective_flip::Config for Test {}
-
 pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId =
     <Test as orml_tokens::Config>::CurrencyId::DOT;
 pub const GRIEFING_CURRENCY: CurrencyId = CurrencyId::DOT;
@@ -140,7 +137,6 @@ where
 impl vault_registry::Config for Test {
     type PalletId = VaultPalletId;
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type Balance = Balance;
     type WeightInfo = ();
     type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;

--- a/crates/nomination/Cargo.toml
+++ b/crates/nomination/Cargo.toml
@@ -19,7 +19,6 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 
 # Parachain dependencies
 currency = { path = "../currency", default-features = false }
@@ -60,7 +59,6 @@ std = [
   "frame-system/std",
   "frame-benchmarking/std",
   "pallet-timestamp/std",
-  "pallet-randomness-collective-flip/std",
 
   "currency/std",
   "security/std",

--- a/crates/nomination/src/mock.rs
+++ b/crates/nomination/src/mock.rs
@@ -26,7 +26,6 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
 
         // Tokens & Balances
         Tokens: orml_tokens::{Pallet, Storage, Config<T>, Event<T>},
@@ -86,8 +85,6 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-impl pallet_randomness_collective_flip::Config for Test {}
-
 pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 pub const DOT: CurrencyId = CurrencyId::DOT;
 pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
@@ -137,7 +134,6 @@ where
 impl vault_registry::Config for Test {
     type PalletId = VaultPalletId;
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type Balance = Balance;
     type WeightInfo = ();
     type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;

--- a/crates/redeem/Cargo.toml
+++ b/crates/redeem/Cargo.toml
@@ -38,7 +38,6 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 [dev-dependencies]
 mocktopus = "0.7.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
 
 # Parachain dependencies
 reward = { path = "../reward" }

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -25,7 +25,6 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
 
         // Tokens & Balances
         Tokens: orml_tokens::{Pallet, Storage, Config<T>, Event<T>},
@@ -86,8 +85,6 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-impl pallet_randomness_collective_flip::Config for Test {}
-
 pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId =
     <Test as orml_tokens::Config>::CurrencyId::DOT;
 pub const GRIEFING_CURRENCY: CurrencyId = CurrencyId::DOT;
@@ -133,7 +130,6 @@ where
 impl vault_registry::Config for Test {
     type PalletId = VaultPalletId;
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type Balance = Balance;
     type WeightInfo = ();
     type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;

--- a/crates/refund/Cargo.toml
+++ b/crates/refund/Cargo.toml
@@ -38,7 +38,6 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 [dev-dependencies]
 mocktopus = "0.7.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 
 reward = { path = "../reward", default-features = false }
 staking = { path = "../staking", default-features = false }

--- a/crates/refund/src/mock.rs
+++ b/crates/refund/src/mock.rs
@@ -28,7 +28,6 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
 
         // Tokens & Balances
         Tokens: orml_tokens::{Pallet, Storage, Config<T>, Event<T>},
@@ -88,8 +87,6 @@ impl frame_system::Config for Test {
     type SS58Prefix = SS58Prefix;
     type OnSetCode = ();
 }
-
-impl pallet_randomness_collective_flip::Config for Test {}
 
 pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 pub const DOT: CurrencyId = CurrencyId::DOT;
@@ -175,7 +172,6 @@ where
 impl vault_registry::Config for Test {
     type PalletId = VaultPalletId;
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type Balance = Balance;
     type WeightInfo = ();
     type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;

--- a/crates/relay/Cargo.toml
+++ b/crates/relay/Cargo.toml
@@ -41,7 +41,6 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 mocktopus = "0.7.0"
 hex = "0.4.2"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
 
 # Parachain dependencies

--- a/crates/relay/src/mock.rs
+++ b/crates/relay/src/mock.rs
@@ -25,7 +25,6 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
 
         // Tokens & Balances
         Tokens: orml_tokens::{Pallet, Storage, Config<T>, Event<T>},
@@ -89,8 +88,6 @@ impl frame_system::Config for Test {
     type SS58Prefix = SS58Prefix;
     type OnSetCode = ();
 }
-
-impl pallet_randomness_collective_flip::Config for Test {}
 
 pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId =
     <Test as orml_tokens::Config>::CurrencyId::DOT;
@@ -157,7 +154,6 @@ where
 impl vault_registry::Config for Test {
     type PalletId = VaultPalletId;
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type Balance = Balance;
     type WeightInfo = ();
     type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;

--- a/crates/replace/Cargo.toml
+++ b/crates/replace/Cargo.toml
@@ -39,7 +39,6 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 [dev-dependencies]
 mocktopus = "0.7.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9" }
 
 # Parachain dependencies
 reward = { path = "../reward" }

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -25,7 +25,6 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
 
         // Tokens & Balances
         Tokens: orml_tokens::{Pallet, Storage, Config<T>, Event<T>},
@@ -86,8 +85,6 @@ impl frame_system::Config for Test {
     type SS58Prefix = SS58Prefix;
     type OnSetCode = ();
 }
-
-impl pallet_randomness_collective_flip::Config for Test {}
 
 pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 pub const GRIEFING_CURRENCY: CurrencyId = CurrencyId::DOT;
@@ -163,7 +160,6 @@ impl currency::Config for Test {
 impl vault_registry::Config for Test {
     type PalletId = VaultPalletId;
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type Balance = Balance;
     type WeightInfo = ();
     type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;

--- a/crates/reward/Cargo.toml
+++ b/crates/reward/Cargo.toml
@@ -27,7 +27,6 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 mocktopus = "0.7.0"
 rand = "0.8.3"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }

--- a/crates/staking/Cargo.toml
+++ b/crates/staking/Cargo.toml
@@ -27,7 +27,6 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 mocktopus = "0.7.0"
 rand = "0.8.3"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }

--- a/crates/vault-registry/Cargo.toml
+++ b/crates/vault-registry/Cargo.toml
@@ -24,7 +24,6 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 
 # Parachain dependencies
 bitcoin = { path = "../bitcoin", default-features = false }
@@ -61,7 +60,6 @@ std = [
   "frame-system/std",
   "frame-benchmarking/std",
   "pallet-timestamp/std",
-  "pallet-randomness-collective-flip/std",
 
   "orml-tokens/std",
   "orml-traits/std",

--- a/crates/vault-registry/README.md
+++ b/crates/vault-registry/README.md
@@ -39,7 +39,6 @@ You should implement it's trait like so:
 /// Used for test_module
 impl vault_registry::Config for Runtime {
     type Event = Event;
-    type RandomnessSource = RandomnessCollectiveFlip;
     type WeightInfo = ();
 }
 ```

--- a/crates/vault-registry/rpc/runtime-api/src/lib.rs
+++ b/crates/vault-registry/rpc/runtime-api/src/lib.rs
@@ -20,13 +20,6 @@ sp_api::decl_runtime_apis! {
         /// Get the vault's collateral (including nomination)
         fn get_vault_total_collateral(vault_id: AccountId) -> Result<BalanceWrapper<Balance>, DispatchError>;
 
-        /// Get the first available vault with sufficient collateral to fulfil an issue request
-        /// with the specified amount of Wrapped.
-        fn get_first_vault_with_sufficient_collateral(amount: BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<AccountId, DispatchError>;
-
-        /// Get the first available vault with sufficient tokens to fulfil a redeem request
-        fn get_first_vault_with_sufficient_tokens(amount: BalanceWrapper<Balance>) -> Result<AccountId, DispatchError>;
-
         /// Get all vaults below the premium redeem threshold, ordered in descending order of this amount
         fn get_premium_redeem_vaults() -> Result<Vec<(AccountId, BalanceWrapper<Balance>)>, DispatchError>;
 

--- a/crates/vault-registry/rpc/src/lib.rs
+++ b/crates/vault-registry/rpc/src/lib.rs
@@ -36,21 +36,6 @@ where
         at: Option<BlockHash>,
     ) -> JsonRpcResult<BalanceWrapper<Balance>>;
 
-    #[rpc(name = "vaultRegistry_getFirstVaultWithSufficientCollateral")]
-    fn get_first_vault_with_sufficient_collateral(
-        &self,
-        amount: BalanceWrapper<Balance>,
-        currency_id: CurrencyId,
-        at: Option<BlockHash>,
-    ) -> JsonRpcResult<AccountId>;
-
-    #[rpc(name = "vaultRegistry_getFirstVaultWithSufficientTokens")]
-    fn get_first_vault_with_sufficient_tokens(
-        &self,
-        amount: BalanceWrapper<Balance>,
-        at: Option<BlockHash>,
-    ) -> JsonRpcResult<AccountId>;
-
     #[rpc(name = "vaultRegistry_getPremiumRedeemVaults")]
     fn get_premium_redeem_vaults(
         &self,
@@ -196,35 +181,6 @@ where
         handle_response(
             api.get_vault_total_collateral(&at, vault_id),
             "Unable to get the vault's collateral.".into(),
-        )
-    }
-
-    fn get_first_vault_with_sufficient_collateral(
-        &self,
-        amount: BalanceWrapper<Balance>,
-        currency_id: CurrencyId,
-        at: Option<<Block as BlockT>::Hash>,
-    ) -> JsonRpcResult<AccountId> {
-        let api = self.client.runtime_api();
-        let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
-
-        handle_response(
-            api.get_first_vault_with_sufficient_collateral(&at, amount, currency_id),
-            "Unable to find a vault with sufficient collateral.".into(),
-        )
-    }
-
-    fn get_first_vault_with_sufficient_tokens(
-        &self,
-        amount: BalanceWrapper<Balance>,
-        at: Option<<Block as BlockT>::Hash>,
-    ) -> JsonRpcResult<AccountId> {
-        let api = self.client.runtime_api();
-        let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
-
-        handle_response(
-            api.get_first_vault_with_sufficient_tokens(&at, amount),
-            "Unable to find a vault with sufficient tokens.".into(),
         )
     }
 

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -24,7 +24,6 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
 
         // Tokens & Balances
         Tokens: orml_tokens::{Pallet, Storage, Config<T>, Event<T>},
@@ -81,8 +80,6 @@ impl frame_system::Config for Test {
     type SS58Prefix = SS58Prefix;
     type OnSetCode = ();
 }
-
-impl pallet_randomness_collective_flip::Config for Test {}
 
 pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 pub const GRIEFING_CURRENCY: CurrencyId = CurrencyId::DOT;
@@ -185,7 +182,6 @@ parameter_types! {
 impl Config for Test {
     type PalletId = VaultPalletId;
     type Event = TestEvent;
-    type RandomnessSource = pallet_randomness_collective_flip::Pallet<Test>;
     type Balance = Balance;
     type WeightInfo = ();
     type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -85,8 +85,6 @@ pub(crate) type BalanceOf<T> = <T as Config>::Balance;
 
 pub(crate) type Collateral<T> = BalanceOf<T>;
 
-pub(crate) type Wrapped<T> = BalanceOf<T>;
-
 pub(crate) type SignedFixedPoint<T> = <T as currency::Config>::SignedFixedPoint;
 
 pub(crate) type UnsignedFixedPoint<T> = <T as currency::Config>::UnsignedFixedPoint;

--- a/parachain/runtime/Cargo.toml
+++ b/parachain/runtime/Cargo.toml
@@ -32,7 +32,6 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
 frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
@@ -147,7 +146,6 @@ std = [
   "frame-benchmarking/std",
   "frame-system-benchmarking/std",
   "pallet-balances/std",
-  "pallet-randomness-collective-flip/std",
   "pallet-timestamp/std",
   "pallet-sudo/std",
   "pallet-utility/std",

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -38,7 +38,7 @@ use sp_version::RuntimeVersion;
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
     construct_runtime, parameter_types,
-    traits::{Everything, Get, KeyOwnerProofSystem, Randomness},
+    traits::{Everything, Get, KeyOwnerProofSystem},
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
         DispatchClass, IdentityFee, Weight,
@@ -196,8 +196,6 @@ impl frame_system::Config for Runtime {
     type SS58Prefix = SS58Prefix;
     type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 }
-
-impl pallet_randomness_collective_flip::Config for Runtime {}
 
 impl pallet_aura::Config for Runtime {
     type AuthorityId = AuraId;
@@ -817,7 +815,6 @@ parameter_types! {
 impl vault_registry::Config for Runtime {
     type PalletId = VaultPalletId;
     type Event = Event;
-    type RandomnessSource = RandomnessCollectiveFlip;
     type Balance = Balance;
     type WeightInfo = ();
     type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
@@ -898,7 +895,6 @@ construct_runtime! {
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
         Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>},
         Utility: pallet_utility::{Pallet, Call, Event},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
         TransactionPayment: pallet_transaction_payment::{Pallet, Storage},
         Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>},
 
@@ -1198,16 +1194,6 @@ impl_runtime_apis! {
         fn get_vault_total_collateral(vault_id: AccountId) -> Result<BalanceWrapper<Balance>, DispatchError> {
             let result = VaultRegistry::get_backing_collateral(&vault_id)?;
             Ok(BalanceWrapper{amount:result.amount()})
-        }
-
-        fn get_first_vault_with_sufficient_collateral(amount: BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<AccountId, DispatchError> {
-            let amount = Amount::new(amount.amount, currency_id);
-            VaultRegistry::get_first_vault_with_sufficient_collateral(&amount)
-        }
-
-        fn get_first_vault_with_sufficient_tokens(amount: BalanceWrapper<Balance>) -> Result<AccountId, DispatchError> {
-            let amount = Amount::new(amount.amount, GetWrappedCurrencyId::get());
-            VaultRegistry::get_first_vault_with_sufficient_tokens(&amount)
         }
 
         fn get_premium_redeem_vaults() -> Result<Vec<(AccountId, BalanceWrapper<Balance>)>, DispatchError> {

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -32,7 +32,6 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
 frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
@@ -117,7 +116,6 @@ std = [
   "frame-benchmarking/std",
   "frame-system-benchmarking/std",
   "pallet-balances/std",
-  "pallet-randomness-collective-flip/std",
   "pallet-timestamp/std",
   "pallet-sudo/std",
   "pallet-utility/std",

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -30,7 +30,7 @@ use sp_version::RuntimeVersion;
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
     construct_runtime, parameter_types,
-    traits::{Everything, Get, KeyOwnerProofSystem, Randomness},
+    traits::{Everything, Get, KeyOwnerProofSystem},
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
         DispatchClass, IdentityFee, Weight,
@@ -183,8 +183,6 @@ impl frame_system::Config for Runtime {
     type OnSetCode = ();
 }
 
-impl pallet_randomness_collective_flip::Config for Runtime {}
-
 impl pallet_aura::Config for Runtime {
     type AuthorityId = AuraId;
     type DisabledValidators = ();
@@ -331,7 +329,6 @@ parameter_types! {
 impl vault_registry::Config for Runtime {
     type PalletId = VaultPalletId;
     type Event = Event;
-    type RandomnessSource = RandomnessCollectiveFlip;
     type Balance = Balance;
     type WeightInfo = ();
     type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
@@ -412,7 +409,6 @@ construct_runtime! {
         Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
         Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>},
         Utility: pallet_utility::{Pallet, Call, Event},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
         TransactionPayment: pallet_transaction_payment::{Pallet, Storage},
 
         // Tokens & Balances
@@ -716,16 +712,6 @@ impl_runtime_apis! {
         fn get_vault_total_collateral(vault_id: AccountId) -> Result<BalanceWrapper<Balance>, DispatchError> {
             let result = VaultRegistry::get_backing_collateral(&vault_id)?;
             Ok(BalanceWrapper{amount:result.amount()})
-        }
-
-        fn get_first_vault_with_sufficient_collateral(amount: BalanceWrapper<Balance>, currency_id: CurrencyId) -> Result<AccountId, DispatchError> {
-            let amount = Amount::new(amount.amount, currency_id);
-            VaultRegistry::get_first_vault_with_sufficient_collateral(&amount)
-        }
-
-        fn get_first_vault_with_sufficient_tokens(amount: BalanceWrapper<Balance>) -> Result<AccountId, DispatchError> {
-            let amount = Amount::new(amount.amount, GetWrappedCurrencyId::get());
-            VaultRegistry::get_first_vault_with_sufficient_tokens(&amount)
         }
 
         fn get_premium_redeem_vaults() -> Result<Vec<(AccountId, BalanceWrapper<Balance>)>, DispatchError> {


### PR DESCRIPTION
This would have been a breaking change, but nobody depends in this code.

- removed `get_first_vault_with_sufficient_collateral` and `removed get_first_vault_with_sufficient_tokens`
- removed randomness pallet