### PR TITLE
refactor!: iterate over reward currencies

### DIFF
--- a/crates/fee/src/mock.rs
+++ b/crates/fee/src/mock.rs
@@ -105,10 +105,15 @@ impl orml_tokens::Config for Test {
     type DustRemovalWhitelist = ();
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
+}
+
 impl reward::Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 impl staking::Config for Test {
@@ -116,6 +121,7 @@ impl staking::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -119,10 +119,15 @@ impl orml_tokens::Config for Test {
     type DustRemovalWhitelist = ();
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
+}
+
 impl reward::Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {
@@ -175,6 +180,7 @@ impl staking::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {

--- a/crates/nomination/src/benchmarking.rs
+++ b/crates/nomination/src/benchmarking.rs
@@ -1,6 +1,6 @@
 use super::*;
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
-use frame_support::assert_ok;
+use frame_support::{assert_ok, traits::Get};
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
 use primitives::CurrencyId;

--- a/crates/nomination/src/ext.rs
+++ b/crates/nomination/src/ext.rs
@@ -65,29 +65,27 @@ pub(crate) mod fee {
 pub(crate) mod staking {
     use crate::types::{SignedFixedPoint, SignedInner};
     use frame_support::dispatch::DispatchError;
-    use vault_registry::{types::CurrencyId, DefaultVaultId};
+    use vault_registry::DefaultVaultId;
 
     pub fn nonce<T: crate::Config>(vault_id: &DefaultVaultId<T>) -> T::Index {
         <staking::Pallet<T>>::nonce(vault_id)
     }
 
     pub fn deposit_stake<T: crate::Config>(
-        currency_id: CurrencyId<T>,
         vault_id: &DefaultVaultId<T>,
         nominator_id: &T::AccountId,
         amount: SignedFixedPoint<T>,
     ) -> Result<(), DispatchError> {
-        <staking::Pallet<T>>::deposit_stake(currency_id, vault_id, nominator_id, amount)
+        <staking::Pallet<T>>::deposit_stake(vault_id, nominator_id, amount)
     }
 
     pub fn withdraw_stake<T: crate::Config>(
-        currency_id: CurrencyId<T>,
         vault_id: &DefaultVaultId<T>,
         nominator_id: &T::AccountId,
         amount: SignedFixedPoint<T>,
         index: Option<T::Index>,
     ) -> Result<(), DispatchError> {
-        <staking::Pallet<T>>::withdraw_stake(currency_id, vault_id, nominator_id, amount, index)
+        <staking::Pallet<T>>::withdraw_stake(vault_id, nominator_id, amount, index)
     }
 
     pub fn compute_stake<T: vault_registry::Config>(
@@ -97,10 +95,7 @@ pub(crate) mod staking {
         <staking::Pallet<T>>::compute_stake(vault_id, nominator_id)
     }
 
-    pub fn force_refund<T: crate::Config>(
-        currency_id: CurrencyId<T>,
-        vault_id: &DefaultVaultId<T>,
-    ) -> Result<SignedInner<T>, DispatchError> {
-        <staking::Pallet<T>>::force_refund(currency_id, vault_id)
+    pub fn force_refund<T: crate::Config>(vault_id: &DefaultVaultId<T>) -> Result<SignedInner<T>, DispatchError> {
+        <staking::Pallet<T>>::force_refund(vault_id)
     }
 }

--- a/crates/nomination/src/lib.rs
+++ b/crates/nomination/src/lib.rs
@@ -28,9 +28,7 @@ pub use default_weights::WeightInfo;
 use currency::Amount;
 use frame_support::{
     dispatch::{DispatchError, DispatchResult},
-    ensure,
-    traits::Get,
-    transactional,
+    ensure, transactional,
 };
 use frame_system::{ensure_root, ensure_signed};
 pub use pallet::*;
@@ -230,13 +228,7 @@ impl<T: Config> Pallet<T> {
         // withdraw all vault rewards first, to prevent the nominator from withdrawing past rewards
         ext::fee::withdraw_all_vault_rewards::<T>(vault_id)?;
         // withdraw `amount` of stake from the vault staking pool
-        ext::staking::withdraw_stake::<T>(
-            T::GetWrappedCurrencyId::get(),
-            vault_id,
-            nominator_id,
-            amount.to_signed_fixed_point()?,
-            Some(index),
-        )?;
+        ext::staking::withdraw_stake::<T>(vault_id, nominator_id, amount.to_signed_fixed_point()?, Some(index))?;
         amount.unlock_on(&vault_id.account_id)?;
         amount.transfer(&vault_id.account_id, &nominator_id)?;
 
@@ -272,12 +264,7 @@ impl<T: Config> Pallet<T> {
         ext::fee::withdraw_all_vault_rewards::<T>(vault_id)?;
 
         // Deposit `amount` of stake into the vault staking pool
-        ext::staking::deposit_stake::<T>(
-            T::GetWrappedCurrencyId::get(),
-            vault_id,
-            nominator_id,
-            amount.to_signed_fixed_point()?,
-        )?;
+        ext::staking::deposit_stake::<T>(vault_id, nominator_id, amount.to_signed_fixed_point()?)?;
         amount.transfer(&nominator_id, &vault_id.account_id)?;
         amount.lock_on(&vault_id.account_id)?;
         ext::vault_registry::try_increase_total_backing_collateral(&amount)?;
@@ -317,7 +304,7 @@ impl<T: Config> Pallet<T> {
             Error::<T>::CollateralizationTooLow
         );
 
-        let refunded_collateral = ext::staking::force_refund::<T>(T::GetWrappedCurrencyId::get(), vault_id)?
+        let refunded_collateral = ext::staking::force_refund::<T>(vault_id)?
             .try_into()
             .map_err(|_| Error::<T>::TryIntoIntError)?;
 

--- a/crates/nomination/src/mock.rs
+++ b/crates/nomination/src/mock.rs
@@ -115,10 +115,15 @@ impl orml_tokens::Config for Test {
     type DustRemovalWhitelist = ();
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
+}
+
 impl reward::Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {
@@ -171,6 +176,7 @@ impl staking::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 impl security::Config for Test {

--- a/crates/oracle/src/mock.rs
+++ b/crates/oracle/src/mock.rs
@@ -140,11 +140,16 @@ impl security::Config for Test {
     type Event = TestEvent;
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
+}
+
 impl staking::Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 pub type TestEvent = Event;

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -168,12 +168,18 @@ impl staking::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
+}
+
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
 }
 
 impl reward::Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {

--- a/crates/refund/src/mock.rs
+++ b/crates/refund/src/mock.rs
@@ -124,10 +124,15 @@ impl orml_tokens::Config for Test {
     type DustRemovalWhitelist = ();
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
+}
+
 impl reward::Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 impl Config for Test {
@@ -215,6 +220,7 @@ impl staking::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 impl oracle::Config for Test {

--- a/crates/relay/src/mock.rs
+++ b/crates/relay/src/mock.rs
@@ -121,10 +121,15 @@ impl orml_tokens::Config for Test {
     type DustRemovalWhitelist = ();
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
+}
+
 impl reward::Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {
@@ -192,6 +197,7 @@ impl staking::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 impl oracle::Config for Test {

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -118,10 +118,15 @@ impl orml_tokens::Config for Test {
     type DustRemovalWhitelist = ();
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
+}
+
 impl reward::Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {
@@ -173,6 +178,7 @@ impl staking::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {

--- a/crates/reward/src/mock.rs
+++ b/crates/reward/src/mock.rs
@@ -61,13 +61,18 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DOT: CurrencyId = CurrencyId::DOT;
-// pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
+pub const KINT: CurrencyId = CurrencyId::KINT;
+pub const KBTC: CurrencyId = CurrencyId::KBTC;
+
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![KINT, KBTC];
+}
 
 impl Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 pub type TestEvent = Event;
@@ -76,14 +81,14 @@ pub type TestError = Error<Test>;
 pub const ALICE: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 1,
     currencies: VaultCurrencyPair {
-        collateral: DOT,
+        collateral: KBTC,
         wrapped: INTERBTC,
     },
 };
 pub const BOB: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 2,
     currencies: VaultCurrencyPair {
-        collateral: DOT,
+        collateral: KBTC,
         wrapped: INTERBTC,
     },
 };

--- a/crates/reward/src/tests.rs
+++ b/crates/reward/src/tests.rs
@@ -14,69 +14,69 @@ macro_rules! fixed {
 #[test]
 fn should_distribute_rewards_equally() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(DOT, &ALICE, fixed!(50)));
-        assert_ok!(Reward::deposit_stake(DOT, &BOB, fixed!(50)));
-        assert_ok!(Reward::distribute_reward(DOT, fixed!(100)));
-        assert_ok!(Reward::compute_reward(DOT, &ALICE), 50);
-        assert_ok!(Reward::compute_reward(DOT, &BOB), 50);
+        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(50)));
+        assert_ok!(Reward::deposit_stake(&BOB, fixed!(50)));
+        assert_ok!(Reward::distribute_reward(KBTC, fixed!(100)));
+        assert_ok!(Reward::compute_reward(KBTC, &ALICE), 50);
+        assert_ok!(Reward::compute_reward(KBTC, &BOB), 50);
     })
 }
 
 #[test]
 fn should_distribute_uneven_rewards_equally() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(DOT, &ALICE, fixed!(50)));
-        assert_ok!(Reward::deposit_stake(DOT, &BOB, fixed!(50)));
-        assert_ok!(Reward::distribute_reward(DOT, fixed!(451)));
-        assert_ok!(Reward::compute_reward(DOT, &ALICE), 225);
-        assert_ok!(Reward::compute_reward(DOT, &BOB), 225);
+        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(50)));
+        assert_ok!(Reward::deposit_stake(&BOB, fixed!(50)));
+        assert_ok!(Reward::distribute_reward(KBTC, fixed!(451)));
+        assert_ok!(Reward::compute_reward(KBTC, &ALICE), 225);
+        assert_ok!(Reward::compute_reward(KBTC, &BOB), 225);
     })
 }
 
 #[test]
 fn should_not_update_previous_rewards() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(DOT, &ALICE, fixed!(40)));
