### PR TITLE
Revert: currencyid

### DIFF
--- a/crates/currency/src/mock.rs
+++ b/crates/currency/src/mock.rs
@@ -1,6 +1,5 @@
 use frame_support::{parameter_types, traits::Everything};
 use orml_traits::parameter_type_with_key;
-pub use primitives::{CurrencyId::Token, TokenSymbol::*};
 use sp_arithmetic::{FixedI128, FixedU128};
 use sp_core::H256;
 use sp_runtime::{
@@ -68,9 +67,12 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
+
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
     pub const MaxLocks: u32 = 50;
 }
 

--- a/crates/currency/src/tests.rs
+++ b/crates/currency/src/tests.rs
@@ -4,7 +4,7 @@ use sp_runtime::FixedPointNumber;
 #[test]
 fn test_checked_fixed_point_mul() {
     run_test(|| {
-        let currency = Token(DOT);
+        let currency = DOT;
         let tests: Vec<(Amount<Test>, UnsignedFixedPoint, Amount<Test>)> = vec![
             (
                 Amount::new(1 * 10u128.pow(8), currency),                 // 1 BTC
@@ -43,7 +43,7 @@ fn test_checked_fixed_point_mul() {
 #[test]
 fn test_checked_fixed_point_mul_rounded_up() {
     run_test(|| {
-        let currency = Token(DOT);
+        let currency = DOT;
         let tests: Vec<(Amount<Test>, UnsignedFixedPoint, Amount<Test>)> = vec![
             (
                 Amount::new(10, currency),

--- a/crates/fee/src/mock.rs
+++ b/crates/fee/src/mock.rs
@@ -3,8 +3,8 @@ use crate::{Config, Error};
 use frame_support::{parameter_types, traits::Everything, PalletId};
 use mocktopus::mocking::clear_mocks;
 use orml_traits::parameter_type_with_key;
+pub use primitives::CurrencyId;
 use primitives::VaultId;
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
 use sp_arithmetic::{FixedI128, FixedU128};
 use sp_core::H256;
 use sp_runtime::{
@@ -79,10 +79,13 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
+
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
     pub const MaxLocks: u32 = 50;
 }
 

--- a/crates/fee/src/tests.rs
+++ b/crates/fee/src/tests.rs
@@ -8,8 +8,8 @@ fn should_get_issue_fee() {
     run_test(|| {
         <IssueFee<Test>>::put(UnsignedFixedPoint::checked_from_rational(10, 100).unwrap());
         assert_ok!(
-            Fee::get_issue_fee(&Amount::<Test>::new(100, Token(INTERBTC))),
-            Amount::<Test>::new(10, Token(INTERBTC))
+            Fee::get_issue_fee(&Amount::<Test>::new(100, CurrencyId::INTERBTC)),
+            Amount::<Test>::new(10, CurrencyId::INTERBTC)
         );
     })
 }

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -10,7 +10,7 @@ use btc_relay::{BtcAddress, BtcPublicKey};
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
-use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultId};
+use primitives::{CurrencyId, VaultId};
 use sp_core::{H160, H256, U256};
 use sp_runtime::{
     traits::{One, Zero},
@@ -26,7 +26,7 @@ use primitives::VaultCurrencyPair;
 use security::Pallet as Security;
 use vault_registry::{types::DefaultVaultCurrencyPair, Pallet as VaultRegistry};
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 
 fn dummy_public_key() -> BtcPublicKey {
     BtcPublicKey([

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 };
 use mocktopus::{macros::mockable, mocking::*};
 use orml_traits::parameter_type_with_key;
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
+pub use primitives::CurrencyId;
 use primitives::{VaultCurrencyPair, VaultId};
 use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
@@ -91,14 +91,18 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(INTERBTC);
-pub const GRIEFING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId =
+    <Test as orml_tokens::Config>::CurrencyId::DOT;
+pub const DEFAULT_WRAPPED_CURRENCY: <Test as orml_tokens::Config>::CurrencyId =
+    <Test as orml_tokens::Config>::CurrencyId::INTERBTC;
+pub const GRIEFING_CURRENCY: CurrencyId = CurrencyId::DOT;
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -289,10 +293,7 @@ impl ExtBuilder {
 
     pub fn build() -> sp_io::TestExternalities {
         ExtBuilder::build_with(orml_tokens::GenesisConfig::<Test> {
-            balances: vec![
-                (USER, Token(DOT), ALICE_BALANCE),
-                (VAULT.account_id, Token(DOT), BOB_BALANCE),
-            ],
+            balances: vec![(USER, DOT, ALICE_BALANCE), (VAULT.account_id, DOT, BOB_BALANCE)],
         })
     }
 }

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -24,7 +24,7 @@ fn griefing(amount: u128) -> Amount<Test> {
 }
 
 fn wrapped(amount: u128) -> Amount<Test> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, INTERBTC)
 }
 
 fn request_issue(

--- a/crates/nomination/src/benchmarking.rs
+++ b/crates/nomination/src/benchmarking.rs
@@ -3,7 +3,7 @@ use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::{assert_ok, traits::Get};
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
-use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
+use primitives::CurrencyId;
 use sp_runtime::traits::One;
 use vault_registry::BtcPublicKey;
 
@@ -12,7 +12,7 @@ use crate::Pallet as Nomination;
 use oracle::Pallet as Oracle;
 use vault_registry::Pallet as VaultRegistry;
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 
 fn dummy_public_key() -> BtcPublicKey {
     BtcPublicKey([

--- a/crates/nomination/src/mock.rs
+++ b/crates/nomination/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 };
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use orml_traits::parameter_type_with_key;
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
+pub use primitives::CurrencyId;
 use primitives::{VaultCurrencyPair, VaultId};
 use sp_arithmetic::{FixedI128, FixedU128};
 use sp_core::H256;
@@ -90,17 +90,19 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = DOT;
+pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = INTERBTC;
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
     collateral: DEFAULT_TESTING_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -306,10 +308,10 @@ impl ExtBuilder {
     pub fn build() -> sp_io::TestExternalities {
         ExtBuilder::build_with(orml_tokens::GenesisConfig::<Test> {
             balances: vec![
-                (ALICE.account_id, Token(DOT), ALICE_BALANCE),
-                (BOB.account_id, Token(DOT), BOB_BALANCE),
-                (ALICE.account_id, Token(INTERBTC), ALICE_BALANCE),
-                (BOB.account_id, Token(INTERBTC), BOB_BALANCE),
+                (ALICE.account_id, DOT, ALICE_BALANCE),
+                (BOB.account_id, DOT, BOB_BALANCE),
+                (ALICE.account_id, INTERBTC, ALICE_BALANCE),
+                (BOB.account_id, INTERBTC, BOB_BALANCE),
             ],
         })
     }

--- a/crates/oracle/src/benchmarking.rs
+++ b/crates/oracle/src/benchmarking.rs
@@ -1,8 +1,7 @@
 use super::{Pallet as Oracle, *};
-use crate::OracleKey;
+use crate::{CurrencyId, OracleKey};
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
-use primitives::{CurrencyId::Token, TokenSymbol::*};
 use sp_runtime::FixedPointNumber;
 use sp_std::prelude::*;
 
@@ -12,10 +11,10 @@ type MomentOf<T> = <T as pallet_timestamp::Config>::Moment;
 
 benchmarks! {
     on_initialize {}: {
-        RawValuesUpdated::<T>::insert(OracleKey::ExchangeRate(Token(DOT)), true);
+        RawValuesUpdated::<T>::insert(OracleKey::ExchangeRate(CurrencyId::DOT), true);
 
         let valid_until: MomentOf<T> = 100u32.into();
-        ValidUntil::<T>::insert(OracleKey::ExchangeRate(Token(DOT)), valid_until);
+        ValidUntil::<T>::insert(OracleKey::ExchangeRate(CurrencyId::DOT), valid_until);
 
         Timestamp::<T>::set_timestamp(1000u32.into());
     }
@@ -26,11 +25,11 @@ benchmarks! {
         let origin: T::AccountId = account("origin", 0, 0);
         <AuthorizedOracles<T>>::insert(origin.clone(), Vec::<u8>::new());
 
-        let key = OracleKey::ExchangeRate(Token(DOT));
+        let key = OracleKey::ExchangeRate(CurrencyId::DOT);
         let values:Vec<_> = (0 .. u).map(|x| (key.clone(), UnsignedFixedPoint::<T>::checked_from_rational(1, x+1).unwrap())).collect();
     }: _(RawOrigin::Signed(origin), values)
     verify {
-        let key = OracleKey::ExchangeRate(Token(DOT));
+        let key = OracleKey::ExchangeRate(CurrencyId::DOT);
         crate::Pallet::<T>::begin_block(0u32.into());
         assert!(Aggregate::<T>::get(key).is_some());
     }

--- a/crates/oracle/src/mock.rs
+++ b/crates/oracle/src/mock.rs
@@ -6,7 +6,6 @@ use frame_support::{
 };
 use mocktopus::mocking::clear_mocks;
 use orml_traits::parameter_type_with_key;
-pub use primitives::{CurrencyId::Token, TokenSymbol::*};
 use sp_arithmetic::{FixedI128, FixedU128};
 use sp_core::H256;
 use sp_runtime::{
@@ -78,10 +77,13 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
+
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
     pub const MaxLocks: u32 = 50;
 }
 

--- a/crates/oracle/src/tests.rs
+++ b/crates/oracle/src/tests.rs
@@ -1,4 +1,7 @@
-use crate::{mock::*, CurrencyId, OracleKey};
+use crate::{
+    mock::{run_test, Oracle, Origin, System, Test, TestError, TestEvent},
+    CurrencyId, OracleKey,
+};
 use frame_support::{assert_err, assert_ok, dispatch::DispatchError};
 use mocktopus::mocking::*;
 use sp_arithmetic::FixedU128;
@@ -28,7 +31,7 @@ fn mine_block() {
 #[test]
 fn feed_values_succeeds() {
     run_test(|| {
-        let key = OracleKey::ExchangeRate(Token(DOT));
+        let key = OracleKey::ExchangeRate(CurrencyId::DOT);
         let rate = FixedU128::checked_from_rational(100, 1).unwrap();
 
         Oracle::is_authorized.mock_safe(|_| MockResult::Return(true));
@@ -82,11 +85,11 @@ mod oracle_offline_detection {
             Oracle::get_max_delay.mock_safe(move || MockResult::Return(10));
 
             set_time(0);
-            feed_value(Token(DOT), OracleA);
+            feed_value(CurrencyId::DOT, OracleA);
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
 
             set_time(5);
-            feed_value(Token(KSM), OracleA);
+            feed_value(CurrencyId::KSM, OracleA);
 
             // DOT expires after block 10
             set_time(10);
@@ -95,11 +98,11 @@ mod oracle_offline_detection {
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
 
             // feeding KSM makes no difference
-            feed_value(Token(KSM), OracleA);
+            feed_value(CurrencyId::KSM, OracleA);
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
 
             // feeding DOT makes it running again
-            feed_value(Token(DOT), OracleA);
+            feed_value(CurrencyId::DOT, OracleA);
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
 
             // KSM expires after t=21 (it was set at t=11)
@@ -111,9 +114,9 @@ mod oracle_offline_detection {
             // check that status remains ERROR until BOTH currencies have been updated
             set_time(100);
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
-            feed_value(Token(DOT), OracleA);
+            feed_value(CurrencyId::DOT, OracleA);
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
-            feed_value(Token(KSM), OracleA);
+            feed_value(CurrencyId::KSM, OracleA);
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
         });
     }
@@ -125,14 +128,14 @@ mod oracle_offline_detection {
             Oracle::get_max_delay.mock_safe(move || MockResult::Return(10));
 
             set_time(0);
-            feed_value(Token(DOT), OracleA);
+            feed_value(CurrencyId::DOT, OracleA);
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
 
             set_time(5);
-            feed_value(Token(KSM), OracleA);
+            feed_value(CurrencyId::KSM, OracleA);
 
             set_time(7);
-            feed_value(Token(DOT), OracleB);
+            feed_value(CurrencyId::DOT, OracleB);
 
             // OracleA's DOT submission expires at 10, but OracleB's only at 17. However, KSM expires at 15:
             set_time(15);
@@ -141,7 +144,7 @@ mod oracle_offline_detection {
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
 
             // Feeding KSM brings it back online
-            feed_value(Token(KSM), OracleA);
+            feed_value(CurrencyId::KSM, OracleA);
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
 
             // check that status is set of ERROR when both oracle's DOT submission expired
@@ -151,7 +154,7 @@ mod oracle_offline_detection {
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Error);
 
             // A DOT submission by any oracle brings it back online
-            feed_value(Token(DOT), OracleA);
+            feed_value(CurrencyId::DOT, OracleA);
             assert_eq!(SecurityPallet::parachain_status(), StatusCode::Running);
         });
     }
@@ -160,7 +163,7 @@ mod oracle_offline_detection {
 #[test]
 fn feed_values_fails_with_invalid_oracle_source() {
     run_test(|| {
-        let key = OracleKey::ExchangeRate(Token(DOT));
+        let key = OracleKey::ExchangeRate(CurrencyId::DOT);
         let successful_rate = FixedU128::checked_from_rational(20, 1).unwrap();
         let failed_rate = FixedU128::checked_from_rational(100, 1).unwrap();
 
@@ -197,14 +200,14 @@ fn feed_values_fails_with_invalid_oracle_source() {
 #[test]
 fn getting_exchange_rate_fails_with_missing_exchange_rate() {
     run_test(|| {
-        let key = OracleKey::ExchangeRate(Token(DOT));
+        let key = OracleKey::ExchangeRate(CurrencyId::DOT);
         assert_err!(Oracle::get_price(key), TestError::MissingExchangeRate);
         assert_err!(
-            Oracle::wrapped_to_collateral(0, Token(DOT)),
+            Oracle::wrapped_to_collateral(0, CurrencyId::DOT),
             TestError::MissingExchangeRate
         );
         assert_err!(
-            Oracle::collateral_to_wrapped(0, Token(DOT)),
+            Oracle::collateral_to_wrapped(0, CurrencyId::DOT),
             TestError::MissingExchangeRate
         );
     });
@@ -216,7 +219,7 @@ fn wrapped_to_collateral() {
         Oracle::get_price.mock_safe(|_| MockResult::Return(Ok(FixedU128::checked_from_rational(2, 1).unwrap())));
         let test_cases = [(0, 0), (2, 4), (10, 20)];
         for (input, expected) in test_cases.iter() {
-            let result = Oracle::wrapped_to_collateral(*input, Token(DOT));
+            let result = Oracle::wrapped_to_collateral(*input, CurrencyId::DOT);
             assert_ok!(result, *expected);
         }
     });
@@ -228,7 +231,7 @@ fn collateral_to_wrapped() {
         Oracle::get_price.mock_safe(|_| MockResult::Return(Ok(FixedU128::checked_from_rational(2, 1).unwrap())));
         let test_cases = [(0, 0), (4, 2), (20, 10), (21, 10)];
         for (input, expected) in test_cases.iter() {
-            let result = Oracle::collateral_to_wrapped(*input, Token(DOT));
+            let result = Oracle::collateral_to_wrapped(*input, CurrencyId::DOT);
             assert_ok!(result, *expected);
         }
     });
@@ -242,7 +245,7 @@ fn test_is_invalidated() {
         Oracle::get_max_delay.mock_safe(|| MockResult::Return(3600));
         Oracle::is_authorized.mock_safe(|_| MockResult::Return(true));
 
-        let key = OracleKey::ExchangeRate(Token(DOT));
+        let key = OracleKey::ExchangeRate(CurrencyId::DOT);
         let rate = FixedU128::checked_from_rational(100, 1).unwrap();
 
         Oracle::is_authorized.mock_safe(|_| MockResult::Return(true));
@@ -271,7 +274,7 @@ fn oracle_names_have_genesis_info() {
 fn insert_authorized_oracle_succeeds() {
     run_test(|| {
         let oracle = 1;
-        let key = OracleKey::ExchangeRate(Token(DOT));
+        let key = OracleKey::ExchangeRate(CurrencyId::DOT);
         let rate = FixedU128::checked_from_rational(1, 1).unwrap();
         assert_err!(
             Oracle::feed_values(Origin::signed(oracle), vec![]),

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -11,7 +11,7 @@ use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::{assert_ok, traits::Get};
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
-use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultCurrencyPair, VaultId};
+use primitives::{CurrencyId, VaultCurrencyPair, VaultId};
 use sp_core::{H160, H256, U256};
 use sp_runtime::traits::One;
 use sp_std::prelude::*;
@@ -24,7 +24,7 @@ use oracle::Pallet as Oracle;
 use security::Pallet as Security;
 use vault_registry::Pallet as VaultRegistry;
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 
 type UnsignedFixedPoint<T> = <T as currency::Config>::UnsignedFixedPoint;
 
@@ -63,7 +63,7 @@ fn initialize_oracle<T: crate::Config>() {
         oracle_id,
         vec![
             (
-                OracleKey::ExchangeRate(Token(DOT)),
+                OracleKey::ExchangeRate(CurrencyId::DOT),
                 UnsignedFixedPoint::<T>::checked_from_rational(1, 1).unwrap(),
             ),
             (

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -9,7 +9,6 @@ use frame_support::{
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 pub use oracle::{CurrencyId, OracleKey};
 use orml_traits::parameter_type_with_key;
-pub use primitives::{CurrencyId::Token, TokenSymbol::*};
 use primitives::{VaultCurrencyPair, VaultId};
 pub use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
@@ -91,18 +90,22 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(INTERBTC);
+pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId =
+    <Test as orml_tokens::Config>::CurrencyId::DOT;
+pub const DEFAULT_WRAPPED_CURRENCY: <Test as orml_tokens::Config>::CurrencyId =
+    <Test as orml_tokens::Config>::CurrencyId::INTERBTC;
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
     collateral: DEFAULT_TESTING_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
-pub const GRIEFING_CURRENCY: CurrencyId = Token(DOT);
+pub const GRIEFING_CURRENCY: CurrencyId = CurrencyId::DOT;
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -319,12 +322,12 @@ impl ExtBuilder {
     pub fn build() -> sp_io::TestExternalities {
         ExtBuilder::build_with(orml_tokens::GenesisConfig::<Test> {
             balances: vec![
-                (USER, Token(DOT), ALICE_BALANCE),
-                (VAULT.account_id, Token(DOT), VAULT_BALANCE),
-                (CAROL, Token(DOT), CAROL_BALANCE),
-                (USER, Token(INTERBTC), ALICE_BALANCE),
-                (VAULT.account_id, Token(INTERBTC), VAULT_BALANCE),
-                (CAROL, Token(INTERBTC), CAROL_BALANCE),
+                (USER, DOT, ALICE_BALANCE),
+                (VAULT.account_id, DOT, VAULT_BALANCE),
+                (CAROL, DOT, CAROL_BALANCE),
+                (USER, INTERBTC, ALICE_BALANCE),
+                (VAULT.account_id, INTERBTC, VAULT_BALANCE),
+                (CAROL, INTERBTC, CAROL_BALANCE),
             ],
         })
     }
@@ -339,7 +342,7 @@ where
         assert_ok!(<oracle::Pallet<Test>>::feed_values(
             Origin::signed(USER),
             vec![
-                (OracleKey::ExchangeRate(Token(DOT)), FixedU128::from(1)),
+                (OracleKey::ExchangeRate(CurrencyId::DOT), FixedU128::from(1)),
                 (OracleKey::FeeEstimation, FixedU128::from(3)),
             ]
         ));

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -20,7 +20,7 @@ fn griefing(amount: u128) -> Amount<Test> {
     Amount::new(amount, GRIEFING_CURRENCY)
 }
 fn wrapped(amount: u128) -> Amount<Test> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, INTERBTC)
 }
 
 macro_rules! assert_emitted {

--- a/crates/refund/src/benchmarking.rs
+++ b/crates/refund/src/benchmarking.rs
@@ -10,7 +10,7 @@ use btc_relay::{BtcAddress, BtcPublicKey};
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::{assert_ok, traits::Get};
 use frame_system::RawOrigin;
-use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultId};
+use primitives::{CurrencyId, VaultId};
 use sp_core::{H160, H256, U256};
 use sp_runtime::traits::One;
 use sp_std::prelude::*;
@@ -23,7 +23,7 @@ use oracle::Pallet as Oracle;
 use security::Pallet as Security;
 use vault_registry::Pallet as VaultRegistry;
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 
 type UnsignedFixedPoint<T> = <T as currency::Config>::UnsignedFixedPoint;
 

--- a/crates/refund/src/mock.rs
+++ b/crates/refund/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 };
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use orml_traits::parameter_type_with_key;
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
+pub use primitives::CurrencyId;
 use primitives::{VaultCurrencyPair, VaultId};
 use sp_core::H256;
 use sp_runtime::{
@@ -99,17 +99,19 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
+pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = CurrencyId::INTERBTC;
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
     collateral: DEFAULT_TESTING_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
     pub const MaxLocks: u32 = 50;
 }
 

--- a/crates/refund/src/tests.rs
+++ b/crates/refund/src/tests.rs
@@ -17,7 +17,7 @@ fn dummy_merkle_proof() -> MerkleProof {
 }
 
 fn wrapped(amount: u128) -> Amount<Test> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, INTERBTC)
 }
 
 #[test]

--- a/crates/relay/src/benchmarking.rs
+++ b/crates/relay/src/benchmarking.rs
@@ -14,7 +14,7 @@ use frame_support::{assert_ok, traits::Get};
 use frame_system::RawOrigin;
 use oracle::Pallet as Oracle;
 use orml_traits::MultiCurrency;
-use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultId};
+use primitives::{CurrencyId, VaultId};
 use security::Pallet as Security;
 use sp_core::{H160, U256};
 use sp_runtime::traits::One;
@@ -29,7 +29,7 @@ use crate::Pallet as Relay;
 
 type UnsignedFixedPoint<T> = <T as currency::Config>::UnsignedFixedPoint;
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 
 fn dummy_public_key() -> BtcPublicKey {
     BtcPublicKey([

--- a/crates/relay/src/mock.rs
+++ b/crates/relay/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 };
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use orml_traits::parameter_type_with_key;
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
+pub use primitives::CurrencyId;
 use primitives::{VaultCurrencyPair, VaultId};
 use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
@@ -94,17 +94,21 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(DOT);
+pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId =
+    <Test as orml_tokens::Config>::CurrencyId::DOT;
+pub const DEFAULT_WRAPPED_CURRENCY: <Test as orml_tokens::Config>::CurrencyId =
+    <Test as orml_tokens::Config>::CurrencyId::DOT;
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
     collateral: DEFAULT_TESTING_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -341,11 +345,11 @@ impl ExtBuilder {
         ExtBuilder::build_with(|storage| {
             orml_tokens::GenesisConfig::<Test> {
                 balances: vec![
-                    (ALICE, Token(DOT), ALICE_BALANCE),
-                    (BOB.account_id, Token(DOT), BOB_BALANCE),
-                    (CAROL.account_id, Token(DOT), CAROL_BALANCE),
-                    (DAVE, Token(DOT), DAVE_BALANCE),
-                    (EVE, Token(DOT), EVE_BALANCE),
+                    (ALICE, DOT, ALICE_BALANCE),
+                    (BOB.account_id, DOT, BOB_BALANCE),
+                    (CAROL.account_id, DOT, CAROL_BALANCE),
+                    (DAVE, DOT, DAVE_BALANCE),
+                    (EVE, DOT, EVE_BALANCE),
                 ],
             }
             .assimilate_storage(storage)

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -11,7 +11,7 @@ use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::traits::Get;
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
-use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultCurrencyPair, VaultId};
+use primitives::{CurrencyId, VaultCurrencyPair, VaultId};
 use sp_core::{H160, H256, U256};
 use sp_runtime::{traits::One, FixedPointNumber};
 use sp_std::prelude::*;
@@ -24,7 +24,7 @@ use oracle::Pallet as Oracle;
 use security::Pallet as Security;
 use vault_registry::Pallet as VaultRegistry;
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 type UnsignedFixedPoint<T> = <T as currency::Config>::UnsignedFixedPoint;
 
 fn wrapped<T: crate::Config>(amount: u32) -> Amount<T> {

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 };
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use orml_traits::parameter_type_with_key;
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
+pub use primitives::CurrencyId;
 use primitives::{VaultCurrencyPair, VaultId};
 use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
@@ -91,15 +91,17 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
+pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = CurrencyId::INTERBTC;
 
-pub const GRIEFING_CURRENCY: CurrencyId = Token(DOT);
+pub const GRIEFING_CURRENCY: CurrencyId = CurrencyId::DOT;
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -295,8 +297,8 @@ impl ExtBuilder {
     pub fn build() -> sp_io::TestExternalities {
         ExtBuilder::build_with(orml_tokens::GenesisConfig::<Test> {
             balances: vec![
-                (OLD_VAULT.account_id, Token(DOT), OLD_VAULT_BALANCE),
-                (NEW_VAULT.account_id, Token(DOT), NEW_VAULT_BALANCE),
+                (OLD_VAULT.account_id, DOT, OLD_VAULT_BALANCE),
+                (NEW_VAULT.account_id, DOT, NEW_VAULT_BALANCE),
             ],
         })
     }

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -48,7 +48,7 @@ fn griefing(amount: u128) -> Amount<Test> {
     Amount::new(amount, GRIEFING_CURRENCY)
 }
 fn wrapped(amount: u128) -> Amount<Test> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, INTERBTC)
 }
 
 mod request_replace_tests {

--- a/crates/reward/src/mock.rs
+++ b/crates/reward/src/mock.rs
@@ -1,7 +1,7 @@
 use crate as reward;
 use crate::{Config, Error};
 use frame_support::{parameter_types, traits::Everything};
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultCurrencyPair, VaultId};
+pub use primitives::{CurrencyId, VaultCurrencyPair, VaultId, INTERBTC};
 use sp_arithmetic::FixedI128;
 use sp_core::H256;
 use sp_runtime::{
@@ -61,8 +61,8 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-    pub const GetNativeCurrencyId: CurrencyId = Token(INTR);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::INTR;
+    pub const GetWrappedCurrencyId: CurrencyId = CurrencyId::INTERBTC;
 }
 
 impl Config for Test {

--- a/crates/reward/src/tests.rs
+++ b/crates/reward/src/tests.rs
@@ -16,9 +16,9 @@ fn should_distribute_rewards_equally() {
     run_test(|| {
         assert_ok!(Reward::deposit_stake(&ALICE, fixed!(50)));
         assert_ok!(Reward::deposit_stake(&BOB, fixed!(50)));
-        assert_ok!(Reward::distribute_reward(Token(INTERBTC), fixed!(100)));
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &ALICE), 50);
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &BOB), 50);
+        assert_ok!(Reward::distribute_reward(INTERBTC, fixed!(100)));
+        assert_ok!(Reward::compute_reward(INTERBTC, &ALICE), 50);
+        assert_ok!(Reward::compute_reward(INTERBTC, &BOB), 50);
     })
 }
 
@@ -27,9 +27,9 @@ fn should_distribute_uneven_rewards_equally() {
     run_test(|| {
         assert_ok!(Reward::deposit_stake(&ALICE, fixed!(50)));
         assert_ok!(Reward::deposit_stake(&BOB, fixed!(50)));
-        assert_ok!(Reward::distribute_reward(Token(INTERBTC), fixed!(451)));
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &ALICE), 225);
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &BOB), 225);
+        assert_ok!(Reward::distribute_reward(INTERBTC, fixed!(451)));
+        assert_ok!(Reward::compute_reward(INTERBTC, &ALICE), 225);
+        assert_ok!(Reward::compute_reward(INTERBTC, &BOB), 225);
     })
 }
 
@@ -37,12 +37,12 @@ fn should_distribute_uneven_rewards_equally() {
 fn should_not_update_previous_rewards() {
     run_test(|| {
         assert_ok!(Reward::deposit_stake(&ALICE, fixed!(40)));
-        assert_ok!(Reward::distribute_reward(Token(INTERBTC), fixed!(1000)));
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &ALICE), 1000);
+        assert_ok!(Reward::distribute_reward(INTERBTC, fixed!(1000)));
+        assert_ok!(Reward::compute_reward(INTERBTC, &ALICE), 1000);
 
         assert_ok!(Reward::deposit_stake(&BOB, fixed!(20)));
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &ALICE), 1000);
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &BOB), 0);
+        assert_ok!(Reward::compute_reward(INTERBTC, &ALICE), 1000);
+        assert_ok!(Reward::compute_reward(INTERBTC, &BOB), 0);
     })
 }
 
@@ -51,10 +51,10 @@ fn should_withdraw_reward() {
     run_test(|| {
         assert_ok!(Reward::deposit_stake(&ALICE, fixed!(45)));
         assert_ok!(Reward::deposit_stake(&BOB, fixed!(55)));
-        assert_ok!(Reward::distribute_reward(Token(INTERBTC), fixed!(2344)));
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &BOB), 1289);
-        assert_ok!(Reward::withdraw_reward(&ALICE, Token(INTERBTC)), 1054);
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &BOB), 1289);
+        assert_ok!(Reward::distribute_reward(INTERBTC, fixed!(2344)));
+        assert_ok!(Reward::compute_reward(INTERBTC, &BOB), 1289);
+        assert_ok!(Reward::withdraw_reward(&ALICE, INTERBTC), 1054);
+        assert_ok!(Reward::compute_reward(INTERBTC, &BOB), 1289);
     })
 }
 
@@ -62,10 +62,10 @@ fn should_withdraw_reward() {
 fn should_withdraw_stake() {
     run_test(|| {
         assert_ok!(Reward::deposit_stake(&ALICE, fixed!(1312)));
-        assert_ok!(Reward::distribute_reward(Token(INTERBTC), fixed!(4242)));
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &ALICE), 4242);
+        assert_ok!(Reward::distribute_reward(INTERBTC, fixed!(4242)));
+        assert_ok!(Reward::compute_reward(INTERBTC, &ALICE), 4242);
         assert_ok!(Reward::withdraw_stake(&ALICE, fixed!(1312)));
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &ALICE), 4242);
+        assert_ok!(Reward::compute_reward(INTERBTC, &ALICE), 4242);
     })
 }
 
@@ -73,8 +73,8 @@ fn should_withdraw_stake() {
 fn should_not_withdraw_stake_if_balance_insufficient() {
     run_test(|| {
         assert_ok!(Reward::deposit_stake(&ALICE, fixed!(100)));
-        assert_ok!(Reward::distribute_reward(Token(INTERBTC), fixed!(2000)));
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &ALICE), 2000);
+        assert_ok!(Reward::distribute_reward(INTERBTC, fixed!(2000)));
+        assert_ok!(Reward::compute_reward(INTERBTC, &ALICE), 2000);
         assert_err!(
             Reward::withdraw_stake(&ALICE, fixed!(200)),
             TestError::InsufficientFunds
@@ -89,8 +89,8 @@ fn should_deposit_stake() {
         assert_ok!(Reward::deposit_stake(&ALICE, fixed!(25)));
         assert_eq!(Reward::stake(&ALICE), fixed!(50));
         assert_ok!(Reward::deposit_stake(&BOB, fixed!(50)));
-        assert_ok!(Reward::distribute_reward(Token(INTERBTC), fixed!(1000)));
-        assert_ok!(Reward::compute_reward(Token(INTERBTC), &ALICE), 500);
+        assert_ok!(Reward::distribute_reward(INTERBTC, fixed!(1000)));
+        assert_ok!(Reward::compute_reward(INTERBTC, &ALICE), 500);
     })
 }
 
@@ -98,10 +98,10 @@ fn should_deposit_stake() {
 fn should_not_distribute_rewards_without_stake() {
     run_test(|| {
         assert_err!(
-            Reward::distribute_reward(Token(INTERBTC), fixed!(1000)),
+            Reward::distribute_reward(INTERBTC, fixed!(1000)),
             TestError::ZeroTotalStake
         );
-        assert_eq!(Reward::total_rewards(Token(INTERBTC)), fixed!(0));
+        assert_eq!(Reward::total_rewards(INTERBTC), fixed!(0));
     })
 }
 
@@ -114,14 +114,11 @@ fn should_distribute_with_many_rewards() {
         assert_ok!(Reward::deposit_stake(&BOB, fixed!(234234444)));
         for _ in 0..30 {
             // NOTE: this will overflow compute_reward with > u32
-            assert_ok!(Reward::distribute_reward(
-                Token(INTERBTC),
-                fixed!(rng.gen::<u32>() as i128)
-            ));
+            assert_ok!(Reward::distribute_reward(INTERBTC, fixed!(rng.gen::<u32>() as i128)));
         }
-        let alice_reward = Reward::compute_reward(Token(INTERBTC), &ALICE).unwrap();
-        assert_ok!(Reward::withdraw_reward(&ALICE, Token(INTERBTC)), alice_reward);
-        let bob_reward = Reward::compute_reward(Token(INTERBTC), &BOB).unwrap();
-        assert_ok!(Reward::withdraw_reward(&BOB, Token(INTERBTC)), bob_reward);
+        let alice_reward = Reward::compute_reward(INTERBTC, &ALICE).unwrap();
+        assert_ok!(Reward::withdraw_reward(&ALICE, INTERBTC), alice_reward);
+        let bob_reward = Reward::compute_reward(INTERBTC, &BOB).unwrap();
+        assert_ok!(Reward::withdraw_reward(&BOB, INTERBTC), bob_reward);
     })
 }

--- a/crates/staking/src/mock.rs
+++ b/crates/staking/src/mock.rs
@@ -1,7 +1,7 @@
 use crate as staking;
 use crate::{Config, Error};
 use frame_support::{parameter_types, traits::Everything};
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
+pub use primitives::{CurrencyId, DOT, INTERBTC};
 use primitives::{VaultCurrencyPair, VaultId};
 use sp_arithmetic::FixedI128;
 use sp_core::H256;
@@ -63,7 +63,7 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
 }
 
 impl Config for Test {
@@ -80,22 +80,22 @@ pub type TestError = Error<Test>;
 pub const VAULT: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 1,
     currencies: VaultCurrencyPair {
-        collateral: Token(DOT),
-        wrapped: Token(INTERBTC),
+        collateral: DOT,
+        wrapped: INTERBTC,
     },
 };
 pub const ALICE: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 2,
     currencies: VaultCurrencyPair {
-        collateral: Token(DOT),
-        wrapped: Token(INTERBTC),
+        collateral: DOT,
+        wrapped: INTERBTC,
     },
 };
 pub const BOB: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 3,
     currencies: VaultCurrencyPair {
-        collateral: Token(DOT),
-        wrapped: Token(INTERBTC),
+        collateral: DOT,
+        wrapped: INTERBTC,
     },
 };
 

--- a/crates/staking/src/tests.rs
+++ b/crates/staking/src/tests.rs
@@ -15,14 +15,14 @@ fn should_stake_and_earn_rewards() {
     run_test(|| {
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(50)));
         assert_ok!(Staking::deposit_stake(&VAULT, &BOB.account_id, fixed!(50)));
-        assert_ok!(Staking::distribute_reward(Token(INTERBTC), &VAULT, fixed!(100)));
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &ALICE.account_id), 50);
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &BOB.account_id), 50);
-        assert_ok!(Staking::slash_stake(Token(INTERBTC), &VAULT, fixed!(20)));
+        assert_ok!(Staking::distribute_reward(INTERBTC, &VAULT, fixed!(100)));
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &ALICE.account_id), 50);
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &BOB.account_id), 50);
+        assert_ok!(Staking::slash_stake(INTERBTC, &VAULT, fixed!(20)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 40);
         assert_ok!(Staking::compute_stake(&VAULT, &BOB.account_id), 40);
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &ALICE.account_id), 50);
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &BOB.account_id), 50);
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &ALICE.account_id), 50);
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &BOB.account_id), 50);
     })
 }
 
