### PR TITLE
fix!: force refund can not re-distribute collateral

### DIFF
--- a/crates/fee/src/benchmarking.rs
+++ b/crates/fee/src/benchmarking.rs
@@ -10,7 +10,7 @@ const SEED: u32 = 0;
 benchmarks! {
     withdraw_rewards {
         let recipient: T::AccountId = account("recipient", 0, SEED);
-    }: _(RawOrigin::Signed(recipient.clone()), recipient.clone())
+    }: _(RawOrigin::Signed(recipient.clone()), recipient.clone(), None)
 }
 
 impl_benchmark_test_suite!(Fee, crate::mock::ExtBuilder::build(), crate::mock::Test);

--- a/crates/nomination/src/benchmarking.rs
+++ b/crates/nomination/src/benchmarking.rs
@@ -89,9 +89,9 @@ benchmarks! {
         mint_collateral::<T>(&nominator, (1u32 << 31).into());
         let amount = 100u32.into();
 
-        assert_ok!(Nomination::<T>::_deposit_collateral(vault.clone(), nominator.clone(), amount));
+        assert_ok!(Nomination::<T>::_deposit_collateral(&vault, &nominator, amount));
 
-    }: _(RawOrigin::Signed(nominator), vault, amount)
+    }: _(RawOrigin::Signed(nominator), vault, amount, None)
 
 }
 