-        assert_ok!(Reward::distribute_reward(DOT, fixed!(1000)));
-        assert_ok!(Reward::compute_reward(DOT, &ALICE), 1000);
+        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(40)));
+        assert_ok!(Reward::distribute_reward(KBTC, fixed!(1000)));
+        assert_ok!(Reward::compute_reward(KBTC, &ALICE), 1000);
 
-        assert_ok!(Reward::deposit_stake(DOT, &BOB, fixed!(20)));
-        assert_ok!(Reward::compute_reward(DOT, &ALICE), 1000);
-        assert_ok!(Reward::compute_reward(DOT, &BOB), 0);
+        assert_ok!(Reward::deposit_stake(&BOB, fixed!(20)));
+        assert_ok!(Reward::compute_reward(KBTC, &ALICE), 1000);
+        assert_ok!(Reward::compute_reward(KBTC, &BOB), 0);
     })
 }
 
 #[test]
 fn should_withdraw_reward() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(DOT, &ALICE, fixed!(45)));
-        assert_ok!(Reward::deposit_stake(DOT, &BOB, fixed!(55)));
-        assert_ok!(Reward::distribute_reward(DOT, fixed!(2344)));
-        assert_ok!(Reward::compute_reward(DOT, &BOB), 1289);
-        assert_ok!(Reward::withdraw_reward(DOT, &ALICE), 1054);
-        assert_ok!(Reward::compute_reward(DOT, &BOB), 1289);
+        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(45)));
+        assert_ok!(Reward::deposit_stake(&BOB, fixed!(55)));
+        assert_ok!(Reward::distribute_reward(KBTC, fixed!(2344)));
+        assert_ok!(Reward::compute_reward(KBTC, &BOB), 1289);
+        assert_ok!(Reward::withdraw_reward(KBTC, &ALICE), 1054);
+        assert_ok!(Reward::compute_reward(KBTC, &BOB), 1289);
     })
 }
 
 #[test]
 fn should_withdraw_stake() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(DOT, &ALICE, fixed!(1312)));