@@ -32,21 +32,18 @@ fn should_stake_and_distribute_and_withdraw() {
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(10000)));
         assert_ok!(Staking::deposit_stake(&VAULT, &BOB.account_id, fixed!(10000)));
 
-        assert_ok!(Staking::distribute_reward(Token(INTERBTC), &VAULT, fixed!(1000)));
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &ALICE.account_id), 500);
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &BOB.account_id), 500);
+        assert_ok!(Staking::distribute_reward(INTERBTC, &VAULT, fixed!(1000)));
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &ALICE.account_id), 500);
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &BOB.account_id), 500);
 
-        assert_ok!(Staking::slash_stake(Token(INTERBTC), &VAULT, fixed!(50)));
-        assert_ok!(Staking::slash_stake(Token(INTERBTC), &VAULT, fixed!(50)));
+        assert_ok!(Staking::slash_stake(INTERBTC, &VAULT, fixed!(50)));
+        assert_ok!(Staking::slash_stake(INTERBTC, &VAULT, fixed!(50)));
 
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(1000)));
-        assert_ok!(Staking::distribute_reward(Token(INTERBTC), &VAULT, fixed!(1000)));
+        assert_ok!(Staking::distribute_reward(INTERBTC, &VAULT, fixed!(1000)));
 
-        assert_ok!(
-            Staking::compute_reward(Token(INTERBTC), &VAULT, &ALICE.account_id),
-            1023
-        );
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &BOB.account_id), 976);
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &ALICE.account_id), 1023);
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &BOB.account_id), 976);
 
         assert_ok!(Staking::withdraw_stake(&VAULT, &ALICE.account_id, fixed!(10000), None));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 950);
