### PR TITLE
fix: account for transaction fees in refund

### DIFF
--- a/crates/refund/src/benchmarking.rs
+++ b/crates/refund/src/benchmarking.rs
@@ -55,6 +55,7 @@ benchmarks! {
             fee: Default::default(),
             issue_id: Default::default(),
             issuer: Default::default(),
+            transfer_fee_btc: Default::default(),
     };
         Refund::<T>::insert_refund_request(&refund_id, &refund_request);
 

--- a/crates/refund/src/ext.rs
+++ b/crates/refund/src/ext.rs
@@ -75,3 +75,13 @@ pub(crate) mod vault_registry {
         <vault_registry::Pallet<T>>::issue_tokens(vault_id, amount)
     }
 }
+
+#[cfg_attr(test, mockable)]
+pub(crate) mod oracle {
+    use frame_support::dispatch::DispatchError;
+    use oracle::{types::UnsignedFixedPoint, OracleKey};
+
+    pub fn get_price<T: crate::Config>(key: OracleKey) -> Result<UnsignedFixedPoint<T>, DispatchError> {
+        <oracle::Pallet<T>>::get_price(key)
+    }
+}

--- a/crates/refund/src/types.rs
+++ b/crates/refund/src/types.rs
@@ -11,7 +11,7 @@ pub(crate) type DefaultVaultId<T> = VaultId<<T as frame_system::Config>::Account
 
 pub type DefaultRefundRequest<T> = RefundRequest<<T as frame_system::Config>::AccountId, BalanceOf<T>, CurrencyId<T>>;
 