-        assert_ok!(Reward::distribute_reward(DOT, fixed!(4242)));
-        assert_ok!(Reward::compute_reward(DOT, &ALICE), 4242);
-        assert_ok!(Reward::withdraw_stake(DOT, &ALICE, fixed!(1312)));
-        assert_ok!(Reward::compute_reward(DOT, &ALICE), 4242);
+        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(1312)));
+        assert_ok!(Reward::distribute_reward(KBTC, fixed!(4242)));
+        assert_ok!(Reward::compute_reward(KBTC, &ALICE), 4242);
+        assert_ok!(Reward::withdraw_stake(&ALICE, fixed!(1312)));
+        assert_ok!(Reward::compute_reward(KBTC, &ALICE), 4242);
     })
 }
 
 #[test]
 fn should_not_withdraw_stake_if_balance_insufficient() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(DOT, &ALICE, fixed!(100)));
-        assert_ok!(Reward::distribute_reward(DOT, fixed!(2000)));
-        assert_ok!(Reward::compute_reward(DOT, &ALICE), 2000);
+        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(100)));
+        assert_ok!(Reward::distribute_reward(KBTC, fixed!(2000)));
+        assert_ok!(Reward::compute_reward(KBTC, &ALICE), 2000);
         assert_err!(
-            Reward::withdraw_stake(DOT, &ALICE, fixed!(200)),
+            Reward::withdraw_stake(&ALICE, fixed!(200)),
             TestError::InsufficientFunds
         );
     })