@@ -57,16 +54,13 @@ fn should_stake_and_distribute_and_withdraw() {
         assert_ok!(Staking::deposit_stake(&VAULT, &BOB.account_id, fixed!(10000)));
         assert_ok!(Staking::compute_stake(&VAULT, &BOB.account_id), 19950);
 
-        assert_ok!(Staking::distribute_reward(Token(INTERBTC), &VAULT, fixed!(1000)));
-        assert_ok!(Staking::slash_stake(Token(INTERBTC), &VAULT, fixed!(10000)));
+        assert_ok!(Staking::distribute_reward(INTERBTC, &VAULT, fixed!(1000)));
+        assert_ok!(Staking::slash_stake(INTERBTC, &VAULT, fixed!(10000)));
 
         assert_ok!(Staking::compute_stake(&VAULT, &BOB.account_id), 9949);
 
-        assert_ok!(
-            Staking::compute_reward(Token(INTERBTC), &VAULT, &ALICE.account_id),
-            1023
-        );
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &BOB.account_id), 1975);
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &ALICE.account_id), 1023);
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &BOB.account_id), 1975);
     })
 }
 
@@ -74,13 +68,10 @@ fn should_stake_and_distribute_and_withdraw() {
 fn should_stake_and_withdraw_rewards() {
     run_test(|| {
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(100)));
-        assert_ok!(Staking::distribute_reward(Token(INTERBTC), &VAULT, fixed!(100)));
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &ALICE.account_id), 100);
-        assert_ok!(
-            Staking::withdraw_reward(Token(INTERBTC), &VAULT, &ALICE.account_id),
-            100
-        );
-        assert_ok!(Staking::compute_reward(Token(INTERBTC), &VAULT, &ALICE.account_id), 0);
+        assert_ok!(Staking::distribute_reward(INTERBTC, &VAULT, fixed!(100)));
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &ALICE.account_id), 100);
+        assert_ok!(Staking::withdraw_reward(INTERBTC, &VAULT, &ALICE.account_id), 100);
+        assert_ok!(Staking::compute_reward(INTERBTC, &VAULT, &ALICE.account_id), 0);
     })
 }
 
