### PR TITLE
refactor!: remove amount_wrapped from refund struct

### DIFF
--- a/crates/refund/src/lib.rs
+++ b/crates/refund/src/lib.rs
@@ -177,9 +177,8 @@ impl<T: Config> Pallet<T> {
 
         let request = RefundRequest {
             vault: vault_id,
-            amount_wrapped: net_refund_amount_wrapped.amount(),
             fee: fee_wrapped.amount(),
-            amount_btc: total_amount_btc.amount(),
+            amount_btc: net_refund_amount_wrapped.amount(),
             issuer,
             btc_address,
             issue_id,
@@ -190,7 +189,7 @@ impl<T: Config> Pallet<T> {
         Self::deposit_event(<Event<T>>::RequestRefund(
             refund_id,
             request.issuer,
-            request.amount_wrapped,
+            request.amount_btc,
             request.vault,
             request.btc_address,
             request.issue_id,
@@ -220,7 +219,7 @@ impl<T: Config> Pallet<T> {
             merkle_proof,
             transaction,
             request.btc_address,
-            request.amount_wrapped,
+            request.amount_btc,
             refund_id,
         )?;
         // mint issued tokens corresponding to the fee. Note that this can fail
@@ -238,7 +237,7 @@ impl<T: Config> Pallet<T> {
             refund_id,
             request.issuer,
             request.vault,
-            request.amount_wrapped,
+            request.amount_btc,
             request.fee,
         ));
 

--- a/crates/refund/src/types.rs
+++ b/crates/refund/src/types.rs
@@ -9,15 +9,11 @@ pub(crate) type Wrapped<T> = BalanceOf<T>;
 pub type DefaultRefundRequest<T> = RefundRequest<<T as frame_system::Config>::AccountId, BalanceOf<T>>;
 
 pub(crate) trait RefundRequestExt<T: crate::Config> {
-    fn amount_wrapped(&self) -> Amount<T>;
     fn fee(&self) -> Amount<T>;
     fn amount_btc(&self) -> Amount<T>;
 }
 
 impl<T: crate::Config> RefundRequestExt<T> for RefundRequest<T::AccountId, BalanceOf<T>> {
-    fn amount_wrapped(&self) -> Amount<T> {
-        Amount::new(self.amount_wrapped, T::GetWrappedCurrencyId::get())
-    }
     fn fee(&self) -> Amount<T> {
         Amount::new(self.fee, T::GetWrappedCurrencyId::get())
     }

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -443,12 +443,7 @@ impl<T: Config> Pallet<T> {
             // refund requests
             if let Ok(req) = ext::refund::get_open_or_completed_refund_request_from_id::<T>(&payment_data.op_return) {
                 ensure!(
-                    !Self::is_valid_request_transaction(
-                        req.amount_wrapped,
-                        req.btc_address,
-                        &payment_data,
-                        &vault.wallet
-                    ),
+                    !Self::is_valid_request_transaction(req.amount_btc, req.btc_address, &payment_data, &vault.wallet),
                     Error::<T>::ValidRefundTransaction
                 );
             };

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -193,20 +193,14 @@ pub mod refund {
         #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
         #[cfg_attr(feature = "std", serde(bound(serialize = "Balance: std::fmt::Display")))]
         #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
-        /// the total amount the vault should send
-        pub amount_wrapped: Balance,
+        /// the total amount which was overpaid
+        pub amount_btc: Balance,
         #[cfg_attr(feature = "std", serde(bound(deserialize = "Balance: std::str::FromStr")))]
         #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
         #[cfg_attr(feature = "std", serde(bound(serialize = "Balance: std::fmt::Display")))]
         #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
         /// total refund fees - taken from request amount
         pub fee: Balance,
-        #[cfg_attr(feature = "std", serde(bound(deserialize = "Balance: std::str::FromStr")))]
-        #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
-        #[cfg_attr(feature = "std", serde(bound(serialize = "Balance: std::fmt::Display")))]
-        #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
-        /// the total amount which was overpaid
-        pub amount_btc: Balance,
         /// the account on issue which overpaid
         pub issuer: AccountId,
         /// the user's Bitcoin address for payment verification

--- a/standalone/runtime/tests/mock/issue_testing_utils.rs
+++ b/standalone/runtime/tests/mock/issue_testing_utils.rs
@@ -204,7 +204,7 @@ pub fn assert_refund_request_event() -> H256 {
 pub fn execute_refund(vault_id: [u8; 32]) -> (H256, RefundRequest<AccountId, u128>) {
     let refund_id = assert_refund_request_event();
     let refund = RefundPallet::get_open_refund_request_from_id(&refund_id).unwrap();
-    assert_ok!(execute_refund_with_amount(vault_id, wrapped(refund.amount_wrapped)));
+    assert_ok!(execute_refund_with_amount(vault_id, wrapped(refund.amount_btc)));
     (refund_id, refund)
 }
 

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -581,7 +581,7 @@ mod execute_refund_payment_limits {
         let refund_id = assert_refund_request_event();
         let refund = RefundPallet::get_open_refund_request_from_id(&refund_id).unwrap();
 
-        (refund_id, wrapped(refund.amount_wrapped))
+        (refund_id, wrapped(refund.amount_btc))
     }
 
     #[test]


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Removes `refund.amount_wrapped` in favour of `refund.amount_btc` (to harmonize with `redeem` and `replace`).

`amount_btc = total_amount_btc - fee_wrapped`