@@ -85,20 +85,20 @@ fn should_not_withdraw_stake_if_balance_insufficient() {
 #[test]
 fn should_deposit_stake() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(DOT, &ALICE, fixed!(25)));
-        assert_ok!(Reward::deposit_stake(DOT, &ALICE, fixed!(25)));
-        assert_eq!(Reward::stake(DOT, &ALICE), fixed!(50));
-        assert_ok!(Reward::deposit_stake(DOT, &BOB, fixed!(50)));
-        assert_ok!(Reward::distribute_reward(DOT, fixed!(1000)));
-        assert_ok!(Reward::compute_reward(DOT, &ALICE), 500);
+        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(25)));
+        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(25)));
+        assert_eq!(Reward::stake(&ALICE), fixed!(50));
+        assert_ok!(Reward::deposit_stake(&BOB, fixed!(50)));
+        assert_ok!(Reward::distribute_reward(KBTC, fixed!(1000)));
+        assert_ok!(Reward::compute_reward(KBTC, &ALICE), 500);
     })
 }
 
 #[test]
 fn should_not_distribute_rewards_without_stake() {
     run_test(|| {
-        assert_ok!(Reward::distribute_reward(DOT, fixed!(1000)), fixed!(1000));
-        assert_eq!(Reward::total_rewards(DOT), fixed!(0));
+        assert_ok!(Reward::distribute_reward(KBTC, fixed!(1000)), fixed!(1000));
+        assert_eq!(Reward::total_rewards(KBTC), fixed!(0));
     })
 }
 
@@ -107,15 +107,15 @@ fn should_distribute_with_many_rewards() {
     // test that reward tally doesn't overflow
     run_test(|| {
         let mut rng = rand::thread_rng();
-        assert_ok!(Reward::deposit_stake(DOT, &ALICE, fixed!(9230404)));
-        assert_ok!(Reward::deposit_stake(DOT, &BOB, fixed!(234234444)));
+        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(9230404)));
+        assert_ok!(Reward::deposit_stake(&BOB, fixed!(234234444)));
         for _ in 0..30 {
             // NOTE: this will overflow compute_reward with > u32
-            assert_ok!(Reward::distribute_reward(DOT, fixed!(rng.gen::<u32>() as i128)));
+            assert_ok!(Reward::distribute_reward(KBTC, fixed!(rng.gen::<u32>() as i128)));
         }
-        let alice_reward = Reward::compute_reward(DOT, &ALICE).unwrap();
-        assert_ok!(Reward::withdraw_reward(DOT, &ALICE), alice_reward);
-        let bob_reward = Reward::compute_reward(DOT, &BOB).unwrap();
-        assert_ok!(Reward::withdraw_reward(DOT, &BOB), bob_reward);
+        let alice_reward = Reward::compute_reward(KBTC, &ALICE).unwrap();
+        assert_ok!(Reward::withdraw_reward(KBTC, &ALICE), alice_reward);
+        let bob_reward = Reward::compute_reward(KBTC, &BOB).unwrap();
+        assert_ok!(Reward::withdraw_reward(KBTC, &BOB), bob_reward);
     })
 }

--- a/crates/staking/src/mock.rs
+++ b/crates/staking/src/mock.rs
@@ -62,11 +62,19 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
+pub const KINT: CurrencyId = CurrencyId::KINT;
+pub const KBTC: CurrencyId = CurrencyId::KBTC;
+
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![KINT, KBTC];
+}
+
 impl Config for Test {
     type Event = TestEvent;
     type SignedInner = SignedInner;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 pub type TestEvent = Event;

--- a/crates/staking/src/tests.rs
+++ b/crates/staking/src/tests.rs
@@ -13,87 +13,75 @@ macro_rules! fixed {
 #[test]
 fn should_stake_and_earn_rewards() {
     run_test(|| {
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &ALICE.account_id, fixed!(50)));
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &BOB.account_id, fixed!(50)));
-        assert_ok!(Staking::distribute_reward(DOT, &VAULT, fixed!(100)));
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &ALICE.account_id), 50);
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &BOB.account_id), 50);
-        assert_ok!(Staking::slash_stake(DOT, &VAULT, fixed!(20)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(50)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &BOB.account_id, fixed!(50)));
+        assert_ok!(Staking::distribute_reward(KBTC, &VAULT, fixed!(100)));
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &ALICE.account_id), 50);
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &BOB.account_id), 50);
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(20)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 40);
         assert_ok!(Staking::compute_stake(&VAULT, &BOB.account_id), 40);
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &ALICE.account_id), 50);
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &BOB.account_id), 50);
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &ALICE.account_id), 50);
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &BOB.account_id), 50);
     })
 }
 
 #[test]
 fn should_stake_and_distribute_and_withdraw() {
     run_test(|| {
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &ALICE.account_id, fixed!(10000)));
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &BOB.account_id, fixed!(10000)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(10000)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &BOB.account_id, fixed!(10000)));
 