@@ -101,7 +92,7 @@ fn should_not_withdraw_stake_if_balance_insufficient_after_slashing() {
     run_test(|| {
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(100)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 100);
-        assert_ok!(Staking::slash_stake(Token(INTERBTC), &VAULT, fixed!(100)));
+        assert_ok!(Staking::slash_stake(INTERBTC, &VAULT, fixed!(100)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 0);
         assert_err!(
             Staking::withdraw_stake(&VAULT, &ALICE.account_id, fixed!(100), None),
@@ -116,22 +107,22 @@ fn should_force_refund() {
         let mut nonce = Staking::nonce(&VAULT);
         assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(100)));
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(100)));
-        assert_ok!(Staking::slash_stake(Token(INTERBTC), &VAULT, fixed!(100)));
+        assert_ok!(Staking::slash_stake(INTERBTC, &VAULT, fixed!(100)));
         assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(100)));
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(10)));
-        assert_ok!(Staking::distribute_reward(Token(INTERBTC), &VAULT, fixed!(100)));
+        assert_ok!(Staking::distribute_reward(INTERBTC, &VAULT, fixed!(100)));
 
         // vault stake & rewards pre-refund
         assert_ok!(Staking::compute_stake_at_index(nonce, &VAULT, &VAULT.account_id), 150);
         assert_ok!(
-            Staking::compute_reward_at_index(nonce, Token(INTERBTC), &VAULT, &VAULT.account_id),
+            Staking::compute_reward_at_index(nonce, INTERBTC, &VAULT, &VAULT.account_id),
             71
         );
 
         // alice stake & rewards pre-refund
         assert_ok!(Staking::compute_stake_at_index(nonce, &VAULT, &ALICE.account_id), 60);
         assert_ok!(
-            Staking::compute_reward_at_index(nonce, Token(INTERBTC), &VAULT, &ALICE.account_id),
+            Staking::compute_reward_at_index(nonce, INTERBTC, &VAULT, &ALICE.account_id),
             28
         );
 
@@ -142,19 +133,19 @@ fn should_force_refund() {
         // vault stake & rewards post-refund
         assert_ok!(Staking::compute_stake_at_index(nonce, &VAULT, &VAULT.account_id), 150);
         assert_ok!(
-            Staking::compute_reward_at_index(nonce, Token(INTERBTC), &VAULT, &VAULT.account_id),
+            Staking::compute_reward_at_index(nonce, INTERBTC, &VAULT, &VAULT.account_id),
             0
         );
 
         assert_ok!(
-            Staking::compute_reward_at_index(nonce - 1, Token(INTERBTC), &VAULT, &VAULT.account_id),
+            Staking::compute_reward_at_index(nonce - 1, INTERBTC, &VAULT, &VAULT.account_id),
             71
         );
 
         // alice stake & rewards post-refund
         assert_ok!(Staking::compute_stake_at_index(nonce, &VAULT, &ALICE.account_id), 0);
         assert_ok!(
-            Staking::compute_reward_at_index(nonce, Token(INTERBTC), &VAULT, &ALICE.account_id),
+            Staking::compute_reward_at_index(nonce, INTERBTC, &VAULT, &ALICE.account_id),
             0
         );
 
@@ -163,7 +154,7 @@ fn should_force_refund() {
             60
         );
         assert_ok!(
-            Staking::compute_reward_at_index(nonce - 1, Token(INTERBTC), &VAULT, &ALICE.account_id),
+            Staking::compute_reward_at_index(nonce - 1, INTERBTC, &VAULT, &ALICE.account_id),
             28
         );
     })
@@ -181,7 +172,7 @@ fn should_compute_stake_after_adjustments() {
             fixed!(1152923504604516976)
         ));
         assert_ok!(Staking::slash_stake(
-            Token(INTERBTC),
+            INTERBTC,
             &VAULT,
             fixed!(1152923504604516976 + 100)
         ));
@@ -194,7 +185,7 @@ fn should_compute_stake_after_adjustments() {
             fixed!(1152924504603286976)
         ));
         assert_ok!(Staking::slash_stake(
-            Token(INTERBTC),
+            INTERBTC,
             &VAULT,
             fixed!(1152924504603286976 + 1_000_000)
         ));

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -5,10 +5,10 @@ use frame_support::traits::Get;
 use frame_system::RawOrigin;
 use oracle::Pallet as Oracle;
 use orml_traits::MultiCurrency;
