### PR TITLE
fix: set launch and voting period to 7 days

### DIFF
--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -455,8 +455,8 @@ type EnsureRootOrAllTechnicalCommittee = EnsureOneOf<
 >;
 
 parameter_types! {
-    pub const LaunchPeriod: BlockNumber = 2 * DAYS;
-    pub const VotingPeriod: BlockNumber = 2 * DAYS;
+    pub const LaunchPeriod: BlockNumber = 7 * DAYS;
+    pub const VotingPeriod: BlockNumber = 7 * DAYS;
     pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
     pub MinimumDeposit: Balance = 100 * CENTS;
     pub const EnactmentPeriod: BlockNumber = DAYS;


### PR DESCRIPTION
`LaunchPeriod` is specified in the docs as 7 days. The voting period is not specified, but when it is 2 days, it could fall entirely in the weekend. This PR sets it to 7 days, [just like kusama](https://github.com/paritytech/polkadot/blob/289d9fc694dd60a331a1a8739c5fbe36c261d5a7/runtime/kusama/src/lib.rs#L560)