-        assert_ok!(Staking::distribute_reward(DOT, &VAULT, fixed!(1000)));
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &ALICE.account_id), 500);
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &BOB.account_id), 500);
+        assert_ok!(Staking::distribute_reward(KBTC, &VAULT, fixed!(1000)));
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &ALICE.account_id), 500);
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &BOB.account_id), 500);
 
-        assert_ok!(Staking::slash_stake(DOT, &VAULT, fixed!(50)));
-        assert_ok!(Staking::slash_stake(DOT, &VAULT, fixed!(50)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(50)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(50)));
 
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &ALICE.account_id, fixed!(1000)));
-        assert_ok!(Staking::distribute_reward(DOT, &VAULT, fixed!(1000)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(1000)));
+        assert_ok!(Staking::distribute_reward(KBTC, &VAULT, fixed!(1000)));
 
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &ALICE.account_id), 1023);
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &BOB.account_id), 976);
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &ALICE.account_id), 1023);
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &BOB.account_id), 976);
 
-        assert_ok!(Staking::withdraw_stake(
-            DOT,
-            &VAULT,
-            &ALICE.account_id,
-            fixed!(10000),
-            None
-        ));
+        assert_ok!(Staking::withdraw_stake(&VAULT, &ALICE.account_id, fixed!(10000), None));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 950);
 
-        assert_ok!(Staking::withdraw_stake(
-            DOT,
-            &VAULT,
-            &ALICE.account_id,
-            fixed!(950),
-            None
-        ));
+        assert_ok!(Staking::withdraw_stake(&VAULT, &ALICE.account_id, fixed!(950), None));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 0);
 
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &BOB.account_id, fixed!(10000)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &BOB.account_id, fixed!(10000)));
         assert_ok!(Staking::compute_stake(&VAULT, &BOB.account_id), 19950);
 
-        assert_ok!(Staking::distribute_reward(DOT, &VAULT, fixed!(1000)));
-        assert_ok!(Staking::slash_stake(DOT, &VAULT, fixed!(10000)));
+        assert_ok!(Staking::distribute_reward(KBTC, &VAULT, fixed!(1000)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(10000)));
 
         assert_ok!(Staking::compute_stake(&VAULT, &BOB.account_id), 9949);
 
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &ALICE.account_id), 1023);
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &BOB.account_id), 1975);
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &ALICE.account_id), 1023);
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &BOB.account_id), 1975);
     })
 }
 
 #[test]
 fn should_stake_and_withdraw_rewards() {
     run_test(|| {
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &ALICE.account_id, fixed!(100)));
-        assert_ok!(Staking::distribute_reward(DOT, &VAULT, fixed!(100)));
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &ALICE.account_id), 100);
-        assert_ok!(Staking::withdraw_reward(DOT, &VAULT, &ALICE.account_id), 100);
-        assert_ok!(Staking::compute_reward(DOT, &VAULT, &ALICE.account_id), 0);
+        assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(100)));
+        assert_ok!(Staking::distribute_reward(KBTC, &VAULT, fixed!(100)));
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &ALICE.account_id), 100);
+        assert_ok!(Staking::withdraw_reward(KBTC, &VAULT, &ALICE.account_id), 100);
+        assert_ok!(Staking::compute_reward(KBTC, &VAULT, &ALICE.account_id), 0);
     })
 }
 
 #[test]
 fn should_not_withdraw_stake_if_balance_insufficient() {
     run_test(|| {
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &ALICE.account_id, fixed!(100)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(100)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 100);
         assert_err!(
-            Staking::withdraw_stake(DOT, &VAULT, &ALICE.account_id, fixed!(200), None),
+            Staking::withdraw_stake(&VAULT, &ALICE.account_id, fixed!(200), None),
             TestError::InsufficientFunds
         );
     })