-use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
+use primitives::CurrencyId;
 use sp_std::prelude::*;
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
 type UnsignedFixedPoint<T> = <T as currency::Config>::UnsignedFixedPoint;
 
 fn wrapped<T: crate::Config>(amount: u32) -> Amount<T> {

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -7,7 +7,7 @@ use frame_support::{
 };
 use mocktopus::{macros::mockable, mocking::clear_mocks};
 use orml_traits::parameter_type_with_key;
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
+pub use primitives::CurrencyId;
 use primitives::{VaultCurrencyPair, VaultId};
 use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
@@ -86,18 +86,20 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+pub const DEFAULT_TESTING_CURRENCY: CurrencyId = CurrencyId::DOT;
+pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = CurrencyId::INTERBTC;
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
     collateral: DEFAULT_TESTING_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
-pub const GRIEFING_CURRENCY: CurrencyId = Token(DOT);
+pub const GRIEFING_CURRENCY: CurrencyId = CurrencyId::DOT;
+pub const DOT: CurrencyId = CurrencyId::DOT;
+pub const INTERBTC: CurrencyId = CurrencyId::INTERBTC;
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = CurrencyId::KINT;
     pub const MaxLocks: u32 = 50;
 }
 

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -52,8 +52,8 @@ pub use module_oracle_rpc_runtime_api::BalanceWrapper;
 pub use security::StatusCode;
 
 pub use primitives::{
-    self, AccountId, Balance, BlockNumber, CurrencyId, CurrencyId::Token, CurrencyInfo, Hash, Moment, Nonce, Signature,
-    SignedFixedPoint, SignedInner, UnsignedFixedPoint, UnsignedInner, DOT, INTERBTC, INTR,
+    self, AccountId, Balance, BlockNumber, CurrencyId, CurrencyInfo, Hash, Moment, Nonce, Signature, SignedFixedPoint,
+    SignedInner, UnsignedFixedPoint, UnsignedInner, DOT, INTERBTC, INTR,
 };
 
 // XCM imports
@@ -822,9 +822,9 @@ impl btc_relay::Config for Runtime {
     type ParachainBlocksPerBitcoinBlock = ParachainBlocksPerBitcoinBlock;
 }
 
