### PR TITLE
Lower collateral thresholds

### DIFF
--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -411,22 +411,19 @@ fn testnet_genesis(
         vault_registry: kintsugi_runtime::VaultRegistryConfig {
             minimum_collateral_vault: vec![(CurrencyId::KSM, 0)],
             punishment_delay: kintsugi_runtime::DAYS,
-            system_collateral_ceiling: vec![(
-                default_pair_kintsugi(CurrencyId::KSM),
-                1000 * CurrencyId::KSM.one(),
-            )],
+            system_collateral_ceiling: vec![(default_pair_kintsugi(CurrencyId::KSM), 1000 * CurrencyId::KSM.one())],
             secure_collateral_threshold: vec![(
                 default_pair_kintsugi(CurrencyId::KSM),
-                FixedU128::checked_from_rational(360, 100).unwrap(),
-            )], /* 360% */
+                FixedU128::checked_from_rational(150, 100).unwrap(),
+            )], /* 150% */
             premium_redeem_threshold: vec![(
                 default_pair_kintsugi(CurrencyId::KSM),
-                FixedU128::checked_from_rational(280, 100).unwrap(),
-            )], /* 280% */
+                FixedU128::checked_from_rational(135, 100).unwrap(),
+            )], /* 135% */
             liquidation_collateral_threshold: vec![(
                 default_pair_kintsugi(CurrencyId::KSM),
-                FixedU128::checked_from_rational(220, 100).unwrap(),
-            )], /* 220% */
+                FixedU128::checked_from_rational(110, 100).unwrap(),
+            )], /* 110% */
         },
         fee: kintsugi_runtime::FeeConfig {
             issue_fee: FixedU128::checked_from_rational(5, 1000).unwrap(), // 0.5%
@@ -623,24 +620,21 @@ fn kintsugi_mainnet_genesis(
         vault_registry: kintsugi_runtime::VaultRegistryConfig {
             minimum_collateral_vault: vec![(CurrencyId::KSM, 0)],
             punishment_delay: kintsugi_runtime::DAYS,
-            system_collateral_ceiling: vec![(
-                default_pair_kintsugi(CurrencyId::KSM),
-                317 * CurrencyId::KSM.one(),
-            )], /* 317 ksm, about 100k
-                 * USD at
-                 * time of writing */
+            system_collateral_ceiling: vec![(default_pair_kintsugi(CurrencyId::KSM), 317 * CurrencyId::KSM.one())], /* 317 ksm, about 100k
+                                                                                                                     * USD at
+                                                                                                                     * time of writing */
             secure_collateral_threshold: vec![(
                 default_pair_kintsugi(CurrencyId::KSM),
-                FixedU128::checked_from_rational(360, 100).unwrap(),
-            )], /* 360% */
+                FixedU128::checked_from_rational(260, 100).unwrap(),
+            )], /* 260% */
             premium_redeem_threshold: vec![(
                 default_pair_kintsugi(CurrencyId::KSM),
-                FixedU128::checked_from_rational(280, 100).unwrap(),
-            )], /* 280% */
+                FixedU128::checked_from_rational(200, 100).unwrap(),
+            )], /* 200% */
             liquidation_collateral_threshold: vec![(
                 default_pair_kintsugi(CurrencyId::KSM),
-                FixedU128::checked_from_rational(220, 100).unwrap(),
-            )], /* 220% */
+                FixedU128::checked_from_rational(150, 100).unwrap(),
+            )], /* 150% */
         },
         fee: kintsugi_runtime::FeeConfig {
             issue_fee: FixedU128::checked_from_rational(5, 1000).unwrap(), // 0.5%
@@ -833,24 +827,21 @@ fn interlay_mainnet_genesis(
         vault_registry: interlay_runtime::VaultRegistryConfig {
             minimum_collateral_vault: vec![(CurrencyId::KSM, 0)],
             punishment_delay: interlay_runtime::DAYS,
-            system_collateral_ceiling: vec![(
-                default_pair_interlay(CurrencyId::DOT),
-                317 * CurrencyId::KSM.one(),
-            )], /* 317 ksm, about 100k
-                 * USD at
-                 * time of writing */
+            system_collateral_ceiling: vec![(default_pair_interlay(CurrencyId::DOT), 3333 * CurrencyId::DOT.one())], /* 3333 DOT, about 100k
+                                                                                                                     * USD at
+                                                                                                                     * time of writing */
             secure_collateral_threshold: vec![(
-                default_pair_interlay(CurrencyId::DOT),
-                FixedU128::checked_from_rational(330, 100).unwrap(),
-            )], /* 330% */
-            premium_redeem_threshold: vec![(
                 default_pair_interlay(CurrencyId::DOT),
                 FixedU128::checked_from_rational(260, 100).unwrap(),
             )], /* 260% */
-            liquidation_collateral_threshold: vec![(
+            premium_redeem_threshold: vec![(
                 default_pair_interlay(CurrencyId::DOT),
                 FixedU128::checked_from_rational(200, 100).unwrap(),
             )], /* 200% */
+            liquidation_collateral_threshold: vec![(
+                default_pair_interlay(CurrencyId::DOT),
+                FixedU128::checked_from_rational(150, 100).unwrap(),
+            )], /* 150% */
         },
         fee: interlay_runtime::FeeConfig {
             issue_fee: FixedU128::checked_from_rational(5, 1000).unwrap(), // 0.5%


### PR DESCRIPTION
The previous thresholds were set under the pessimistic assumption of 24 hours of network inactivity (non-liveness). This change balances out vault profitability with system safety assumptions. 

Network liveness guarantees are still on the safe side, since it is assumed that 6 Bitcoin block confirmations take 4 hours and only after that can a Burn Redeem be performed.