@@ -102,12 +90,12 @@ fn should_not_withdraw_stake_if_balance_insufficient() {
 #[test]
 fn should_not_withdraw_stake_if_balance_insufficient_after_slashing() {
     run_test(|| {
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &ALICE.account_id, fixed!(100)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(100)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 100);
-        assert_ok!(Staking::slash_stake(DOT, &VAULT, fixed!(100)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(100)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 0);
         assert_err!(
-            Staking::withdraw_stake(DOT, &VAULT, &ALICE.account_id, fixed!(100), None),
+            Staking::withdraw_stake(&VAULT, &ALICE.account_id, fixed!(100), None),
             TestError::InsufficientFunds
         );
     })
@@ -117,47 +105,47 @@ fn should_not_withdraw_stake_if_balance_insufficient_after_slashing() {
 fn should_force_refund() {
     run_test(|| {
         let mut nonce = Staking::nonce(&VAULT);
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &VAULT.account_id, fixed!(100)));
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &ALICE.account_id, fixed!(100)));
-        assert_ok!(Staking::slash_stake(DOT, &VAULT, fixed!(100)));
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &VAULT.account_id, fixed!(100)));
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &ALICE.account_id, fixed!(10)));
-        assert_ok!(Staking::distribute_reward(DOT, &VAULT, fixed!(100)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(100)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(100)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(100)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(100)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(10)));
+        assert_ok!(Staking::distribute_reward(KBTC, &VAULT, fixed!(100)));
 
         // vault stake & rewards pre-refund
         assert_ok!(Staking::compute_stake_at_index(nonce, &VAULT, &VAULT.account_id), 150);
         assert_ok!(
-            Staking::compute_reward_at_index(nonce, DOT, &VAULT, &VAULT.account_id),
+            Staking::compute_reward_at_index(nonce, KBTC, &VAULT, &VAULT.account_id),
             71
         );
 
         // alice stake & rewards pre-refund
         assert_ok!(Staking::compute_stake_at_index(nonce, &VAULT, &ALICE.account_id), 60);
         assert_ok!(
-            Staking::compute_reward_at_index(nonce, DOT, &VAULT, &ALICE.account_id),
+            Staking::compute_reward_at_index(nonce, KBTC, &VAULT, &ALICE.account_id),
             28
         );
 
-        assert_ok!(Staking::force_refund(DOT, &VAULT));
+        assert_ok!(Staking::force_refund(&VAULT));
 
         nonce = Staking::nonce(&VAULT);
 
         // vault stake & rewards post-refund
         assert_ok!(Staking::compute_stake_at_index(nonce, &VAULT, &VAULT.account_id), 150);
         assert_ok!(
-            Staking::compute_reward_at_index(nonce, DOT, &VAULT, &VAULT.account_id),
+            Staking::compute_reward_at_index(nonce, KBTC, &VAULT, &VAULT.account_id),
             0
         );
 
         assert_ok!(
-            Staking::compute_reward_at_index(nonce - 1, DOT, &VAULT, &VAULT.account_id),
+            Staking::compute_reward_at_index(nonce - 1, KBTC, &VAULT, &VAULT.account_id),
             71
         );
 
         // alice stake & rewards post-refund
         assert_ok!(Staking::compute_stake_at_index(nonce, &VAULT, &ALICE.account_id), 0);
         assert_ok!(
-            Staking::compute_reward_at_index(nonce, DOT, &VAULT, &ALICE.account_id),
+            Staking::compute_reward_at_index(nonce, KBTC, &VAULT, &ALICE.account_id),
             0
         );
 
@@ -166,7 +154,7 @@ fn should_force_refund() {
             60
         );
         assert_ok!(
-            Staking::compute_reward_at_index(nonce - 1, DOT, &VAULT, &ALICE.account_id),
+            Staking::compute_reward_at_index(nonce - 1, KBTC, &VAULT, &ALICE.account_id),
             28
         );
     })
@@ -177,42 +165,26 @@ fn should_compute_stake_after_adjustments() {
     // this replicates a failing integration test due to repeated
     // deposits and slashing which led to incorrect stake
     run_test(|| {
-        assert_ok!(Staking::deposit_stake(DOT, &VAULT, &VAULT.account_id, fixed!(100)));
+        assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(100)));
         assert_ok!(Staking::deposit_stake(
-            DOT,
             &VAULT,
             &VAULT.account_id,
             fixed!(1152923504604516976)
         ));
-        assert_ok!(Staking::slash_stake(DOT, &VAULT, fixed!(1152923504604516976 + 100)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(1152923504604516976 + 100)));
+
+        assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(1_000_000)));
 
         assert_ok!(Staking::deposit_stake(
-            DOT,
-            &VAULT,
-            &VAULT.account_id,
-            fixed!(1_000_000)
-        ));
-
-        assert_ok!(Staking::deposit_stake(
-            DOT,
             &VAULT,
             &VAULT.account_id,
             fixed!(1152924504603286976)
         ));
-        assert_ok!(Staking::slash_stake(
-            DOT,
-            &VAULT,
-            fixed!(1152924504603286976 + 1_000_000)
-        ));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(1152924504603286976 + 1_000_000)));
 
         assert_ok!(Staking::compute_stake(&VAULT, &VAULT.account_id), 0);
 