-pub(crate) trait RefundRequestExt<T: crate::Config> {
+pub trait RefundRequestExt<T: crate::Config> {
     fn fee(&self) -> Amount<T>;
     fn amount_btc(&self) -> Amount<T>;
 }

--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -82,6 +82,21 @@ fn get_properties() -> Map<String, Value> {
     properties
 }
 
+fn expected_transaction_size() -> u32 {
+    virtual_transaction_size(
+        TransactionInputMetadata {
+            count: 2,
+            script_type: InputType::P2WPKHv0,
+        },
+        TransactionOutputMetadata {
+            num_op_return: 1,
+            num_p2pkh: 2,
+            num_p2sh: 0,
+            num_p2wpkh: 0,
+        },
+    )
+}
+
 pub fn local_config(id: ParaId) -> ChainSpec {
     ChainSpec::from_genesis(
         "interBTC",
@@ -308,18 +323,7 @@ fn testnet_genesis(
             issue_btc_dust_value: DEFAULT_DUST_VALUE,
         },
         redeem: RedeemConfig {
-            redeem_transaction_size: virtual_transaction_size(
-                TransactionInputMetadata {
-                    count: 2,
-                    script_type: InputType::P2WPKHv0,
-                },
-                TransactionOutputMetadata {
-                    num_op_return: 1,
-                    num_p2pkh: 2,
-                    num_p2sh: 0,
-                    num_p2wpkh: 0,
-                },
-            ),
+            redeem_transaction_size: expected_transaction_size(),
             redeem_period: DAYS,
             redeem_btc_dust_value: DEFAULT_DUST_VALUE,
         },
@@ -357,6 +361,7 @@ fn testnet_genesis(
         },
         refund: RefundConfig {
             refund_btc_dust_value: DEFAULT_DUST_VALUE,
+            refund_transaction_size: expected_transaction_size(),
         },
         nomination: NominationConfig {
             is_nomination_enabled: false,
@@ -529,18 +534,7 @@ fn mainnet_genesis(
             issue_btc_dust_value: DEFAULT_DUST_VALUE,
         },
         redeem: RedeemConfig {
-            redeem_transaction_size: virtual_transaction_size(
-                TransactionInputMetadata {
-                    count: 2,
-                    script_type: InputType::P2WPKHv0,
-                },
-                TransactionOutputMetadata {
-                    num_op_return: 1,
-                    num_p2pkh: 2,
-                    num_p2sh: 0,
-                    num_p2wpkh: 0,
-                },
-            ),
+            redeem_transaction_size: expected_transaction_size(),
             redeem_period: DAYS,
             redeem_btc_dust_value: DEFAULT_DUST_VALUE,
         },
@@ -580,6 +574,7 @@ fn mainnet_genesis(
         },
         refund: RefundConfig {
             refund_btc_dust_value: DEFAULT_DUST_VALUE,
+            refund_transaction_size: expected_transaction_size(),
         },
         nomination: NominationConfig {
             is_nomination_enabled: false,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -224,7 +224,8 @@ pub mod refund {
         #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
         #[cfg_attr(feature = "std", serde(bound(serialize = "Balance: std::fmt::Display")))]
         #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
-        /// the total amount which was overpaid
+        /// the total amount to be transferred back to the user. Note that amount_btc + fee + transfer_fee_btc =
+        /// overpaid amount
         pub amount_btc: Balance,
         #[cfg_attr(feature = "std", serde(bound(deserialize = "Balance: std::str::FromStr")))]
         #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
@@ -232,6 +233,8 @@ pub mod refund {
         #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
         /// total refund fees - taken from request amount
         pub fee: Balance,
+        /// amount the vault should spend on the bitcoin inclusion fee - taken from request amount
+        pub transfer_fee_btc: Balance,
         /// the account on issue which overpaid
         pub issuer: AccountId,
         /// the user's Bitcoin address for payment verification

--- a/standalone/runtime/tests/mock/issue_testing_utils.rs
+++ b/standalone/runtime/tests/mock/issue_testing_utils.rs
@@ -198,7 +198,7 @@ pub fn assert_refund_request_event() -> H256 {
     SystemModule::events()
         .iter()
         .find_map(|record| match record.event {
-            Event::Refund(RefundEvent::RequestRefund(id, _, _, _, _, _, _)) => Some(id),
+            Event::Refund(RefundEvent::RequestRefund(id, _, _, _, _, _, _, _)) => Some(id),
             _ => None,
         })
         .expect("request refund event not found")

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -1262,6 +1262,13 @@ impl ExtBuilder {
         .assimilate_storage(&mut storage)
         .unwrap();
 
+        refund::GenesisConfig::<Runtime> {
+            refund_btc_dust_value: 3,
+            refund_transaction_size: 401,
+        }
+        .assimilate_storage(&mut storage)
+        .unwrap();
+
         Self {
             test_externalities: sp_io::TestExternalities::from(storage),
         }

--- a/standalone/runtime/tests/test_staked_relayers.rs
+++ b/standalone/runtime/tests/test_staked_relayers.rs
@@ -4,6 +4,7 @@ use crate::redeem_testing_utils::{setup_redeem, USER};
 use currency::Amount;
 use mock::{assert_eq, replace_testing_utils::*, *};
 use primitives::VaultCurrencyPair;
+use refund::types::RefundRequestExt;
 use sp_core::H256;
 
 pub const RELAYER: [u8; 32] = ALICE;
@@ -205,7 +206,7 @@ fn integration_test_double_spend_refund() {
             setup_vault_for_double_spend(issued_tokens, stealing_vault, true);
 
         let user_btc_address = BtcAddress::P2PKH(H160([2; 20]));
-        let refund_amount = wrapped(100);
+        let refund_amount = wrapped(10_000);
         let refund_id = RefundPallet::request_refund(
             &refund_amount,
             default_vault_id_of(stealing_vault),
@@ -215,6 +216,7 @@ fn integration_test_double_spend_refund() {
         )
         .unwrap()
         .unwrap();
+        let refund_request = RefundPallet::refund_requests(refund_id).unwrap();
 
         let current_block_number = 1;
 
@@ -224,7 +226,7 @@ fn integration_test_double_spend_refund() {
                 default_vault_id_of(stealing_vault),
                 vault_public_key_one,
                 user_btc_address,
-                refund_amount,
+                refund_request.amount_btc(),
                 Some(refund_id),
             )
         };
@@ -235,7 +237,7 @@ fn integration_test_double_spend_refund() {
                 default_vault_id_of(stealing_vault),
                 vault_public_key_two,
                 user_btc_address,
-                refund_amount,
+                refund_request.amount_btc(),
                 Some(refund_id),
             );
         SecurityPallet::set_active_block_number(current_block_number + 1 + CONFIRMATIONS);

--- a/standalone/src/chain_spec.rs
+++ b/standalone/src/chain_spec.rs
@@ -220,6 +220,21 @@ fn default_pair(currency_id: CurrencyId) -> VaultCurrencyPair<CurrencyId> {
     }
 }
 
+fn expected_transaction_size() -> u32 {
+    virtual_transaction_size(
+        TransactionInputMetadata {
+            count: 2,
+            script_type: InputType::P2WPKHv0,
+        },
+        TransactionOutputMetadata {
+            num_op_return: 1,
+            num_p2pkh: 2,
+            num_p2sh: 0,
+            num_p2wpkh: 0,
+        },
+    )
+}
+
 fn testnet_genesis(
     root_key: AccountId,
     initial_authorities: Vec<(AuraId, GrandpaId)>,
@@ -273,18 +288,7 @@ fn testnet_genesis(
             issue_btc_dust_value: 1000,
         },
         redeem: RedeemConfig {
-            redeem_transaction_size: virtual_transaction_size(
-                TransactionInputMetadata {
-                    count: 2,
-                    script_type: InputType::P2WPKHv0,
-                },
-                TransactionOutputMetadata {
-                    num_op_return: 1,
-                    num_p2pkh: 2,
-                    num_p2sh: 0,
-                    num_p2wpkh: 0,
-                },
-            ),
+            redeem_transaction_size: expected_transaction_size(),
             redeem_period: DAYS,
             redeem_btc_dust_value: 1000,
         },
@@ -343,6 +347,7 @@ fn testnet_genesis(
         },
         refund: RefundConfig {
             refund_btc_dust_value: 1000,
+            refund_transaction_size: expected_transaction_size(),
         },
         nomination: NominationConfig {
             is_nomination_enabled: false,


### PR DESCRIPTION
This pr adds an allowance for the vault to pay the bitcoin transaction fees, just like we do in redeem.

** Breaking changes **
- new `transfer_fee_btc` field in the `RefundRequest` struct
- Added `transfer_fee` to the `RequestRefund` event
- There is now a `RefundTransactionSize` storage item. We may need to manually initialize is in kusama