--- a/crates/nomination/src/ext.rs
+++ b/crates/nomination/src/ext.rs
@@ -69,6 +69,10 @@ pub(crate) mod staking {
     use frame_support::dispatch::DispatchError;
     use vault_registry::types::CurrencyId;
 
+    pub fn nonce<T: crate::Config>(vault_id: &T::AccountId) -> T::Index {
+        <staking::Pallet<T>>::nonce(vault_id)
+    }
+
     pub fn deposit_stake<T: crate::Config>(
         currency_id: CurrencyId<T>,
         vault_id: &T::AccountId,
@@ -83,8 +87,9 @@ pub(crate) mod staking {
         vault_id: &T::AccountId,
         nominator_id: &T::AccountId,
         amount: SignedFixedPoint<T>,
+        index: Option<T::Index>,
     ) -> Result<(), DispatchError> {
-        <staking::Pallet<T>>::withdraw_stake(currency_id, vault_id, nominator_id, amount)
+        <staking::Pallet<T>>::withdraw_stake(currency_id, vault_id, nominator_id, amount, index)
     }
 
     pub fn compute_stake<T: vault_registry::Config>(

--- a/crates/nomination/src/tests.rs
+++ b/crates/nomination/src/tests.rs
@@ -7,7 +7,7 @@ use mocktopus::mocking::*;
 fn should_not_deposit_against_invalid_vault() {
     run_test(|| {
         assert_err!(
-            Nomination::_deposit_collateral(ALICE, BOB, 100),
+            Nomination::_deposit_collateral(&ALICE, &BOB, 100),
             TestError::VaultNotOptedInToNomination
         );
     })
@@ -26,6 +26,6 @@ fn should_deposit_against_valid_vault() {
             .mock_safe(|_| MockResult::Return(Ok(DEFAULT_TESTING_CURRENCY)));
 
         assert_ok!(Nomination::_opt_in_to_nomination(&ALICE));
-        assert_ok!(Nomination::_deposit_collateral(ALICE, BOB, 100));
+        assert_ok!(Nomination::_deposit_collateral(&ALICE, &BOB, 100));
     })
 }

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -49,7 +49,13 @@ pub(crate) mod staking {
         nominator_id: &T::AccountId,
         amount: &Amount<T>,
     ) -> Result<(), DispatchError> {
-        <staking::Pallet<T>>::withdraw_stake(currency_id, vault_id, nominator_id, amount.to_signed_fixed_point()?)
+        <staking::Pallet<T>>::withdraw_stake(
+            currency_id,
+            vault_id,
+            nominator_id,
+            amount.to_signed_fixed_point()?,
+            None,
+        )
     }
 
     pub fn slash_stake<T: crate::Config>(

--- a/standalone/runtime/tests/mock/nomination_testing_utils.rs
+++ b/standalone/runtime/tests/mock/nomination_testing_utils.rs
@@ -84,6 +84,7 @@ pub fn withdraw_nominator_collateral(
     Call::Nomination(NominationCall::withdraw_collateral(
         account_of(vault),
         amount_collateral.amount(),
+        None,
     ))
     .dispatch(origin_of(account_of(nominator)))
 }

--- a/standalone/runtime/tests/test_fee_pool.rs
+++ b/standalone/runtime/tests/test_fee_pool.rs
@@ -53,7 +53,7 @@ fn test_with<R>(execute: impl Fn(CurrencyId) -> R) {
 
 fn withdraw_vault_global_pool_rewards(account: [u8; 32]) -> i128 {
     let amount = VaultRewardsPallet::compute_reward(INTERBTC, &account_of(account)).unwrap();
-    assert_ok!(Call::Fee(FeeCall::withdraw_rewards(account_of(account))).dispatch(origin_of(account_of(account))));
+    assert_ok!(Call::Fee(FeeCall::withdraw_rewards(account_of(account), None)).dispatch(origin_of(account_of(account))));
     amount
 }
 
@@ -63,7 +63,7 @@ fn withdraw_local_pool_rewards(pool_id: [u8; 32], account: [u8; 32]) -> i128 {
         &account_of(account),
     )
     .unwrap();
-    assert_ok!(Call::Fee(FeeCall::withdraw_rewards(account_of(pool_id))).dispatch(origin_of(account_of(account))));
+    assert_ok!(Call::Fee(FeeCall::withdraw_rewards(account_of(pool_id), None)).dispatch(origin_of(account_of(account))));
     amount
 }
 
@@ -328,7 +328,7 @@ fn integration_test_fee_with_parachain_shutdown_fails() {
         SecurityPallet::set_status(StatusCode::Shutdown);
 
         assert_noop!(
-            Call::Fee(FeeCall::withdraw_rewards(account_of(ALICE))).dispatch(origin_of(account_of(ALICE))),
+            Call::Fee(FeeCall::withdraw_rewards(account_of(ALICE), None)).dispatch(origin_of(account_of(ALICE))),
             SecurityError::ParachainShutdown
         );
     })

--- a/standalone/runtime/tests/test_nomination.rs
+++ b/standalone/runtime/tests/test_nomination.rs
@@ -82,7 +82,7 @@ mod spec_based_tests {
             SecurityError::ParachainNotRunning,
         );
         assert_noop!(
-            Call::Nomination(NominationCall::withdraw_collateral(account_of(BOB), 100))
+            Call::Nomination(NominationCall::withdraw_collateral(account_of(BOB), 100, None))
                 .dispatch(origin_of(account_of(ALICE))),
             SecurityError::ParachainNotRunning,
         );
@@ -178,8 +178,7 @@ mod spec_based_tests {
             let nonce: u32 = VaultStakingPallet::nonce(&account_of(VAULT));
             assert_eq!(nonce, 1);
             assert_eq!(
-                VaultStakingPallet::compute_reward_at_index(nonce - 1, INTERBTC, &account_of(VAULT), &account_of(USER))
-                    .unwrap(),
+                VaultStakingPallet::compute_stake_at_index(nonce - 1, &account_of(VAULT), &account_of(USER)).unwrap(),
                 DEFAULT_NOMINATION as i128
             );
         })
@@ -272,7 +271,8 @@ mod spec_based_tests {
             assert_noop!(
                 Call::Nomination(NominationCall::withdraw_collateral(
                     account_of(VAULT),
-                    DEFAULT_BACKING_COLLATERAL
+                    DEFAULT_BACKING_COLLATERAL,
+                    None
                 ))
                 .dispatch(origin_of(account_of(USER))),
                 NominationError::VaultNominationDisabled
@@ -281,15 +281,17 @@ mod spec_based_tests {
             assert_noop!(
                 Call::Nomination(NominationCall::withdraw_collateral(
                     account_of(CAROL),
-                    DEFAULT_BACKING_COLLATERAL
+                    DEFAULT_BACKING_COLLATERAL,
+                    None
                 ))
                 .dispatch(origin_of(account_of(USER))),
-                NominationError::VaultNotOptedInToNomination
+                VaultRegistryError::VaultNotFound
             );
             assert_noop!(
                 Call::Nomination(NominationCall::withdraw_collateral(
                     account_of(VAULT),
-                    DEFAULT_BACKING_COLLATERAL
+                    DEFAULT_BACKING_COLLATERAL,
+                    None
                 ))
                 .dispatch(origin_of(account_of(USER))),
                 NominationError::VaultNotOptedInToNomination
@@ -298,7 +300,8 @@ mod spec_based_tests {
             assert_noop!(
                 Call::Nomination(NominationCall::withdraw_collateral(
                     account_of(VAULT),
-                    DEFAULT_BACKING_COLLATERAL
+                    DEFAULT_BACKING_COLLATERAL,
+                    None
                 ))
                 .dispatch(origin_of(account_of(USER))),
                 NominationError::InsufficientCollateral
@@ -553,8 +556,7 @@ fn integration_test_vault_opt_out_must_refund_nomination() {
         let nonce: u32 = VaultStakingPallet::nonce(&account_of(VAULT));
         assert_eq!(nonce, 1);
         assert_eq!(
-            VaultStakingPallet::compute_reward_at_index(nonce - 1, INTERBTC, &account_of(VAULT), &account_of(USER))
-                .unwrap(),
+            VaultStakingPallet::compute_stake_at_index(nonce - 1, &account_of(VAULT), &account_of(USER)).unwrap(),
             DEFAULT_NOMINATION as i128
         );
     })


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

The previous implementation assumed that we could redistribute collateral as rewards which is not possible. To resolve this we now only withdraw and re-deposit the vault's collateral, nominators must provide the staking pool `T::Index` on `withdraw_collateral` and `withdraw_rewards`.