### PR TITLE
fix: kintsugi genesis does not need lightSyncState

### DIFF
--- a/parachain/res/kintsugi.json
+++ b/parachain/res/kintsugi.json
@@ -26,7 +26,6 @@
   "relay_chain": "kusama",
   "para_id": 2092,
   "consensusEngine": null,
-  "lightSyncState": null,
   "codeSubstitutes": {},
   "genesis": {
     "raw": {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>