### PR TITLE
refactor: compute pallet accounts at runtime

### DIFF
--- a/crates/annuity/src/mock.rs
+++ b/crates/annuity/src/mock.rs
@@ -1,9 +1,5 @@
 use crate::{self as annuity, BlockRewardProvider, Config};
-use frame_support::{
-    parameter_types,
-    traits::{Everything, GenesisBuild},
-    PalletId,
-};
+use frame_support::{parameter_types, traits::Everything, PalletId};
 pub use primitives::CurrencyId;
 use sp_core::H256;
 use sp_runtime::{
@@ -26,7 +22,7 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
-        Annuity: annuity::{Pallet, Call, Storage, Config<T>, Event<T>},
+        Annuity: annuity::{Pallet, Call, Storage, Event<T>},
     }
 );
 
@@ -126,11 +122,7 @@ pub struct ExtBuilder;
 
 impl ExtBuilder {
     pub fn build() -> sp_io::TestExternalities {
-        let mut storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-
-        annuity::GenesisConfig::<Test>::default()
-            .assimilate_storage(&mut storage)
-            .unwrap();
+        let storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 
         storage.into()
     }

--- a/crates/annuity/src/tests.rs
+++ b/crates/annuity/src/tests.rs
@@ -6,19 +6,19 @@ use crate::mock::*;
 #[test]
 fn should_calculate_emission_rewards() {
     run_test(|| {
-        <Balances as Currency<AccountId>>::make_free_balance_be(&Annuity::annuity_pallet_id(), YEAR_1_REWARDS);
+        <Balances as Currency<AccountId>>::make_free_balance_be(&Annuity::account_id(), YEAR_1_REWARDS);
         Annuity::update_reward_per_block();
         assert_eq!(Annuity::reward_per_block(), 12000);
 
-        <Balances as Currency<AccountId>>::make_free_balance_be(&Annuity::annuity_pallet_id(), YEAR_2_REWARDS);
+        <Balances as Currency<AccountId>>::make_free_balance_be(&Annuity::account_id(), YEAR_2_REWARDS);
         Annuity::update_reward_per_block();
         assert_eq!(Annuity::reward_per_block(), 9000);
 
-        <Balances as Currency<AccountId>>::make_free_balance_be(&Annuity::annuity_pallet_id(), YEAR_3_REWARDS);
+        <Balances as Currency<AccountId>>::make_free_balance_be(&Annuity::account_id(), YEAR_3_REWARDS);
         Annuity::update_reward_per_block();
         assert_eq!(Annuity::reward_per_block(), 6000);
 
-        <Balances as Currency<AccountId>>::make_free_balance_be(&Annuity::annuity_pallet_id(), YEAR_4_REWARDS);
+        <Balances as Currency<AccountId>>::make_free_balance_be(&Annuity::account_id(), YEAR_4_REWARDS);
         Annuity::update_reward_per_block();
         assert_eq!(Annuity::reward_per_block(), 3000);
     })

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -602,7 +602,6 @@ pub mod pallet {
     /// transferred to LiquidationVault and claims are later handled via the LiquidationVault.
     #[pallet::storage]
     #[pallet::getter(fn liquidation_vault_account_id)]
-    // TODO: this will not work with multiple wrapped currencies
     pub(super) type LiquidationVaultAccountId<T: Config> = StorageValue<_, T::AccountId, ValueQuery>;
 
     #[pallet::storage]

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1181,10 +1181,10 @@ construct_runtime! {
         Escrow: escrow::{Pallet, Call, Storage, Event<T>},
         Vesting: orml_vesting::{Pallet, Storage, Call, Event<T>, Config<T>},
 
-        EscrowAnnuity: annuity::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>},
+        EscrowAnnuity: annuity::<Instance1>::{Pallet, Call, Storage, Event<T>},
         EscrowRewards: reward::<Instance1>::{Pallet, Storage, Event<T>},
 
-        VaultAnnuity: annuity::<Instance2>::{Pallet, Storage, Event<T>, Config<T>},
+        VaultAnnuity: annuity::<Instance2>::{Pallet, Storage, Event<T>},
         VaultRewards: reward::<Instance2>::{Pallet, Storage, Event<T>},
         VaultStaking: staking::{Pallet, Storage, Event<T>},
 

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1206,10 +1206,10 @@ construct_runtime! {
         Escrow: escrow::{Pallet, Call, Storage, Event<T>},
         Vesting: orml_vesting::{Pallet, Storage, Call, Event<T>, Config<T>},
 
-        EscrowAnnuity: annuity::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>},
+        EscrowAnnuity: annuity::<Instance1>::{Pallet, Call, Storage, Event<T>},
         EscrowRewards: reward::<Instance1>::{Pallet, Storage, Event<T>},
 
-        VaultAnnuity: annuity::<Instance2>::{Pallet, Storage, Event<T>, Config<T>},
+        VaultAnnuity: annuity::<Instance2>::{Pallet, Storage, Event<T>},
         VaultRewards: reward::<Instance2>::{Pallet, Storage, Event<T>},
         VaultStaking: staking::{Pallet, Storage, Event<T>},
 

--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -392,8 +392,6 @@ fn testnet_genesis(
         technical_membership: Default::default(),
         treasury: Default::default(),
         democracy: Default::default(),
-        escrow_annuity: Default::default(),
-        vault_annuity: Default::default(),
         supply: kintsugi_runtime::SupplyConfig {
             initial_supply: kintsugi_runtime::token_distribution::INITIAL_ALLOCATION,
             start_height: kintsugi_runtime::YEARS * 5,
@@ -566,8 +564,6 @@ fn kintsugi_mainnet_genesis(
         technical_membership: Default::default(),
         treasury: Default::default(),
         democracy: Default::default(),
-        escrow_annuity: Default::default(),
-        vault_annuity: Default::default(),
         supply: kintsugi_runtime::SupplyConfig {
             initial_supply: kintsugi_runtime::token_distribution::INITIAL_ALLOCATION,
             start_height: kintsugi_runtime::YEARS * 5,
@@ -773,8 +769,6 @@ fn interlay_mainnet_genesis(
         technical_membership: Default::default(),
         treasury: Default::default(),
         democracy: Default::default(),
-        escrow_annuity: Default::default(),
-        vault_annuity: Default::default(),
         supply: interlay_runtime::SupplyConfig {
             initial_supply: interlay_runtime::token_distribution::INITIAL_ALLOCATION,
             start_height: interlay_runtime::YEARS * 5,

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -676,7 +676,7 @@ construct_runtime! {
         VaultStaking: staking::{Pallet, Storage, Event<T>},
         Escrow: escrow::{Pallet, Call, Storage, Event<T>},
         Vesting: orml_vesting::{Pallet, Storage, Call, Event<T>, Config<T>},
-        VaultAnnuity: annuity::<Instance1>::{Pallet, Storage, Event<T>, Config<T>},
+        VaultAnnuity: annuity::<Instance1>::{Pallet, Storage, Event<T>},
 
         // Bitcoin SPV
         BTCRelay: btc_relay::{Pallet, Call, Config<T>, Storage, Event<T>},

--- a/standalone/runtime/tests/test_annuity.rs
+++ b/standalone/runtime/tests/test_annuity.rs
@@ -26,7 +26,7 @@ fn get_last_reward() -> u128 {
 fn integration_test_annuity() {
     ExtBuilder::build().execute_with(|| {
         assert_ok!(Call::Tokens(TokensCall::set_balance {
-            who: AnnuityPallet::annuity_pallet_id(),
+            who: AnnuityPallet::account_id(),
             currency_id: NATIVE_CURRENCY_ID,
             new_free: 10_000_000_000_000,
             new_reserved: 0,

--- a/standalone/src/chain_spec.rs
+++ b/standalone/src/chain_spec.rs
@@ -268,7 +268,6 @@ fn testnet_genesis(
             // Assign network admin rights.
             key: root_key.clone(),
         },
-        vault_annuity: Default::default(),
         tokens: TokensConfig {
             balances: endowed_accounts
                 .iter()


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Prevents having to explicitly set these on Kintsugi, also no other project puts these account ids in storage.