### PR TITLE
feat: add orml-xcm pallet to send xcm message with sovereign account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,6 +3496,7 @@ dependencies = [
  "orml-traits",
  "orml-unknown-tokens",
  "orml-vesting",
+ "orml-xcm",
  "orml-xcm-support",
  "orml-xtokens",
  "pallet-aura",
@@ -3944,6 +3945,7 @@ dependencies = [
  "orml-traits",
  "orml-unknown-tokens",
  "orml-vesting",
+ "orml-xcm",
  "orml-xcm-support",
  "orml-xtokens",
  "pallet-aura",
@@ -5704,6 +5706,20 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+]
+
+[[package]]
+name = "orml-xcm"
+version = "0.4.1-dev"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=1f520348f31b5e94b8a5dd7f8e6b8ec359df4177#1f520348f31b5e94b8a5dd7f8e6b8ec359df4177"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-xcm",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-std",
+ "xcm",
 ]
 
 [[package]]
@@ -11458,6 +11474,7 @@ dependencies = [
  "orml-traits",
  "orml-unknown-tokens",
  "orml-vesting",
+ "orml-xcm",
  "orml-xcm-support",
  "orml-xtokens",
  "pallet-aura",
@@ -11779,7 +11796,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "regex",
  "serde",
  "serde_json",
@@ -11899,8 +11916,8 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.4",
+ "cfg-if 0.1.10",
+ "rand 0.6.5",
  "static_assertions",
 ]
 

--- a/parachain/runtime/interlay/Cargo.toml
+++ b/parachain/runtime/interlay/Cargo.toml
@@ -112,6 +112,7 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -66,10 +66,8 @@ use orml_xcm_support::{IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset}
 use pallet_xcm::{EnsureXcm, IsMajorityOfBody, XcmPassthrough};
 use polkadot_parachain::primitives::Sibling;
 use sp_runtime::traits::Convert;
-use xcm::{
-    v1::{prelude::*, MultiAsset, MultiLocation, NetworkId},
-    AlwaysV1,
-};
+use xcm::latest::prelude::*;
+
 use xcm_builder::{
     AccountId32Aliases, AllowTopLevelPaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds, LocationInverter,
     NativeAsset, ParentAsSuperuser, ParentIsDefault, RelayChainAsNative, SiblingParachainAsNative,
@@ -671,7 +669,7 @@ pub type LocalOriginToLocation = (SignedToAccountId32<Origin, AccountId, ParentN
 /// queues.
 pub type XcmRouter = (
     // Two routers - use UMP to communicate with the relay chain:
-    cumulus_primitives_utility::ParentAsUmp<ParachainSystem, AlwaysV1>,
+    cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm>,
     // ..and XCMP to communicate with the sibling chains.
     XcmpQueue,
 );
@@ -702,7 +700,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type Event = Event;
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type ChannelInfo = ParachainSystem;
-    type VersionWrapper = AlwaysV1;
+    type VersionWrapper = PolkadotXcm;
 }
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {
@@ -1161,6 +1159,11 @@ impl nomination::Config for Runtime {
     type WeightInfo = ();
 }
 
+impl orml_xcm::Config for Runtime {
+    type Event = Event;
+    type SovereignOrigin = EnsureRoot;
+}
+
 construct_runtime! {
     pub enum Runtime where
         Block = Block,
@@ -1224,6 +1227,7 @@ construct_runtime! {
         XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>},
         PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin},
+        OrmlXcm: orml_xcm::{Pallet, Call, Event<T>},
         DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>},
 
         XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},

--- a/parachain/runtime/kintsugi/Cargo.toml
+++ b/parachain/runtime/kintsugi/Cargo.toml
@@ -109,6 +109,7 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -67,10 +67,8 @@ use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use sp_runtime::{traits::Convert, FixedPointNumber, Perquintill};
-use xcm::{
-    v1::{prelude::*, MultiAsset, MultiLocation, NetworkId},
-    AlwaysV1,
-};
+use xcm::latest::prelude::*;
+
 use xcm_builder::{
     AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom,
     EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, LocationInverter, NativeAsset, ParentAsSuperuser,
@@ -693,7 +691,7 @@ pub type LocalOriginToLocation = (SignedToAccountId32<Origin, AccountId, ParentN
 /// queues.
 pub type XcmRouter = (
     // Two routers - use UMP to communicate with the relay chain:
-    cumulus_primitives_utility::ParentAsUmp<ParachainSystem, AlwaysV1>,
+    cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm>,
     // ..and XCMP to communicate with the sibling chains.
     XcmpQueue,
 );
@@ -724,7 +722,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type Event = Event;
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type ChannelInfo = ParachainSystem;
-    type VersionWrapper = AlwaysV1;
+    type VersionWrapper = PolkadotXcm;
 }
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {
@@ -744,6 +742,11 @@ pub type LocalAssetTransactor = MultiCurrencyAdapter<
 >;
 
 pub use currency_id_convert::CurrencyIdConvert;
+
+impl orml_xcm::Config for Runtime {
+    type Event = Event;
+    type SovereignOrigin = EnsureRoot;
+}
 
 mod currency_id_convert {
     use super::*;
@@ -1246,6 +1249,7 @@ construct_runtime! {
         XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>},
         PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin},
+        OrmlXcm: orml_xcm::{Pallet, Call, Event<T>},
         DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>},
 
         XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},

--- a/parachain/runtime/testnet/Cargo.toml
+++ b/parachain/runtime/testnet/Cargo.toml
@@ -112,6 +112,7 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "1f520348f31b5e94b8a5dd7f8e6b8ec359df4177", default-features = false }
 

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -67,10 +67,8 @@ use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use pallet_xcm::{EnsureXcm, IsMajorityOfBody, XcmPassthrough};
 use polkadot_parachain::primitives::Sibling;
 use sp_runtime::{traits::Convert, FixedPointNumber, Perquintill};
-use xcm::{
-    v1::{prelude::*, MultiAsset, MultiLocation, NetworkId},
-    AlwaysV1,
-};
+use xcm::latest::prelude::*;
+
 use xcm_builder::{
     AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom,
     EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, LocationInverter, NativeAsset, ParentAsSuperuser,
@@ -732,7 +730,7 @@ pub type LocalOriginToLocation = (SignedToAccountId32<Origin, AccountId, ParentN
 /// queues.
 pub type XcmRouter = (
     // Two routers - use UMP to communicate with the relay chain:
-    cumulus_primitives_utility::ParentAsUmp<ParachainSystem, AlwaysV1>,
+    cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm>,
     // ..and XCMP to communicate with the sibling chains.
     XcmpQueue,
 );
@@ -763,7 +761,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type Event = Event;
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type ChannelInfo = ParachainSystem;
-    type VersionWrapper = AlwaysV1;
+    type VersionWrapper = PolkadotXcm;
 }
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {
@@ -1222,6 +1220,11 @@ impl nomination::Config for Runtime {
     type WeightInfo = ();
 }
 
+impl orml_xcm::Config for Runtime {
+    type Event = Event;
+    type SovereignOrigin = EnsureRoot;
+}
+
 construct_runtime! {
     pub enum Runtime where
         Block = Block,
@@ -1285,6 +1288,7 @@ construct_runtime! {
         XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>},
         PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin},
+        OrmlXcm: orml_xcm::{Pallet, Call, Event<T>},
         DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>},
 
         XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},


### PR DESCRIPTION
We need to omrl-xcm pallet to be able to send messages to the relay chain that originate from the parachain's sovereign account. This is required for opening hrmp channels.

Also let PolkadotXcm pallet be in charge of deciding xcm versions (like acala)