-const RELAY_CHAIN_CURRENCY_ID: CurrencyId = Token(DOT);
-const WRAPPED_CURRENCY_ID: CurrencyId = Token(INTERBTC);
-const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
+const RELAY_CHAIN_CURRENCY_ID: CurrencyId = DOT;
+const WRAPPED_CURRENCY_ID: CurrencyId = INTERBTC;
+const NATIVE_CURRENCY_ID: CurrencyId = INTR;
 
 parameter_types! {
     pub const GetCollateralCurrencyId: CurrencyId = RELAY_CHAIN_CURRENCY_ID;

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -55,8 +55,8 @@ pub use module_oracle_rpc_runtime_api::BalanceWrapper;
 pub use security::StatusCode;
 
 pub use primitives::{
-    self, AccountId, Balance, BlockNumber, CurrencyId, CurrencyId::Token, CurrencyInfo, Hash, Moment, Nonce, Signature,
-    SignedFixedPoint, SignedInner, UnsignedFixedPoint, UnsignedInner, KBTC, KINT, KSM,
+    self, AccountId, Balance, BlockNumber, CurrencyId, CurrencyInfo, Hash, Moment, Nonce, Signature, SignedFixedPoint,
+    SignedInner, UnsignedFixedPoint, UnsignedInner, KBTC, KINT, KSM,
 };
 
 // XCM imports
@@ -613,7 +613,7 @@ pub struct XcmConfig;
 
 // the ksm cost to to execute a no-op extrinsic
 fn base_tx_in_ksm() -> Balance {
-    KSM.one() / 50_000
+    CurrencyId::KSM.one() / 50_000
 }
 pub fn ksm_per_second() -> u128 {
     let base_weight = Balance::from(ExtrinsicBaseWeight::get());
@@ -626,7 +626,7 @@ parameter_types! {
     pub KintPerSecond: (AssetId, u128) = (
         MultiLocation::new(
             1,
-            X2(Parachain(2092), GeneralKey(Token(KINT).encode())),
+            X2(Parachain(2092), GeneralKey(CurrencyId::KINT.encode())),
         ).into(),
         // KINT:KSM = 4:3
         (ksm_per_second() * 4) / 3
@@ -634,7 +634,7 @@ parameter_types! {
     pub KbtcPerSecond: (AssetId, u128) = (
         MultiLocation::new(
             1,
-            X2(Parachain(2092), GeneralKey(Token(KBTC).encode())),
+            X2(Parachain(2092), GeneralKey(CurrencyId::KBTC.encode())),
         ).into(),
         // KBTC:KSM = 1:150 & Satoshi:Planck = 1:10_000
         ksm_per_second() / 1_500_000
@@ -848,9 +848,9 @@ impl btc_relay::Config for Runtime {
     type ParachainBlocksPerBitcoinBlock = ParachainBlocksPerBitcoinBlock;
 }
 
-const RELAY_CHAIN_CURRENCY_ID: CurrencyId = Token(KSM);
-const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
-const NATIVE_CURRENCY_ID: CurrencyId = Token(KINT);
+const RELAY_CHAIN_CURRENCY_ID: CurrencyId = KSM;
+const WRAPPED_CURRENCY_ID: CurrencyId = KBTC;
+const NATIVE_CURRENCY_ID: CurrencyId = KINT;
 
 parameter_types! {
     pub const GetCollateralCurrencyId: CurrencyId = RELAY_CHAIN_CURRENCY_ID;

--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -2,10 +2,7 @@ use bitcoin::utils::{virtual_transaction_size, InputType, TransactionInputMetada
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
 use interbtc_rpc::jsonrpc_core::serde_json::{map::Map, Value};
-use primitives::{
-    AccountId, Balance, BlockNumber, CurrencyId, CurrencyId::Token, Signature, TokenSymbol, VaultCurrencyPair, DOT,
-    KINT, KSM,
-};
+use primitives::{AccountId, Balance, BlockNumber, CurrencyId, Signature, VaultCurrencyPair, KINT};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
@@ -88,7 +85,7 @@ fn get_properties() -> Map<String, Value> {
     let mut properties = Map::new();
     let mut token_symbol: Vec<String> = vec![];
     let mut token_decimals: Vec<u32> = vec![];
-    TokenSymbol::get_info().iter().for_each(|(symbol_name, decimals)| {
+    CurrencyId::get_info().iter().for_each(|(symbol_name, decimals)| {
         token_symbol.push(symbol_name.to_string());
         token_decimals.push(*decimals);
     });
@@ -354,19 +351,19 @@ fn testnet_genesis(
             replace_btc_dust_value: DEFAULT_DUST_VALUE,
         },
         vault_registry: kintsugi_runtime::VaultRegistryConfig {
-            minimum_collateral_vault: vec![(Token(KSM), 0)],
+            minimum_collateral_vault: vec![(CurrencyId::KSM, 0)],
             punishment_delay: kintsugi_runtime::DAYS,
-            system_collateral_ceiling: vec![(default_pair_kintsugi(Token(KSM)), 1000 * KSM.one())],
+            system_collateral_ceiling: vec![(default_pair_kintsugi(CurrencyId::KSM), 1000 * CurrencyId::KSM.one())],
             secure_collateral_threshold: vec![(
-                default_pair_kintsugi(Token(KSM)),
+                default_pair_kintsugi(CurrencyId::KSM),
                 FixedU128::checked_from_rational(150, 100).unwrap(),
             )], /* 150% */
             premium_redeem_threshold: vec![(
-                default_pair_kintsugi(Token(KSM)),
+                default_pair_kintsugi(CurrencyId::KSM),
                 FixedU128::checked_from_rational(135, 100).unwrap(),
             )], /* 135% */
             liquidation_collateral_threshold: vec![(
-                default_pair_kintsugi(Token(KSM)),
+                default_pair_kintsugi(CurrencyId::KSM),
                 FixedU128::checked_from_rational(110, 100).unwrap(),
             )], /* 110% */
         },
@@ -495,7 +492,7 @@ fn kintsugi_mainnet_genesis(
         tokens: kintsugi_runtime::TokensConfig {
             balances: initial_allocation
                 .iter()
-                .map(|(who, amount)| (who.clone(), Token(KINT), *amount))
+                .map(|(who, amount)| (who.clone(), KINT, *amount))
                 .collect(),
         },
         vesting: kintsugi_runtime::VestingConfig { vesting: vesting_list },
@@ -523,22 +520,21 @@ fn kintsugi_mainnet_genesis(
             replace_btc_dust_value: DEFAULT_DUST_VALUE,
         },
         vault_registry: kintsugi_runtime::VaultRegistryConfig {
-            minimum_collateral_vault: vec![(Token(KSM), 0)],
+            minimum_collateral_vault: vec![(CurrencyId::KSM, 0)],
             punishment_delay: kintsugi_runtime::DAYS,
-            system_collateral_ceiling: vec![(default_pair_kintsugi(Token(KSM)), 317 * KSM.one())], /* 317 ksm, about
-                                                                                                    * 100k
-                                                                                                    * USD at
-                                                                                                    * time of writing */
+            system_collateral_ceiling: vec![(default_pair_kintsugi(CurrencyId::KSM), 317 * CurrencyId::KSM.one())], /* 317 ksm, about 100k
+                                                                                                                     * USD at
+                                                                                                                     * time of writing */
             secure_collateral_threshold: vec![(
-                default_pair_kintsugi(Token(KSM)),
+                default_pair_kintsugi(CurrencyId::KSM),
                 FixedU128::checked_from_rational(260, 100).unwrap(),
             )], /* 260% */
             premium_redeem_threshold: vec![(
-                default_pair_kintsugi(Token(KSM)),
+                default_pair_kintsugi(CurrencyId::KSM),
                 FixedU128::checked_from_rational(200, 100).unwrap(),
             )], /* 200% */
             liquidation_collateral_threshold: vec![(
-                default_pair_kintsugi(Token(KSM)),
+                default_pair_kintsugi(CurrencyId::KSM),
                 FixedU128::checked_from_rational(150, 100).unwrap(),
             )], /* 150% */
         },
@@ -701,7 +697,7 @@ fn interlay_mainnet_genesis(
         tokens: interlay_runtime::TokensConfig {
             balances: initial_allocation
                 .iter()
-                .map(|(who, amount)| (who.clone(), Token(KINT), *amount))
+                .map(|(who, amount)| (who.clone(), KINT, *amount))
                 .collect(),
         },
         vesting: interlay_runtime::VestingConfig { vesting: vesting_list },
@@ -729,21 +725,21 @@ fn interlay_mainnet_genesis(
             replace_btc_dust_value: DEFAULT_DUST_VALUE,
         },
         vault_registry: interlay_runtime::VaultRegistryConfig {
-            minimum_collateral_vault: vec![(Token(KSM), 0)],
+            minimum_collateral_vault: vec![(CurrencyId::KSM, 0)],
             punishment_delay: interlay_runtime::DAYS,
-            system_collateral_ceiling: vec![(default_pair_interlay(Token(DOT)), 3333 * DOT.one())], /* 3333 DOT, about 100k
-                                                                                                     * USD at
-                                                                                                     * time of writing */
+            system_collateral_ceiling: vec![(default_pair_interlay(CurrencyId::DOT), 3333 * CurrencyId::DOT.one())], /* 3333 DOT, about 100k
+                                                                                                                      * USD at
+                                                                                                                      * time of writing */
             secure_collateral_threshold: vec![(
-                default_pair_interlay(Token(DOT)),
+                default_pair_interlay(CurrencyId::DOT),
                 FixedU128::checked_from_rational(260, 100).unwrap(),
             )], /* 260% */
             premium_redeem_threshold: vec![(
-                default_pair_interlay(Token(DOT)),
+                default_pair_interlay(CurrencyId::DOT),
                 FixedU128::checked_from_rational(200, 100).unwrap(),
             )], /* 200% */
             liquidation_collateral_threshold: vec![(
-                default_pair_interlay(Token(DOT)),
+                default_pair_interlay(CurrencyId::DOT),
                 FixedU128::checked_from_rational(150, 100).unwrap(),
             )], /* 150% */
         },

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -394,17 +394,17 @@ pub trait CurrencyInfo {
 
 macro_rules! create_currency_id {
     ($(#[$meta:meta])*
-	$vis:vis enum TokenSymbol {
+	$vis:vis enum CurrencyId {
         $($(#[$vmeta:meta])* $symbol:ident($name:expr, $deci:literal),)*
     }) => {
 		$(#[$meta])*
-		$vis enum TokenSymbol {
+		$vis enum CurrencyId {
 			$($(#[$vmeta])* $symbol,)*
 		}
 
-        $(pub const $symbol: TokenSymbol = TokenSymbol::$symbol;)*
+        $(pub const $symbol: CurrencyId = CurrencyId::$symbol;)*
 
-        impl TokenSymbol {
+        impl CurrencyId {
 			pub fn get_info() -> Vec<(&'static str, u32)> {
 				vec![
 					$((stringify!($symbol), $deci),)*
@@ -417,20 +417,20 @@ macro_rules! create_currency_id {
 
             const fn decimals(&self) -> u8 {
 				match self {
-					$(TokenSymbol::$symbol => $deci,)*
+					$(CurrencyId::$symbol => $deci,)*
 				}
 			}
 		}
 
-		impl CurrencyInfo for TokenSymbol {
+		impl CurrencyInfo for CurrencyId {
 			fn name(&self) -> &str {
 				match self {
-					$(TokenSymbol::$symbol => $name,)*
+					$(CurrencyId::$symbol => $name,)*
 				}
 			}
 			fn symbol(&self) -> &str {
 				match self {
-					$(TokenSymbol::$symbol => stringify!($symbol),)*
+					$(CurrencyId::$symbol => stringify!($symbol),)*
 				}
 			}
 			fn decimals(&self) -> u8 {
@@ -438,11 +438,11 @@ macro_rules! create_currency_id {
 			}
 		}
 
-		impl TryFrom<Vec<u8>> for TokenSymbol {
+		impl TryFrom<Vec<u8>> for CurrencyId {
 			type Error = ();
-			fn try_from(v: Vec<u8>) -> Result<TokenSymbol, ()> {
+			fn try_from(v: Vec<u8>) -> Result<CurrencyId, ()> {
 				match v.as_slice() {
-					$(bstringify!($symbol) => Ok(TokenSymbol::$symbol),)*
+					$(bstringify!($symbol) => Ok(CurrencyId::$symbol),)*
 					_ => Err(()),
 				}
 			}
@@ -453,7 +453,7 @@ macro_rules! create_currency_id {
 create_currency_id! {
     #[derive(Encode, Decode, Eq, Hash, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo)]
     #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-    pub enum TokenSymbol {
+    pub enum CurrencyId {
         DOT("Polkadot", 10),
         INTERBTC("interBTC", 8),
         INTR("Interlay", 10),
@@ -462,10 +462,4 @@ create_currency_id! {
         KBTC("kBTC", 8),
         KINT("Kintsugi", 12),
     }
-}
-
-#[derive(Encode, Decode, Eq, Hash, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum CurrencyId {
-    Token(TokenSymbol),
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -395,33 +395,14 @@ pub trait CurrencyInfo {
 macro_rules! create_currency_id {
     ($(#[$meta:meta])*
 	$vis:vis enum TokenSymbol {
-        $($(#[$vmeta:meta])* $symbol:ident($name:expr, $deci:literal) = $val:literal,)*
+        $($(#[$vmeta:meta])* $symbol:ident($name:expr, $deci:literal),)*
     }) => {
 		$(#[$meta])*
 		$vis enum TokenSymbol {
-			$($(#[$vmeta])* $symbol = $val,)*
+			$($(#[$vmeta])* $symbol,)*
 		}
 
         $(pub const $symbol: TokenSymbol = TokenSymbol::$symbol;)*
-
-        impl TryFrom<u8> for TokenSymbol {
-			type Error = ();
-
-			fn try_from(v: u8) -> Result<Self, Self::Error> {
-				match v {
-					$($val => Ok(TokenSymbol::$symbol),)*
-					_ => Err(()),
-				}
-			}
-		}
-
-		impl Into<u8> for TokenSymbol {
-			fn into(self) -> u8 {
-				match self {
-					$(TokenSymbol::$symbol => ($val),)*
-				}
-			}
-		}
 
         impl TokenSymbol {
 			pub fn get_info() -> Vec<(&'static str, u32)> {
@@ -472,15 +453,14 @@ macro_rules! create_currency_id {
 create_currency_id! {
     #[derive(Encode, Decode, Eq, Hash, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo)]
     #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-    #[repr(u8)]
     pub enum TokenSymbol {
-        DOT("Polkadot", 10) = 0,
-        INTERBTC("interBTC", 8) = 1,
-        INTR("Interlay", 10) = 2,
+        DOT("Polkadot", 10),
+        INTERBTC("interBTC", 8),
+        INTR("Interlay", 10),
 
-        KSM("Kusama", 12) = 10,
-        KBTC("kBTC", 8) = 11,
-        KINT("Kintsugi", 12) = 12,
+        KSM("Kusama", 12),
+        KBTC("kBTC", 8),
+        KINT("Kintsugi", 12),
     }
 }
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -54,8 +54,8 @@ pub use security::StatusCode;
 
 use currency::Amount;
 pub use primitives::{
-    self, AccountId, Balance, BlockNumber, CurrencyId, CurrencyId::Token, CurrencyInfo, Hash, Moment, Nonce, Signature,
-    SignedFixedPoint, SignedInner, TokenSymbol, UnsignedFixedPoint, UnsignedInner, DOT, INTERBTC, INTR, KINT, KSM,
+    self, AccountId, Balance, BlockNumber, CurrencyId, CurrencyInfo, Hash, Moment, Nonce, Signature, SignedFixedPoint,
+    SignedInner, UnsignedFixedPoint, UnsignedInner, DOT, INTERBTC, INTR, KINT, KSM,
 };
 
 use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
@@ -437,9 +437,9 @@ impl btc_relay::Config for Runtime {
 }
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(INTR);
+    pub const GetCollateralCurrencyId: CurrencyId = DOT;
+    pub const GetWrappedCurrencyId: CurrencyId = INTERBTC;
+    pub const GetNativeCurrencyId: CurrencyId = INTR;
 }
 
 type NativeCurrency = orml_tokens::CurrencyAdapter<Runtime, GetNativeCurrencyId>;

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -17,13 +17,11 @@ pub use frame_support::{
 use interbtc_runtime_standalone::GetNativeCurrencyId;
 pub use interbtc_runtime_standalone::{
     AccountId, BlockNumber, Call, CurrencyId, Event, GetCollateralCurrencyId, GetWrappedCurrencyId, Runtime,
-    TechnicalCommitteeInstance, VaultAnnuityInstance, VaultRewardsInstance,
+    TechnicalCommitteeInstance, VaultAnnuityInstance, VaultRewardsInstance, DOT, INTERBTC, INTR
 };
 pub use mocktopus::mocking::*;
 pub use orml_tokens::CurrencyAdapter;
-pub use primitives::{
-    CurrencyId::Token, VaultCurrencyPair, VaultId as PrimitiveVaultId, DOT, INTERBTC, INTR, KBTC, KINT, KSM,
-};
+pub use primitives::{VaultCurrencyPair, VaultId as PrimitiveVaultId};
 use redeem::RedeemRequestStatus;
 use staking::DefaultVaultCurrencyPair;
 use vault_registry::types::UpdatableVault;
@@ -170,10 +168,14 @@ pub type NominationError = nomination::Error<Runtime>;
 pub type NominationEvent = nomination::Event<Runtime>;
 pub type NominationPallet = nomination::Pallet<Runtime>;
 
-pub const DEFAULT_TESTING_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(INTERBTC);
-pub const GRIEFING_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(DOT);
-pub const WRAPPED_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(INTERBTC);
+pub const DEFAULT_TESTING_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId =
+    <Runtime as orml_tokens::Config>::CurrencyId::DOT;
+pub const DEFAULT_WRAPPED_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId =
+    <Runtime as orml_tokens::Config>::CurrencyId::INTERBTC;
+pub const GRIEFING_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId =
+    <Runtime as orml_tokens::Config>::CurrencyId::DOT;
+pub const WRAPPED_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId =
+    <Runtime as orml_tokens::Config>::CurrencyId::INTERBTC;
 
 pub fn default_vault_id_of(hash: [u8; 32]) -> VaultId {
     VaultId {
@@ -322,11 +324,11 @@ pub fn iter_currency_pairs() -> impl Iterator<Item = DefaultVaultCurrencyPair<Ru
 }
 
 pub fn iter_collateral_currencies() -> impl Iterator<Item = CurrencyId> {
-    vec![Token(DOT), Token(KSM)].into_iter()
+    vec![CurrencyId::DOT, CurrencyId::KSM].into_iter()
 }
 
 pub fn iter_wrapped_currencies() -> impl Iterator<Item = CurrencyId> {
-    vec![Token(KBTC), Token(INTERBTC)].into_iter()
+    vec![CurrencyId::KBTC, CurrencyId::INTERBTC].into_iter()
 }
 
 pub fn iter_all_currencies() -> impl Iterator<Item = CurrencyId> {
@@ -1312,7 +1314,7 @@ impl ExtBuilder {
         .unwrap();
 
         vault_registry::GenesisConfig::<Runtime> {
-            minimum_collateral_vault: vec![(Token(DOT), 0), (Token(KSM), 0)],
+            minimum_collateral_vault: vec![(CurrencyId::DOT, 0), (CurrencyId::KSM, 0)],
             punishment_delay: 8,
             system_collateral_ceiling: iter_currency_pairs().map(|pair| (pair, FUND_LIMIT_CEILING)).collect(),
             secure_collateral_threshold: iter_currency_pairs()
@@ -1396,7 +1398,7 @@ impl ExtBuilder {
             .dispatch(root()));
             assert_ok!(Call::Oracle(OracleCall::feed_values {
                 values: vec![
-                    (OracleKey::ExchangeRate(Token(DOT)), FixedU128::from(1)),
+                    (OracleKey::ExchangeRate(CurrencyId::DOT), FixedU128::from(1)),
                     (OracleKey::FeeEstimation, FixedU128::from(3)),
                 ]
             })
@@ -1429,9 +1431,9 @@ impl ExtBuilder {
 }
 
 pub const fn wrapped(amount: u128) -> Amount<Runtime> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, INTERBTC)
 }
 
 pub const fn griefing(amount: u128) -> Amount<Runtime> {
-    Amount::new(amount, Token(DOT))
+    Amount::new(amount, DOT)
 }

--- a/standalone/runtime/tests/test_annuity.rs
+++ b/standalone/runtime/tests/test_annuity.rs
@@ -6,7 +6,7 @@ use mock::{assert_eq, *};
 type AnnuityPallet = annuity::Pallet<Runtime, VaultAnnuityInstance>;
 type AnnuityEvent = annuity::Event<Runtime, VaultAnnuityInstance>;
 
-const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
+const NATIVE_CURRENCY_ID: CurrencyId = INTR;
 
 fn get_last_reward() -> u128 {
     SystemPallet::events()

--- a/standalone/runtime/tests/test_fee_pool.rs
+++ b/standalone/runtime/tests/test_fee_pool.rs
@@ -46,12 +46,12 @@ fn test_with<R>(execute: impl Fn(CurrencyId) -> R) {
     let test_with = |currency_id| {
         ExtBuilder::build().execute_with(|| execute(currency_id));
     };
-    test_with(Token(KSM));
-    test_with(Token(DOT));
+    test_with(CurrencyId::KSM);
+    test_with(CurrencyId::DOT);
 }
 
 fn withdraw_vault_global_pool_rewards(vault_id: &VaultId) -> i128 {
-    let amount = VaultRewardsPallet::compute_reward(Token(INTERBTC), vault_id).unwrap();
+    let amount = VaultRewardsPallet::compute_reward(INTERBTC, vault_id).unwrap();
     assert_ok!(Call::Fee(FeeCall::withdraw_rewards {
         vault_id: vault_id.clone(),
         index: None
@@ -72,7 +72,7 @@ fn withdraw_local_pool_rewards(vault_id: &VaultId, nominator_id: &AccountId) -> 
 }
 
 fn get_vault_global_pool_rewards(vault_id: &VaultId) -> i128 {
-    VaultRewardsPallet::compute_reward(Token(INTERBTC), vault_id).unwrap()
+    VaultRewardsPallet::compute_reward(INTERBTC, vault_id).unwrap()
 }
 
 fn get_local_pool_rewards(vault_id: &VaultId, nominator_id: &AccountId) -> i128 {

--- a/standalone/runtime/tests/test_governance.rs
+++ b/standalone/runtime/tests/test_governance.rs
@@ -28,8 +28,8 @@ type TreasuryPallet = pallet_treasury::Pallet<Runtime>;
 
 type VestingCall = orml_vesting::Call<Runtime>;
 
-const COLLATERAL_CURRENCY_ID: CurrencyId = Token(DOT);
-const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
+const COLLATERAL_CURRENCY_ID: CurrencyId = CurrencyId::DOT;
+const NATIVE_CURRENCY_ID: CurrencyId = CurrencyId::INTR;
 const INITIAL_VOTING_POWER: u128 = 5_000_000_000_000;
 
 fn get_max_locked(account_id: AccountId) -> Balance {

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -12,7 +12,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
             for currency_id in iter_collateral_currencies() {
                 assert_ok!(OraclePallet::_set_exchange_rate(currency_id, FixedU128::one()));
             }
-            if wrapped_id != Token(INTERBTC) {
+            if wrapped_id != INTERBTC {
                 assert_ok!(OraclePallet::_set_exchange_rate(wrapped_id, FixedU128::one()));
             }
             UserData::force_to(USER, default_user_state());
@@ -22,9 +22,9 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
             execute(vault_id)
         });
     };
-    test_with(Token(DOT), Token(KBTC));
-    test_with(Token(KSM), Token(INTERBTC));
-    test_with(Token(DOT), Token(INTERBTC));
+    test_with(CurrencyId::DOT, CurrencyId::KBTC);
+    test_with(CurrencyId::KSM, CurrencyId::INTERBTC);
+    test_with(CurrencyId::DOT, CurrencyId::INTERBTC);
 }
 
 fn test_with_initialized_vault<R>(execute: impl Fn(VaultId) -> R) {
@@ -33,10 +33,10 @@ fn test_with_initialized_vault<R>(execute: impl Fn(VaultId) -> R) {
 
         // register a second vault with another currency id
         let mut other_vault = vault_id.clone();
-        other_vault.currencies.collateral = if let Token(DOT) = vault_id.collateral_currency() {
-            Token(KSM)
+        other_vault.currencies.collateral = if let CurrencyId::DOT = vault_id.collateral_currency() {
+            CurrencyId::KSM
         } else {
-            Token(DOT)
+            CurrencyId::DOT
         };
         CoreVaultData::force_to(&other_vault, default_vault_state(&other_vault));
 
@@ -427,8 +427,8 @@ mod request_issue_tests {
             let griefing_collateral = griefing(100);
 
             let different_collateral = match vault_id.currencies.collateral {
-                Token(KSM) => Token(DOT),
-                _ => Token(KSM),
+                CurrencyId::KSM => CurrencyId::DOT,
+                _ => CurrencyId::KSM,
             };
             let different_collateral_vault_id = PrimitiveVaultId::new(
                 vault_id.account_id.clone(),

--- a/standalone/runtime/tests/test_multisig.rs
+++ b/standalone/runtime/tests/test_multisig.rs
@@ -15,7 +15,7 @@ fn integration_test_multisig_transfer() {
         // step 0: clear eve's balance for easier testing
         assert_ok!(Call::Tokens(TokensCall::set_balance {
             who: account_of(EVE),
-            currency_id: Token(DOT),
+            currency_id: DOT,
             new_free: 0,
             new_reserved: 0,
         })
@@ -25,7 +25,7 @@ fn integration_test_multisig_transfer() {
         let multisig_account = MultiSigPallet::multi_account_id(&vec![account_of(ALICE), account_of(BOB)], 2);
         assert_ok!(Call::Tokens(TokensCall::set_balance {
             who: multisig_account.clone(),
-            currency_id: Token(DOT),
+            currency_id: DOT,
             new_free: 20_000_000_000_001,
             new_reserved: 0,
         })
@@ -34,7 +34,7 @@ fn integration_test_multisig_transfer() {
         // step 2: submit a call, to be executed from the shared account
         let call = Call::Tokens(TokensCall::transfer {
             dest: account_of(EVE),
-            currency_id: Token(DOT),
+            currency_id: DOT,
             amount: 20_000_000_000_001,
         })
         .encode();
@@ -78,7 +78,7 @@ fn integration_test_multisig_vesting() {
         // vested transfer takes free balance of caller
         assert_ok!(Call::Tokens(TokensCall::set_balance {
             who: multisig_account.clone(),
-            currency_id: Token(INTR),
+            currency_id: INTR,
             new_free: vesting_amount,
             new_reserved: 0,
         })
@@ -117,7 +117,7 @@ fn integration_test_multisig_vesting() {
 
         // max amount should be locked in vesting
         assert_eq!(
-            TokensPallet::locks(&account_of(EVE), Token(INTR))
+            TokensPallet::locks(&account_of(EVE), INTR)
                 .iter()
                 .map(|balance_lock| balance_lock.amount)
                 .max()
@@ -149,7 +149,7 @@ fn integration_test_batched_multisig_vesting() {
         // vested transfer takes free balance of caller
         assert_ok!(Call::Tokens(TokensCall::set_balance {
             who: multisig_account.clone(),
-            currency_id: Token(INTR),
+            currency_id: INTR,
             new_free: vesting_amounts.iter().sum(),
             new_reserved: 0,
         })
@@ -196,7 +196,7 @@ fn integration_test_batched_multisig_vesting() {
         // max amount should be locked in vesting
         for (account, vesting_amount) in accounts.iter().zip(vesting_amounts) {
             assert_eq!(
-                TokensPallet::locks(&account, Token(INTR))
+                TokensPallet::locks(&account, INTR)
                     .iter()
                     .map(|balance_lock| balance_lock.amount)
                     .max()

--- a/standalone/runtime/tests/test_nomination.rs
+++ b/standalone/runtime/tests/test_nomination.rs
@@ -12,7 +12,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
             for currency_id in iter_collateral_currencies() {
                 assert_ok!(OraclePallet::_set_exchange_rate(currency_id, FixedU128::one()));
             }
-            if wrapped_id != Token(INTERBTC) {
+            if wrapped_id != INTERBTC {
                 assert_ok!(OraclePallet::_set_exchange_rate(wrapped_id, FixedU128::one()));
             }
             UserData::force_to(USER, default_user_state());
@@ -23,9 +23,9 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
             execute(vault_id)
         });
     };
-    test_with(Token(DOT), Token(KBTC));
-    test_with(Token(KSM), Token(INTERBTC));
-    test_with(Token(DOT), Token(INTERBTC));
+    test_with(CurrencyId::DOT, CurrencyId::KBTC);
+    test_with(CurrencyId::KSM, CurrencyId::INTERBTC);
+    test_with(CurrencyId::DOT, CurrencyId::INTERBTC);
 }
 
 fn test_with_nomination_enabled<R>(execute: impl Fn(VaultId) -> R) {
@@ -78,7 +78,7 @@ mod spec_based_tests {
 
     fn nomination_with_non_running_status_fails(status: StatusCode) {
         SecurityPallet::set_status(status);
-        let vault_id = vault_id_of(VAULT, Token(DOT));
+        let vault_id = vault_id_of(VAULT, DOT);
         assert_noop!(
             Call::Nomination(NominationCall::opt_in_to_nomination {
                 currency_pair: vault_id.currencies.clone()
@@ -156,11 +156,11 @@ mod spec_based_tests {
         //   - A Vault with id `vaultId` MUST exist in the Vaults mapping.
         test_with(|_| {
             assert_noop!(
-                nomination_opt_out(&vault_id_of(USER, Token(DOT))),
+                nomination_opt_out(&vault_id_of(USER, DOT)),
                 NominationError::VaultNotOptedInToNomination
             );
             assert_noop!(
-                nomination_opt_out(&vault_id_of(VAULT, Token(DOT))),
+                nomination_opt_out(&vault_id_of(VAULT, DOT)),
                 NominationError::VaultNotOptedInToNomination
             );
         })
@@ -174,8 +174,8 @@ mod spec_based_tests {
         //   - `get_total_nominated_collateral(vault_id)` must return zero.
         //   - For all nominators, `get_nominator_collateral(vault_id, user_id)` must return zero.
         //   - Staking pallet `nonce` must be incremented by one.
-        //   - `compute_reward_at_index(nonce - 1, Token(INTERBTC), vault_id, user_id)` in the Staking pallet must be
-        //     equal to the user’s nomination just before the vault opted out.
+        //   - `compute_reward_at_index(nonce - 1, INTERBTC, vault_id, user_id)` in the Staking pallet must be equal to
+        //     the user’s nomination just before the vault opted out.
         test_with_nomination_enabled_and_vault_opted_in(|vault_id| {
             assert_nominate_collateral(&vault_id, account_of(USER), default_nomination(&vault_id));
             assert_eq!(

--- a/standalone/runtime/tests/test_redeem.rs
+++ b/standalone/runtime/tests/test_redeem.rs
@@ -11,7 +11,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
             let vault_id = PrimitiveVaultId::new(account_of(VAULT), collateral_id, wrapped_id);
             SecurityPallet::set_active_block_number(1);
             assert_ok!(OraclePallet::_set_exchange_rate(collateral_id, FixedU128::one()));
-            if wrapped_id != Token(INTERBTC) {
+            if wrapped_id != INTERBTC {
                 assert_ok!(OraclePallet::_set_exchange_rate(wrapped_id, FixedU128::one()));
             }
             set_default_thresholds();
@@ -33,10 +33,10 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
         })
     };
 
-    test_with(Token(DOT), Token(KBTC), None);
-    test_with(Token(DOT), Token(INTERBTC), None);
-    test_with(Token(DOT), Token(INTERBTC), Some(Token(KSM)));
-    test_with(Token(KSM), Token(INTERBTC), None);
+    test_with(CurrencyId::DOT, CurrencyId::KBTC, None);
+    test_with(CurrencyId::DOT, CurrencyId::INTERBTC, None);
+    test_with(CurrencyId::DOT, CurrencyId::INTERBTC, Some(CurrencyId::KSM));
+    test_with(CurrencyId::KSM, CurrencyId::INTERBTC, None);
 }
 
 /// to-be-replaced & replace_collateral are decreased in request_redeem
@@ -431,8 +431,8 @@ mod spec_based_tests {
                 let amount_btc = vault_id.wrapped(10000);
 
                 let different_collateral = match vault_id.currencies.collateral {
-                    Token(KSM) => Token(DOT),
-                    _ => Token(KSM),
+                    CurrencyId::KSM => CurrencyId::DOT,
+                    _ => CurrencyId::KSM,
                 };
                 assert_ok!(OraclePallet::_set_exchange_rate(different_collateral, FixedU128::one()));
 
@@ -1166,10 +1166,10 @@ mod spec_based_tests {
                     Call::Redeem(RedeemCall::mint_tokens_for_reimbursed_redeem {
                         currency_pair: VaultCurrencyPair {
                             collateral: vault_id.currencies.collateral,
-                            wrapped: if vault_id.currencies.wrapped == Token(DOT) {
-                                Token(INTERBTC)
+                            wrapped: if vault_id.currencies.wrapped == DOT {
+                                INTERBTC
                             } else {
-                                Token(DOT)
+                                DOT
                             },
                         },
                         redeem_id: redeem_id

--- a/standalone/runtime/tests/test_refund.rs
+++ b/standalone/runtime/tests/test_refund.rs
@@ -11,7 +11,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
             for currency_id in iter_collateral_currencies() {
                 assert_ok!(OraclePallet::_set_exchange_rate(currency_id, FixedU128::one()));
             }
-            if wrapped_currency != Token(INTERBTC) {
+            if wrapped_currency != INTERBTC {
                 assert_ok!(OraclePallet::_set_exchange_rate(wrapped_currency, FixedU128::one()));
             }
             let vault_id = VaultId::new(account_of(BOB), collateral_currency, wrapped_currency);
@@ -19,9 +19,9 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
             execute(vault_id)
         });
     };
-    test_with(Token(KSM), Token(INTERBTC));
-    test_with(Token(DOT), Token(INTERBTC));
-    test_with(Token(DOT), Token(KBTC));
+    test_with(CurrencyId::KSM, CurrencyId::INTERBTC);
+    test_with(CurrencyId::DOT, CurrencyId::INTERBTC);
+    test_with(CurrencyId::DOT, CurrencyId::KBTC);
 }
 
 mod spec_based_tests {

--- a/standalone/runtime/tests/test_relayers.rs
+++ b/standalone/runtime/tests/test_relayers.rs
@@ -18,8 +18,8 @@ fn test_with<R>(execute: impl Fn(CurrencyId) -> R) {
             execute(currency_id)
         })
     };
-    test_with(Token(DOT));
-    test_with(Token(KSM));
+    test_with(CurrencyId::DOT);
+    test_with(CurrencyId::KSM);
 }
 
 fn setup_vault_for_potential_double_spend(
@@ -500,7 +500,7 @@ fn integration_test_relay_parachain_status_check_fails() {
         );
         assert_noop!(
             Call::Relay(RelayCall::report_vault_theft {
-                vault_id: vault_id_of(ALICE, Token(DOT)),
+                vault_id: vault_id_of(ALICE, DOT),
                 raw_merkle_proof: Default::default(),
                 raw_tx: Default::default()
             })

--- a/standalone/runtime/tests/test_vault_registry.rs
+++ b/standalone/runtime/tests/test_vault_registry.rs
@@ -13,7 +13,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
             for currency_id in iter_collateral_currencies() {
                 assert_ok!(OraclePallet::_set_exchange_rate(currency_id, FixedU128::one()));
             }
-            if wrapped_id != Token(INTERBTC) {
+            if wrapped_id != INTERBTC {
                 assert_ok!(OraclePallet::_set_exchange_rate(wrapped_id, FixedU128::one()));
             }
             UserData::force_to(USER, default_user_state());
@@ -24,9 +24,9 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
             execute(vault_id)
         });
     };
-    test_with(Token(DOT), Token(KBTC));
-    test_with(Token(KSM), Token(INTERBTC));
-    test_with(Token(DOT), Token(INTERBTC));
+    test_with(CurrencyId::DOT, CurrencyId::KBTC);
+    test_with(CurrencyId::KSM, CurrencyId::INTERBTC);
+    test_with(CurrencyId::DOT, CurrencyId::INTERBTC);
 }
 
 mod deposit_collateral_test {

--- a/standalone/src/chain_spec.rs
+++ b/standalone/src/chain_spec.rs
@@ -1,10 +1,10 @@
 use bitcoin::utils::{virtual_transaction_size, InputType, TransactionInputMetadata, TransactionOutputMetadata};
 use hex_literal::hex;
 use interbtc_runtime::{
-    AccountId, AuraConfig, BTCRelayConfig, CurrencyId, CurrencyId::Token, FeeConfig, GenesisConfig,
-    GetWrappedCurrencyId, GrandpaConfig, IssueConfig, NominationConfig, OracleConfig, RedeemConfig, RefundConfig,
-    ReplaceConfig, SecurityConfig, Signature, StatusCode, SudoConfig, SystemConfig, TechnicalCommitteeConfig,
-    TokenSymbol, TokensConfig, VaultRegistryConfig, BITCOIN_BLOCK_SPACING, DAYS, DOT, INTR, KINT, KSM, WASM_BINARY,
+    AccountId, AuraConfig, BTCRelayConfig, CurrencyId, FeeConfig, GenesisConfig, GetWrappedCurrencyId, GrandpaConfig,
+    IssueConfig, NominationConfig, OracleConfig, RedeemConfig, RefundConfig, ReplaceConfig, SecurityConfig, Signature,
+    StatusCode, SudoConfig, SystemConfig, TechnicalCommitteeConfig, TokensConfig, VaultRegistryConfig,
+    BITCOIN_BLOCK_SPACING, DAYS, DOT, INTR, KINT, KSM, WASM_BINARY,
 };
 use primitives::VaultCurrencyPair;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -53,7 +53,7 @@ fn get_properties() -> Map<String, Value> {
     let mut properties = Map::new();
     let mut token_symbol: Vec<String> = vec![];
     let mut token_decimals: Vec<u32> = vec![];
-    TokenSymbol::get_info().iter().for_each(|(symbol_name, decimals)| {
+    CurrencyId::get_info().iter().for_each(|(symbol_name, decimals)| {
         token_symbol.push(symbol_name.to_string());
         token_decimals.push(*decimals);
     });
@@ -273,10 +273,10 @@ fn testnet_genesis(
                 .iter()
                 .flat_map(|k| {
                     vec![
-                        (k.clone(), Token(DOT), 1 << 60),
-                        (k.clone(), Token(INTR), 1 << 60),
-                        (k.clone(), Token(KSM), 1 << 60),
-                        (k.clone(), Token(KINT), 1 << 60),
+                        (k.clone(), DOT, 1 << 60),
+                        (k.clone(), INTR, 1 << 60),
+                        (k.clone(), KSM, 1 << 60),
+                        (k.clone(), KINT, 1 << 60),
                     ]
                 })
                 .collect(),
@@ -306,41 +306,41 @@ fn testnet_genesis(
             replace_btc_dust_value: 1000,
         },
         vault_registry: VaultRegistryConfig {
-            minimum_collateral_vault: vec![(Token(DOT), 0), (Token(KSM), 0)],
+            minimum_collateral_vault: vec![(CurrencyId::DOT, 0), (CurrencyId::KSM, 0)],
             punishment_delay: DAYS,
             secure_collateral_threshold: vec![
                 (
-                    default_pair(Token(DOT)),
+                    default_pair(CurrencyId::DOT),
                     FixedU128::checked_from_rational(150, 100).unwrap(),
                 ),
                 (
-                    default_pair(Token(KSM)),
+                    default_pair(CurrencyId::KSM),
                     FixedU128::checked_from_rational(150, 100).unwrap(),
                 ),
             ], /* 150% */
             premium_redeem_threshold: vec![
                 (
-                    default_pair(Token(DOT)),
+                    default_pair(CurrencyId::DOT),
                     FixedU128::checked_from_rational(135, 100).unwrap(),
                 ),
                 (
-                    default_pair(Token(KSM)),
+                    default_pair(CurrencyId::KSM),
                     FixedU128::checked_from_rational(135, 100).unwrap(),
                 ),
             ], /* 135% */
             liquidation_collateral_threshold: vec![
                 (
-                    default_pair(Token(DOT)),
+                    default_pair(CurrencyId::DOT),
                     FixedU128::checked_from_rational(110, 100).unwrap(),
                 ),
                 (
-                    default_pair(Token(KSM)),
+                    default_pair(CurrencyId::KSM),
                     FixedU128::checked_from_rational(110, 100).unwrap(),
                 ),
             ], /* 110% */
             system_collateral_ceiling: vec![
-                (default_pair(Token(DOT)), 1000 * DOT.one()),
-                (default_pair(Token(KSM)), 1000 * KSM.one()),
+                (default_pair(CurrencyId::DOT), 1000 * CurrencyId::DOT.one()),
+                (default_pair(CurrencyId::KSM), 1000 * CurrencyId::KSM.one()),
             ],
         },
         fee: FeeConfig {


### PR DESCRIPTION
The currencyId change would break Token storage, so we revert it for now. In draft now because I want to double check if can't do a proper migration