-        assert_ok!(Staking::deposit_stake(
-            DOT,
-            &VAULT,
-            &VAULT.account_id,
-            fixed!(1_000_000)
-        ));
+        assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(1_000_000)));
 
         assert_ok!(Staking::compute_stake(&VAULT, &VAULT.account_id), 1_000_000);
     })

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -30,43 +30,31 @@ pub(crate) mod security {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod staking {
-    use crate::{
-        types::{CurrencyId, SignedInner},
-        DefaultVaultId,
-    };
+    use crate::{types::SignedInner, DefaultVaultId};
     use currency::Amount;
     use frame_support::dispatch::DispatchError;
 
     pub fn deposit_stake<T: crate::Config>(
-        currency_id: CurrencyId<T>,
         vault_id: &DefaultVaultId<T>,
         nominator_id: &T::AccountId,
         amount: &Amount<T>,
     ) -> Result<(), DispatchError> {
-        <staking::Pallet<T>>::deposit_stake(currency_id, vault_id, nominator_id, amount.to_signed_fixed_point()?)
+        <staking::Pallet<T>>::deposit_stake(vault_id, nominator_id, amount.to_signed_fixed_point()?)
     }
 
     pub fn withdraw_stake<T: crate::Config>(
-        currency_id: CurrencyId<T>,
         vault_id: &DefaultVaultId<T>,
         nominator_id: &T::AccountId,
         amount: &Amount<T>,
     ) -> Result<(), DispatchError> {
-        <staking::Pallet<T>>::withdraw_stake(
-            currency_id,
-            vault_id,
-            nominator_id,
-            amount.to_signed_fixed_point()?,
-            None,
-        )
+        <staking::Pallet<T>>::withdraw_stake(vault_id, nominator_id, amount.to_signed_fixed_point()?, None)
     }
 
     pub fn slash_stake<T: crate::Config>(
-        currency_id: CurrencyId<T>,
         vault_id: &DefaultVaultId<T>,
         amount: &Amount<T>,
     ) -> Result<(), DispatchError> {
-        <staking::Pallet<T>>::slash_stake(currency_id, vault_id, amount.to_signed_fixed_point()?)
+        <staking::Pallet<T>>::slash_stake(vault_id, amount.to_signed_fixed_point()?)
     }
 
     pub fn compute_stake<T: crate::Config>(
@@ -87,28 +75,20 @@ pub(crate) mod staking {
 pub(crate) mod reward {
     use crate::DefaultVaultId;
     use currency::Amount;
-    use frame_support::{dispatch::DispatchError, traits::Get};
+    use frame_support::dispatch::DispatchError;
 
     pub fn deposit_stake<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
         amount: &Amount<T>,
     ) -> Result<(), DispatchError> {
-        <reward::Pallet<T>>::deposit_stake(
-            T::GetWrappedCurrencyId::get(),
-            vault_id,
-            amount.to_signed_fixed_point()?,
-        )
+        <reward::Pallet<T>>::deposit_stake(vault_id, amount.to_signed_fixed_point()?)
     }
 
     pub fn withdraw_stake<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
         amount: &Amount<T>,
     ) -> Result<(), DispatchError> {
-        <reward::Pallet<T>>::withdraw_stake(
-            T::GetWrappedCurrencyId::get(),
-            vault_id,
-            amount.to_signed_fixed_point()?,
-        )
+        <reward::Pallet<T>>::withdraw_stake(vault_id, amount.to_signed_fixed_point()?)
     }
 }
 

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -720,7 +720,7 @@ impl<T: Config> Pallet<T> {
         amount.lock_on(&vault_id.account_id)?;
 
         // Deposit `amount` of stake in the pool
-        ext::staking::deposit_stake::<T>(T::GetWrappedCurrencyId::get(), vault_id, &vault_id.account_id, amount)?;
+        ext::staking::deposit_stake::<T>(vault_id, &vault_id.account_id, amount)?;
 
         Ok(())
     }
@@ -736,7 +736,7 @@ impl<T: Config> Pallet<T> {
         Self::decrease_total_backing_collateral(amount)?;
 
         // Withdraw `amount` of stake from the pool
-        ext::staking::withdraw_stake::<T>(T::GetWrappedCurrencyId::get(), vault_id, &vault_id.account_id, amount)?;
+        ext::staking::withdraw_stake::<T>(vault_id, &vault_id.account_id, amount)?;
 
         Ok(())
     }
@@ -807,7 +807,7 @@ impl<T: Config> Pallet<T> {
     fn slash_backing_collateral(vault_id: &DefaultVaultId<T>, amount: &Amount<T>) -> DispatchResult {
         amount.unlock_on(&vault_id.account_id)?;
         Self::decrease_total_backing_collateral(amount)?;
-        ext::staking::slash_stake::<T>(T::GetWrappedCurrencyId::get(), vault_id, amount)?;
+        ext::staking::slash_stake::<T>(vault_id, amount)?;
         Ok(())
     }
 
@@ -1214,12 +1214,7 @@ impl<T: Config> Pallet<T> {
             old_vault.decrease_liquidated_collateral(&to_be_released)?;
 
             // deposit old-vault's collateral (this was withdrawn on liquidation)
-            ext::staking::deposit_stake::<T>(
-                T::GetWrappedCurrencyId::get(),
-                old_vault_id,
-                &old_vault_id.account_id,
-                &to_be_released,
-            )?;
+            ext::staking::deposit_stake::<T>(old_vault_id, &old_vault_id.account_id, &to_be_released)?;
         }
 
         old_vault.decrease_tokens(tokens)?;

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -116,10 +116,15 @@ impl orml_tokens::Config for Test {
     type DustRemovalWhitelist = ();
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
+}
+
 impl reward::Config for Test {
     type Event = TestEvent;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {
@@ -210,6 +215,7 @@ impl staking::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 pub type TestEvent = Event;

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -509,12 +509,7 @@ impl<T: Config> RichVault<T> {
     pub(crate) fn slash_for_to_be_redeemed(&mut self, amount: &Amount<T>) -> DispatchResult {
         let vault_id = self.id();
         let collateral = self.get_vault_collateral()?.min(amount)?;
-        ext::staking::withdraw_stake::<T>(
-            T::GetWrappedCurrencyId::get(),
-            &vault_id,
-            &vault_id.account_id,
-            &collateral,
-        )?;
+        ext::staking::withdraw_stake::<T>(&vault_id, &vault_id.account_id, &collateral)?;
         self.increase_liquidated_collateral(&collateral)?;
         Ok(())
     }
@@ -530,15 +525,10 @@ impl<T: Config> RichVault<T> {
             .unwrap_or((amount.clone(), None));
 
         // "slash" vault first
-        ext::staking::withdraw_stake::<T>(
-            T::GetWrappedCurrencyId::get(),
-            &vault_id,
-            &vault_id.account_id,
-            &to_withdraw,
-        )?;
+        ext::staking::withdraw_stake::<T>(&vault_id, &vault_id.account_id, &to_withdraw)?;
         // take remainder from nominators
         if let Some(to_slash) = to_slash {
-            ext::staking::slash_stake::<T>(T::GetWrappedCurrencyId::get(), &vault_id, &to_slash)?;
+            ext::staking::slash_stake::<T>(&vault_id, &to_slash)?;
         }
 
         Pallet::<T>::transfer_funds(

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -815,10 +815,15 @@ impl orml_tokens::Config for Runtime {
     type DustRemovalWhitelist = DustRemovalWhitelist;
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![KINT, KBTC];
+}
+
 impl reward::Config for Runtime {
     type Event = Event;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 impl security::Config for Runtime {
@@ -853,6 +858,7 @@ impl staking::Config for Runtime {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -284,10 +284,15 @@ impl orml_tokens::Config for Runtime {
     type DustRemovalWhitelist = DustRemovalWhitelist;
 }
 
+parameter_types! {
+    pub GetRewardCurrencyIds: Vec<CurrencyId> = vec![INTERBTC];
+}
+
 impl reward::Config for Runtime {
     type Event = Event;
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 impl security::Config for Runtime {
@@ -322,6 +327,7 @@ impl staking::Config for Runtime {
     type SignedFixedPoint = SignedFixedPoint;
     type SignedInner = SignedInner;
     type CurrencyId = CurrencyId;
+    type GetRewardCurrencyIds = GetRewardCurrencyIds;
 }
 
 parameter_types! {

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -808,7 +808,6 @@ mod execute_issue_tests {
 
             // need stake for rewards to deposit
             assert_ok!(VaultRewardsPallet::deposit_stake(
-                DOT,
                 &vault_id_of(VAULT, currency_id),
                 signed_fixed_point!(1)
             ));


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

## Breaking Changes

- `Reward::Event::DepositStake` - rm `CurrencyId`
- `Reward::Event::WithdrawStake` - rm `CurrencyId`
- `Reward::TotalStake` - `StorageMap` > `StorageValue`
- `Reward::Stake` - `StorageDoubleMap` > `StorageMap`
- `Reward::RewardTally` - `(currency_id, vault_id)` > `(vault_id, currency_id)`