### PR TITLE
chore: remove unnecessary Security whitelist entry when shutdown

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -187,7 +187,6 @@ impl Contains<Call> for BaseCallFilter {
                 | Call::Democracy(_)
                 | Call::Escrow(_)
                 | Call::TechnicalCommittee(_)
-                | Call::Security(_) // to unset shutdown
         ) {
             // always allow core calls
             true

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -189,7 +189,6 @@ impl Contains<Call> for BaseCallFilter {
                 | Call::Democracy(_)
                 | Call::Escrow(_)
                 | Call::TechnicalCommittee(_)
-                | Call::Security(_) // to unset shutdown
         ) {
             // always allow core calls
             true

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -156,7 +156,12 @@ impl Contains<Call> for BaseCallFilter {
     fn contains(call: &Call) -> bool {
         if matches!(
             call,
-            Call::System(_) | Call::Timestamp(_) | Call::Sudo(_) | Call::Security(_) // to unset shutdown
+            Call::System(_)
+                | Call::Timestamp(_)
+                | Call::Sudo(_)
+                | Call::Democracy(_)
+                | Call::Escrow(_)
+                | Call::TechnicalCommittee(_)
         ) {
             // always allow core calls
             true

--- a/standalone/runtime/tests/test_governance.rs
+++ b/standalone/runtime/tests/test_governance.rs
@@ -175,7 +175,30 @@ fn launch_and_execute_referendum() {
 }
 
 #[test]
-fn can_recover_from_shutdown() {
+fn can_recover_from_shutdown_using_governance() {
+    test_with(|| {
+        // use sudo to set parachain status
+        assert_ok!(Call::Sudo(SudoCall::sudo {
+            call: Box::new(Call::Security(SecurityCall::set_parachain_status {
+                status_code: StatusCode::Shutdown,
+            })),
+        })
+        .dispatch(origin_of(account_of(ALICE))));
+        assert!(SecurityPallet::is_parachain_shutdown());
+
+        create_proposal(
+            Call::Security(SecurityCall::set_parachain_status {
+                status_code: StatusCode::Running,
+            })
+            .encode(),
+        );
+        launch_and_execute_referendum();
+        assert!(!SecurityPallet::is_parachain_shutdown());
+    })
+}
+
+#[test]
+fn can_recover_from_shutdown_using_root() {
     test_with(|| {
         // use sudo to set parachain status
         assert_ok!(Call::Sudo(SudoCall::sudo {


### PR DESCRIPTION
No need to whitelist Security calls when shutdown, since all allowed calls would be wrapped in sudo or democracy. Add test in standalone