### PR TITLE
refactor: harmonize currency-ids and add consts to currency pallet

### DIFF
--- a/crates/currency/src/lib.rs
+++ b/crates/currency/src/lib.rs
@@ -73,7 +73,15 @@ pub mod pallet {
             + Default
             + Debug;
 
-        /// Wrapped currency: INTERBTC.
+        /// Native currency e.g. INTR/KINT
+        #[pallet::constant]
+        type GetNativeCurrencyId: Get<CurrencyId<Self>>;
+
+        /// Relay chain currency e.g. DOT/KSM
+        #[pallet::constant]
+        type GetRelayChainCurrencyId: Get<CurrencyId<Self>>;
+
+        /// Wrapped currency e.g. INTERBTC/KBTC
         #[pallet::constant]
         type GetWrappedCurrencyId: Get<CurrencyId<Self>>;
 
@@ -90,6 +98,22 @@ pub mod pallet {
 
     #[pallet::pallet]
     pub struct Pallet<T>(_);
+}
+
+pub mod getters {
+    use super::*;
+
+    pub fn get_relay_chain_currency_id<T: Config>() -> CurrencyId<T> {
+        <T as Config>::GetRelayChainCurrencyId::get()
+    }
+
+    pub fn get_native_currency_id<T: Config>() -> CurrencyId<T> {
+        <T as Config>::GetNativeCurrencyId::get()
+    }
+
+    pub fn get_wrapped_currency_id<T: Config>() -> CurrencyId<T> {
+        <T as Config>::GetWrappedCurrencyId::get()
+    }
 }
 
 pub fn get_free_balance<T: Config>(currency_id: T::CurrencyId, account: &T::AccountId) -> Amount<T> {

--- a/crates/currency/src/mock.rs
+++ b/crates/currency/src/mock.rs
@@ -69,7 +69,8 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
+    pub const GetNativeCurrencyId: CurrencyId = Token(INTR);
+    pub const GetRelayChainCurrencyId: CurrencyId = Token(DOT);
     pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
     pub const MaxLocks: u32 = 50;
 }
@@ -107,6 +108,8 @@ impl crate::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetRelayChainCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }

--- a/crates/fee/src/lib.rs
+++ b/crates/fee/src/lib.rs
@@ -112,9 +112,6 @@ pub mod pallet {
 
         /// Handler to transfer undistributed rewards.
         type OnSweep: OnSweep<Self::AccountId, Amount<Self>>;
-
-        #[pallet::constant]
-        type GetNativeCurrencyId: Get<Self::CurrencyId>;
     }
 
     #[pallet::error]

--- a/crates/fee/src/mock.rs
+++ b/crates/fee/src/mock.rs
@@ -80,9 +80,9 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
+    pub const GetNativeCurrencyId: CurrencyId = Token(INTR);
+    pub const GetRelayChainCurrencyId: CurrencyId = Token(DOT);
     pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
     pub const MaxLocks: u32 = 50;
 }
 
@@ -151,6 +151,8 @@ impl currency::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetRelayChainCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -169,7 +171,6 @@ impl Config for Test {
     type VaultRewards = Rewards;
     type VaultStaking = Staking;
     type OnSweep = ();
-    type GetNativeCurrencyId = GetNativeCurrencyId;
 }
 
 pub type TestEvent = Event;

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -20,11 +20,11 @@ fn dummy_merkle_proof() -> MerkleProof {
 }
 
 fn griefing(amount: u128) -> Amount<Test> {
-    Amount::new(amount, GRIEFING_CURRENCY)
+    Amount::new(amount, DEFAULT_NATIVE_CURRENCY)
 }
 
 fn wrapped(amount: u128) -> Amount<Test> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, DEFAULT_WRAPPED_CURRENCY)
 }
 
 fn request_issue(
@@ -74,7 +74,7 @@ fn get_dummy_request_id() -> H256 {
 fn test_request_issue_banned_fails() {
     run_test(|| {
         assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(
-            DEFAULT_TESTING_CURRENCY,
+            DEFAULT_COLLATERAL_CURRENCY,
             FixedU128::one()
         ));
         <vault_registry::Pallet<Test>>::insert_vault(

--- a/crates/nomination/src/mock.rs
+++ b/crates/nomination/src/mock.rs
@@ -90,17 +90,19 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_COLLATERAL_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_NATIVE_CURRENCY: CurrencyId = Token(INTR);
 pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
-    collateral: DEFAULT_TESTING_CURRENCY,
+    collateral: DEFAULT_COLLATERAL_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DEFAULT_COLLATERAL_CURRENCY;
+    pub const GetNativeCurrencyId: CurrencyId = DEFAULT_NATIVE_CURRENCY;
+    pub const GetWrappedCurrencyId: CurrencyId = DEFAULT_WRAPPED_CURRENCY;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -148,7 +150,7 @@ impl vault_registry::Config for Test {
     type Event = TestEvent;
     type Balance = Balance;
     type WeightInfo = ();
-    type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
+    type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
 }
 
 pub struct CurrencyConvert;
@@ -172,6 +174,8 @@ impl currency::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetCollateralCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -212,7 +216,6 @@ impl fee::Config for Test {
     type UnsignedInner = UnsignedInner;
     type VaultRewards = Rewards;
     type VaultStaking = Staking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = ();
 }
 
@@ -232,14 +235,14 @@ pub type TestError = Error<Test>;
 pub const ALICE: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 1,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
 pub const BOB: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 2,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
@@ -281,7 +284,7 @@ impl ExtBuilder {
         .unwrap();
 
         vault_registry::GenesisConfig::<Test> {
-            minimum_collateral_vault: vec![(DEFAULT_TESTING_CURRENCY, 0)],
+            minimum_collateral_vault: vec![(DEFAULT_COLLATERAL_CURRENCY, 0)],
             punishment_delay: 8,
             system_collateral_ceiling: vec![(DEFAULT_CURRENCY_PAIR, 1_000_000_000_000)],
             secure_collateral_threshold: vec![(
@@ -322,7 +325,7 @@ where
     clear_mocks();
     ExtBuilder::build().execute_with(|| {
         assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(
-            DEFAULT_TESTING_CURRENCY,
+            DEFAULT_COLLATERAL_CURRENCY,
             UnsignedFixedPoint::one()
         ));
         Security::set_active_block_number(1);

--- a/crates/nomination/src/tests.rs
+++ b/crates/nomination/src/tests.rs
@@ -13,7 +13,7 @@ fn should_not_deposit_against_invalid_vault() {
     })
 }
 fn collateral(amount: u128) -> Amount<Test> {
-    Amount::new(amount, DEFAULT_TESTING_CURRENCY)
+    Amount::new(amount, DEFAULT_COLLATERAL_CURRENCY)
 }
 
 #[test]

--- a/crates/oracle/src/mock.rs
+++ b/crates/oracle/src/mock.rs
@@ -78,10 +78,14 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
+pub const DEFAULT_COLLATERAL_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_NATIVE_CURRENCY: CurrencyId = Token(INTR);
+pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DEFAULT_COLLATERAL_CURRENCY;
+    pub const GetNativeCurrencyId: CurrencyId = DEFAULT_NATIVE_CURRENCY;
+    pub const GetWrappedCurrencyId: CurrencyId = DEFAULT_WRAPPED_CURRENCY;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -118,6 +122,8 @@ impl currency::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetCollateralCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -91,18 +91,19 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(INTERBTC);
+pub const DEFAULT_COLLATERAL_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_NATIVE_CURRENCY: CurrencyId = Token(INTR);
+pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
-    collateral: DEFAULT_TESTING_CURRENCY,
+    collateral: DEFAULT_COLLATERAL_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
-pub const GRIEFING_CURRENCY: CurrencyId = Token(DOT);
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DEFAULT_COLLATERAL_CURRENCY;
+    pub const GetNativeCurrencyId: CurrencyId = DEFAULT_NATIVE_CURRENCY;
+    pub const GetWrappedCurrencyId: CurrencyId = DEFAULT_WRAPPED_CURRENCY;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -141,7 +142,7 @@ impl vault_registry::Config for Test {
     type Event = TestEvent;
     type Balance = Balance;
     type WeightInfo = ();
-    type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
+    type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
 }
 
 pub struct CurrencyConvert;
@@ -165,6 +166,8 @@ impl currency::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetCollateralCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -229,7 +232,6 @@ impl fee::Config for Test {
     type UnsignedInner = UnsignedInner;
     type VaultRewards = Rewards;
     type VaultStaking = Staking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = ();
 }
 
@@ -246,7 +248,7 @@ pub const USER: AccountId = 1;
 pub const VAULT: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 2,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
@@ -279,7 +281,7 @@ impl ExtBuilder {
         .unwrap();
 
         vault_registry::GenesisConfig::<Test> {
-            minimum_collateral_vault: vec![(DEFAULT_TESTING_CURRENCY, 0)],
+            minimum_collateral_vault: vec![(DEFAULT_COLLATERAL_CURRENCY, 0)],
             punishment_delay: 8,
             system_collateral_ceiling: vec![(DEFAULT_CURRENCY_PAIR, 1_000_000_000_000)],
             secure_collateral_threshold: vec![(

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -13,13 +13,13 @@ use vault_registry::{DefaultVault, VaultStatus, Wallet};
 type Event = crate::Event<Test>;
 
 fn collateral(amount: u128) -> Amount<Test> {
-    Amount::new(amount, DEFAULT_TESTING_CURRENCY)
+    Amount::new(amount, DEFAULT_COLLATERAL_CURRENCY)
 }
 fn griefing(amount: u128) -> Amount<Test> {
-    Amount::new(amount, GRIEFING_CURRENCY)
+    Amount::new(amount, DEFAULT_NATIVE_CURRENCY)
 }
 fn wrapped(amount: u128) -> Amount<Test> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, DEFAULT_WRAPPED_CURRENCY)
 }
 
 macro_rules! assert_emitted {

--- a/crates/refund/src/benchmarking.rs
+++ b/crates/refund/src/benchmarking.rs
@@ -7,10 +7,11 @@ use bitcoin::{
     },
 };
 use btc_relay::{BtcAddress, BtcPublicKey};
+use currency::getters::{get_relay_chain_currency_id as get_collateral_currency_id, *};
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
-use frame_support::{assert_ok, traits::Get};
+use frame_support::assert_ok;
 use frame_system::RawOrigin;
-use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultId};
+use primitives::VaultId;
 use sp_core::{H160, H256, U256};
 use sp_runtime::traits::One;
 use sp_std::prelude::*;
@@ -22,8 +23,6 @@ use btc_relay::Pallet as BtcRelay;
 use oracle::Pallet as Oracle;
 use security::Pallet as Security;
 use vault_registry::Pallet as VaultRegistry;
-
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
 
 type UnsignedFixedPoint<T> = <T as currency::Config>::UnsignedFixedPoint;
 
@@ -39,8 +38,8 @@ benchmarks! {
         let origin: T::AccountId = account("Origin", 0, 0);
         let vault_id: VaultId<T::AccountId, _> = VaultId::new(
             account("Vault", 0, 0),
-            T::GetGriefingCollateralCurrencyId::get(),
-            <T as currency::Config>::GetWrappedCurrencyId::get()
+            get_collateral_currency_id::<T>(),
+            get_wrapped_currency_id::<T>(),
         );
         let relayer_id: T::AccountId = account("Relayer", 0, 0);
 
@@ -122,7 +121,8 @@ benchmarks! {
         Security::<T>::set_active_block_number(Security::<T>::active_block_number() +
         BtcRelay::<T>::parachain_confirmations() + 1u32.into());
 
-        assert_ok!(Oracle::<T>::_set_exchange_rate(DEFAULT_TESTING_CURRENCY,
+        assert_ok!(Oracle::<T>::_set_exchange_rate(
+            get_collateral_currency_id::<T>(),
             UnsignedFixedPoint::<T>::one()
         ));
     }: _(RawOrigin::Signed(vault_id.account_id.clone()), refund_id, proof, raw_tx)

--- a/crates/refund/src/mock.rs
+++ b/crates/refund/src/mock.rs
@@ -20,7 +20,7 @@ use sp_runtime::{
 pub const VAULT: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 1,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
@@ -99,17 +99,19 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_COLLATERAL_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_NATIVE_CURRENCY: CurrencyId = Token(INTR);
 pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
-    collateral: DEFAULT_TESTING_CURRENCY,
+    collateral: DEFAULT_COLLATERAL_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DEFAULT_COLLATERAL_CURRENCY;
+    pub const GetNativeCurrencyId: CurrencyId = DEFAULT_NATIVE_CURRENCY;
+    pub const GetWrappedCurrencyId: CurrencyId = DEFAULT_WRAPPED_CURRENCY;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -158,7 +160,6 @@ impl fee::Config for Test {
     type UnsignedInner = UnsignedInner;
     type VaultRewards = Rewards;
     type VaultStaking = Staking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = ();
 }
 
@@ -193,7 +194,7 @@ impl vault_registry::Config for Test {
     type Event = TestEvent;
     type Balance = Balance;
     type WeightInfo = ();
-    type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
+    type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
 }
 
 pub struct CurrencyConvert;
@@ -217,6 +218,8 @@ impl currency::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetCollateralCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -255,7 +258,7 @@ impl ExtBuilder {
         let mut storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 
         vault_registry::GenesisConfig::<Test> {
-            minimum_collateral_vault: vec![(DEFAULT_TESTING_CURRENCY, 0)],
+            minimum_collateral_vault: vec![(DEFAULT_COLLATERAL_CURRENCY, 0)],
             punishment_delay: 8,
             system_collateral_ceiling: vec![(DEFAULT_CURRENCY_PAIR, 1_000_000_000_000)],
             secure_collateral_threshold: vec![(
@@ -285,7 +288,7 @@ where
     clear_mocks();
     ExtBuilder::build().execute_with(|| {
         assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(
-            DEFAULT_TESTING_CURRENCY,
+            DEFAULT_COLLATERAL_CURRENCY,
             UnsignedFixedPoint::one()
         ));
         System::set_block_number(1);

--- a/crates/relay/src/mock.rs
+++ b/crates/relay/src/mock.rs
@@ -94,17 +94,19 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(DOT);
-pub const DEFAULT_WRAPPED_CURRENCY: <Test as orml_tokens::Config>::CurrencyId = Token(DOT);
+pub const DEFAULT_COLLATERAL_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_NATIVE_CURRENCY: CurrencyId = Token(INTR);
+pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
-    collateral: DEFAULT_TESTING_CURRENCY,
+    collateral: DEFAULT_COLLATERAL_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DEFAULT_COLLATERAL_CURRENCY;
+    pub const GetNativeCurrencyId: CurrencyId = DEFAULT_NATIVE_CURRENCY;
+    pub const GetWrappedCurrencyId: CurrencyId = DEFAULT_WRAPPED_CURRENCY;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -167,7 +169,7 @@ impl vault_registry::Config for Test {
     type Event = TestEvent;
     type Balance = Balance;
     type WeightInfo = ();
-    type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
+    type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
 }
 
 pub struct CurrencyConvert;
@@ -191,6 +193,8 @@ impl currency::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetCollateralCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -221,7 +225,6 @@ impl fee::Config for Test {
     type UnsignedInner = UnsignedInner;
     type VaultRewards = Rewards;
     type VaultStaking = Staking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = ();
 }
 
@@ -268,7 +271,7 @@ pub const ALICE: AccountId = 1;
 pub const BOB: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 2,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
@@ -276,7 +279,7 @@ pub const BOB: VaultId<AccountId, CurrencyId> = VaultId {
 pub const CAROL: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 3,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
@@ -313,7 +316,7 @@ impl ExtBuilder {
         .unwrap();
 
         vault_registry::GenesisConfig::<Test> {
-            minimum_collateral_vault: vec![(DEFAULT_TESTING_CURRENCY, 0)],
+            minimum_collateral_vault: vec![(DEFAULT_COLLATERAL_CURRENCY, 0)],
             punishment_delay: 0,
             system_collateral_ceiling: vec![(DEFAULT_CURRENCY_PAIR, 1_000_000_000_000)],
             secure_collateral_threshold: vec![(

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -91,15 +91,14 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_COLLATERAL_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_NATIVE_CURRENCY: CurrencyId = Token(INTR);
 pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
 
-pub const GRIEFING_CURRENCY: CurrencyId = Token(DOT);
-
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DEFAULT_COLLATERAL_CURRENCY;
+    pub const GetNativeCurrencyId: CurrencyId = DEFAULT_NATIVE_CURRENCY;
+    pub const GetWrappedCurrencyId: CurrencyId = DEFAULT_WRAPPED_CURRENCY;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -162,6 +161,8 @@ impl currency::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetCollateralCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -171,7 +172,7 @@ impl vault_registry::Config for Test {
     type Event = TestEvent;
     type Balance = Balance;
     type WeightInfo = ();
-    type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
+    type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
 }
 
 impl staking::Config for Test {
@@ -230,7 +231,6 @@ impl fee::Config for Test {
     type UnsignedInner = UnsignedInner;
     type VaultRewards = Rewards;
     type VaultStaking = Staking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = ();
 }
 
@@ -245,14 +245,14 @@ pub type TestError = Error<Test>;
 pub const OLD_VAULT: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 1,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
 pub const NEW_VAULT: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 2,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
@@ -309,7 +309,7 @@ where
     clear_mocks();
     ExtBuilder::build().execute_with(|| {
         assert_ok!(<oracle::Pallet<Test>>::_set_exchange_rate(
-            DEFAULT_TESTING_CURRENCY,
+            DEFAULT_COLLATERAL_CURRENCY,
             UnsignedFixedPoint::one()
         ));
         System::set_block_number(1);

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -45,10 +45,10 @@ fn test_request() -> ReplaceRequest<AccountId, BlockNumber, Balance, CurrencyId>
 }
 
 fn griefing(amount: u128) -> Amount<Test> {
-    Amount::new(amount, GRIEFING_CURRENCY)
+    Amount::new(amount, DEFAULT_NATIVE_CURRENCY)
 }
 fn wrapped(amount: u128) -> Amount<Test> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, DEFAULT_WRAPPED_CURRENCY)
 }
 
 mod request_replace_tests {

--- a/crates/staking/src/mock.rs
+++ b/crates/staking/src/mock.rs
@@ -63,7 +63,7 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetNativeCurrencyId: CurrencyId = Token(INTR);
 }
 
 impl Config for Test {

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -86,18 +86,19 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-pub const DEFAULT_TESTING_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_COLLATERAL_CURRENCY: CurrencyId = Token(DOT);
+pub const DEFAULT_NATIVE_CURRENCY: CurrencyId = Token(INTR);
 pub const DEFAULT_WRAPPED_CURRENCY: CurrencyId = Token(INTERBTC);
+
 pub const DEFAULT_CURRENCY_PAIR: VaultCurrencyPair<CurrencyId> = VaultCurrencyPair {
-    collateral: DEFAULT_TESTING_CURRENCY,
+    collateral: DEFAULT_COLLATERAL_CURRENCY,
     wrapped: DEFAULT_WRAPPED_CURRENCY,
 };
-pub const GRIEFING_CURRENCY: CurrencyId = Token(DOT);
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = Token(DOT);
-    pub const GetWrappedCurrencyId: CurrencyId = Token(INTERBTC);
-    pub const GetNativeCurrencyId: CurrencyId = Token(KINT);
+    pub const GetCollateralCurrencyId: CurrencyId = DEFAULT_COLLATERAL_CURRENCY;
+    pub const GetNativeCurrencyId: CurrencyId = DEFAULT_NATIVE_CURRENCY;
+    pub const GetWrappedCurrencyId: CurrencyId = DEFAULT_WRAPPED_CURRENCY;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -167,6 +168,8 @@ impl currency::Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetCollateralCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -184,7 +187,6 @@ impl fee::Config for Test {
     type UnsignedInner = Balance;
     type VaultRewards = Rewards;
     type VaultStaking = Staking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = ();
 }
 
@@ -197,7 +199,7 @@ impl Config for Test {
     type Event = TestEvent;
     type Balance = Balance;
     type WeightInfo = ();
-    type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
+    type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test
@@ -230,21 +232,21 @@ pub struct ExtBuilder;
 pub const DEFAULT_ID: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 3,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
 pub const OTHER_ID: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 4,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
 pub const RICH_ID: VaultId<AccountId, CurrencyId> = VaultId {
     account_id: 5,
     currencies: VaultCurrencyPair {
-        collateral: DEFAULT_TESTING_CURRENCY,
+        collateral: DEFAULT_COLLATERAL_CURRENCY,
         wrapped: DEFAULT_WRAPPED_CURRENCY,
     },
 };
@@ -261,7 +263,7 @@ impl ExtBuilder {
 
         // Parameters to be set in tests
         vault_registry::GenesisConfig::<Test> {
-            minimum_collateral_vault: vec![(DEFAULT_TESTING_CURRENCY, 0)],
+            minimum_collateral_vault: vec![(DEFAULT_COLLATERAL_CURRENCY, 0)],
             punishment_delay: 0,
             system_collateral_ceiling: vec![(DEFAULT_CURRENCY_PAIR, 1_000_000_000_000)],
             secure_collateral_threshold: vec![(DEFAULT_CURRENCY_PAIR, UnsignedFixedPoint::one())],
@@ -276,27 +278,27 @@ impl ExtBuilder {
     pub fn build() -> sp_io::TestExternalities {
         ExtBuilder::build_with(orml_tokens::GenesisConfig::<Test> {
             balances: vec![
-                (DEFAULT_ID.account_id, DEFAULT_TESTING_CURRENCY, DEFAULT_COLLATERAL),
-                (OTHER_ID.account_id, DEFAULT_TESTING_CURRENCY, DEFAULT_COLLATERAL),
-                (RICH_ID.account_id, DEFAULT_TESTING_CURRENCY, RICH_COLLATERAL),
+                (DEFAULT_ID.account_id, DEFAULT_COLLATERAL_CURRENCY, DEFAULT_COLLATERAL),
+                (OTHER_ID.account_id, DEFAULT_COLLATERAL_CURRENCY, DEFAULT_COLLATERAL),
+                (RICH_ID.account_id, DEFAULT_COLLATERAL_CURRENCY, RICH_COLLATERAL),
                 (
                     MULTI_VAULT_TEST_IDS[0],
-                    DEFAULT_TESTING_CURRENCY,
+                    DEFAULT_COLLATERAL_CURRENCY,
                     MULTI_VAULT_TEST_COLLATERAL,
                 ),
                 (
                     MULTI_VAULT_TEST_IDS[1],
-                    DEFAULT_TESTING_CURRENCY,
+                    DEFAULT_COLLATERAL_CURRENCY,
                     MULTI_VAULT_TEST_COLLATERAL,
                 ),
                 (
                     MULTI_VAULT_TEST_IDS[2],
-                    DEFAULT_TESTING_CURRENCY,
+                    DEFAULT_COLLATERAL_CURRENCY,
                     MULTI_VAULT_TEST_COLLATERAL,
                 ),
                 (
                     MULTI_VAULT_TEST_IDS[3],
-                    DEFAULT_TESTING_CURRENCY,
+                    DEFAULT_COLLATERAL_CURRENCY,
                     MULTI_VAULT_TEST_COLLATERAL,
                 ),
             ],
@@ -323,7 +325,7 @@ where
         System::set_block_number(1);
         Security::set_active_block_number(1);
         set_default_thresholds();
-        <oracle::Pallet<Test>>::_set_exchange_rate(DEFAULT_TESTING_CURRENCY, UnsignedFixedPoint::one()).unwrap();
+        <oracle::Pallet<Test>>::_set_exchange_rate(DEFAULT_COLLATERAL_CURRENCY, UnsignedFixedPoint::one()).unwrap();
         test()
     })
 }

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -21,7 +21,7 @@ fn vault_id(account_id: AccountId) -> VaultId<AccountId, CurrencyId> {
     VaultId {
         account_id,
         currencies: VaultCurrencyPair {
-            collateral: DEFAULT_TESTING_CURRENCY,
+            collateral: DEFAULT_COLLATERAL_CURRENCY,
             wrapped: DEFAULT_WRAPPED_CURRENCY,
         },
     }
@@ -87,15 +87,15 @@ fn create_sample_vault() -> DefaultVaultId<Test> {
 }
 
 fn amount(amount: u128) -> Amount<Test> {
-    Amount::new(amount, DEFAULT_TESTING_CURRENCY)
+    Amount::new(amount, DEFAULT_COLLATERAL_CURRENCY)
 }
 
 fn griefing(amount: u128) -> Amount<Test> {
-    Amount::new(amount, GRIEFING_CURRENCY)
+    Amount::new(amount, DEFAULT_NATIVE_CURRENCY)
 }
 
 fn wrapped(amount: u128) -> Amount<Test> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, DEFAULT_WRAPPED_CURRENCY)
 }
 
 fn create_vault_and_issue_tokens(
@@ -1438,10 +1438,10 @@ fn test_try_increase_to_be_replaced_tokens() {
             &wrapped(1)
         ));
 
-        let (total_wrapped, total_collateral) =
+        let (total_wrapped, total_griefing_collateral) =
             VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(2), &griefing(10)).unwrap();
         assert!(total_wrapped == wrapped(2));
-        assert!(total_collateral == amount(10));
+        assert!(total_griefing_collateral == griefing(10));
 
         // check that we can't request more than we have issued tokens
         assert_noop!(
@@ -1458,10 +1458,10 @@ fn test_try_increase_to_be_replaced_tokens() {
         let mut vault = VaultRegistry::get_active_rich_vault_from_id(&vault_id).unwrap();
         vault.increase_available_replace_collateral(&griefing(10)).unwrap();
 
-        let (total_wrapped, total_collateral) =
+        let (total_wrapped, total_griefing_collateral) =
             VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(1), &griefing(20)).unwrap();
         assert_eq!(total_wrapped, wrapped(3));
-        assert_eq!(total_collateral, amount(30));
+        assert_eq!(total_griefing_collateral, griefing(30));
 
         // check that to_be_replaced_tokens is was written to storage
         let vault = VaultRegistry::get_active_vault_from_id(&vault_id).unwrap();

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -655,7 +655,7 @@ impl Config for XcmConfig {
         IdentityFee<Balance>,
         ParentLocation,
         AccountId,
-        orml_tokens::CurrencyAdapter<Runtime, GetCollateralCurrencyId>,
+        orml_tokens::CurrencyAdapter<Runtime, GetRelayChainCurrencyId>,
         (),
     >;
     type ResponseHandler = (); // Don't handle responses for now.
@@ -736,7 +736,7 @@ mod currency_id_convert {
     impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
         fn convert(id: CurrencyId) -> Option<MultiLocation> {
             match id {
-                RELAY_CHAIN_CURRENCY_ID => Some(MultiLocation::parent()),
+                PARENT_CURRENCY_ID => Some(MultiLocation::parent()),
                 WRAPPED_CURRENCY_ID => Some(native_currency_location(id)),
                 NATIVE_CURRENCY_ID => Some(native_currency_location(id)),
                 _ => None,
@@ -747,7 +747,7 @@ mod currency_id_convert {
     impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
         fn convert(location: MultiLocation) -> Option<CurrencyId> {
             match location {
-                x if x == MultiLocation::parent() => Some(RELAY_CHAIN_CURRENCY_ID),
+                x if x == MultiLocation::parent() => Some(PARENT_CURRENCY_ID),
                 MultiLocation {
                     parents: 1,
                     interior: X2(Parachain(id), GeneralKey(key)),
@@ -826,14 +826,14 @@ impl btc_relay::Config for Runtime {
     type ParachainBlocksPerBitcoinBlock = ParachainBlocksPerBitcoinBlock;
 }
 
-const RELAY_CHAIN_CURRENCY_ID: CurrencyId = Token(DOT);
-const WRAPPED_CURRENCY_ID: CurrencyId = Token(INTERBTC);
 const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
+const PARENT_CURRENCY_ID: CurrencyId = Token(DOT);
+const WRAPPED_CURRENCY_ID: CurrencyId = Token(INTERBTC);
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = RELAY_CHAIN_CURRENCY_ID;
-    pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
     pub const GetNativeCurrencyId: CurrencyId = NATIVE_CURRENCY_ID;
+    pub const GetRelayChainCurrencyId: CurrencyId = PARENT_CURRENCY_ID;
+    pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
 }
 
 type NativeCurrency = orml_tokens::CurrencyAdapter<Runtime, GetNativeCurrencyId>;
@@ -1052,6 +1052,8 @@ impl currency::Config for Runtime {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetRelayChainCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -1097,7 +1099,7 @@ impl vault_registry::Config for Runtime {
     type Event = Event;
     type Balance = Balance;
     type WeightInfo = ();
-    type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
+    type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
@@ -1122,7 +1124,6 @@ impl fee::Config for Runtime {
     type UnsignedInner = UnsignedInner;
     type VaultRewards = VaultRewards;
     type VaultStaking = VaultStaking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = currency::SweepFunds<Runtime, FeeAccount>;
 }
 

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -762,7 +762,7 @@ mod currency_id_convert {
     impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
         fn convert(id: CurrencyId) -> Option<MultiLocation> {
             match id {
-                RELAY_CHAIN_CURRENCY_ID => Some(MultiLocation::parent()),
+                PARENT_CURRENCY_ID => Some(MultiLocation::parent()),
                 WRAPPED_CURRENCY_ID => Some(native_currency_location(id)),
                 NATIVE_CURRENCY_ID => Some(native_currency_location(id)),
                 _ => None,
@@ -773,7 +773,7 @@ mod currency_id_convert {
     impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
         fn convert(location: MultiLocation) -> Option<CurrencyId> {
             match location {
-                x if x == MultiLocation::parent() => Some(RELAY_CHAIN_CURRENCY_ID),
+                x if x == MultiLocation::parent() => Some(PARENT_CURRENCY_ID),
                 MultiLocation {
                     parents: 1,
                     interior: X2(Parachain(id), GeneralKey(key)),
@@ -852,14 +852,14 @@ impl btc_relay::Config for Runtime {
     type ParachainBlocksPerBitcoinBlock = ParachainBlocksPerBitcoinBlock;
 }
 
-const RELAY_CHAIN_CURRENCY_ID: CurrencyId = Token(KSM);
-const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
 const NATIVE_CURRENCY_ID: CurrencyId = Token(KINT);
+const PARENT_CURRENCY_ID: CurrencyId = Token(KSM);
+const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = RELAY_CHAIN_CURRENCY_ID;
-    pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
     pub const GetNativeCurrencyId: CurrencyId = NATIVE_CURRENCY_ID;
+    pub const GetRelayChainCurrencyId: CurrencyId = PARENT_CURRENCY_ID;
+    pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
 }
 
 type NativeCurrency = orml_tokens::CurrencyAdapter<Runtime, GetNativeCurrencyId>;
@@ -1081,6 +1081,8 @@ impl currency::Config for Runtime {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetRelayChainCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -1151,7 +1153,6 @@ impl fee::Config for Runtime {
     type UnsignedInner = UnsignedInner;
     type VaultRewards = VaultRewards;
     type VaultStaking = VaultStaking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = currency::SweepFunds<Runtime, FeeAccount>;
 }
 

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -758,7 +758,7 @@ mod currency_id_convert {
     impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
         fn convert(id: CurrencyId) -> Option<MultiLocation> {
             match id {
-                RELAY_CHAIN_CURRENCY_ID => Some(MultiLocation::parent()),
+                PARENT_CURRENCY_ID => Some(MultiLocation::parent()),
                 WRAPPED_CURRENCY_ID => Some(native_currency_location(id)),
                 NATIVE_CURRENCY_ID => Some(native_currency_location(id)),
                 _ => None,
@@ -769,7 +769,7 @@ mod currency_id_convert {
     impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
         fn convert(location: MultiLocation) -> Option<CurrencyId> {
             match location {
-                x if x == MultiLocation::parent() => Some(RELAY_CHAIN_CURRENCY_ID),
+                x if x == MultiLocation::parent() => Some(PARENT_CURRENCY_ID),
                 MultiLocation {
                     parents: 1,
                     interior: X2(Parachain(id), GeneralKey(key)),
@@ -848,14 +848,14 @@ impl btc_relay::Config for Runtime {
     type ParachainBlocksPerBitcoinBlock = ParachainBlocksPerBitcoinBlock;
 }
 
-const RELAY_CHAIN_CURRENCY_ID: CurrencyId = Token(KSM);
-const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
 const NATIVE_CURRENCY_ID: CurrencyId = Token(KINT);
+const PARENT_CURRENCY_ID: CurrencyId = Token(KSM);
+const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = RELAY_CHAIN_CURRENCY_ID;
-    pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
     pub const GetNativeCurrencyId: CurrencyId = NATIVE_CURRENCY_ID;
+    pub const GetRelayChainCurrencyId: CurrencyId = PARENT_CURRENCY_ID;
+    pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
 }
 
 type NativeCurrency = orml_tokens::CurrencyAdapter<Runtime, GetNativeCurrencyId>;
@@ -1074,6 +1074,8 @@ impl currency::Config for Runtime {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetRelayChainCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -1144,7 +1146,6 @@ impl fee::Config for Runtime {
     type UnsignedInner = UnsignedInner;
     type VaultRewards = VaultRewards;
     type VaultStaking = VaultStaking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = currency::SweepFunds<Runtime, FeeAccount>;
 }
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -487,14 +487,14 @@ impl btc_relay::Config for Runtime {
     type ParachainBlocksPerBitcoinBlock = ParachainBlocksPerBitcoinBlock;
 }
 
-const RELAY_CHAIN_CURRENCY_ID: CurrencyId = Token(DOT);
-const WRAPPED_CURRENCY_ID: CurrencyId = Token(INTERBTC);
 const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
+const PARENT_CURRENCY_ID: CurrencyId = Token(DOT);
+const WRAPPED_CURRENCY_ID: CurrencyId = Token(INTERBTC);
 
 parameter_types! {
-    pub const GetCollateralCurrencyId: CurrencyId = RELAY_CHAIN_CURRENCY_ID;
-    pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
     pub const GetNativeCurrencyId: CurrencyId = NATIVE_CURRENCY_ID;
+    pub const GetRelayChainCurrencyId: CurrencyId = PARENT_CURRENCY_ID;
+    pub const GetWrappedCurrencyId: CurrencyId = WRAPPED_CURRENCY_ID;
 }
 
 type NativeCurrency = orml_tokens::CurrencyAdapter<Runtime, GetNativeCurrencyId>;
@@ -710,6 +710,8 @@ impl currency::Config for Runtime {
     type SignedFixedPoint = SignedFixedPoint;
     type UnsignedFixedPoint = UnsignedFixedPoint;
     type Balance = Balance;
+    type GetNativeCurrencyId = GetNativeCurrencyId;
+    type GetRelayChainCurrencyId = GetRelayChainCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
 }
@@ -755,7 +757,7 @@ impl vault_registry::Config for Runtime {
     type Event = Event;
     type Balance = Balance;
     type WeightInfo = ();
-    type GetGriefingCollateralCurrencyId = GetCollateralCurrencyId;
+    type GetGriefingCollateralCurrencyId = GetNativeCurrencyId;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
@@ -780,7 +782,6 @@ impl fee::Config for Runtime {
     type UnsignedInner = UnsignedInner;
     type VaultRewards = VaultRewards;
     type VaultStaking = VaultStaking;
-    type GetNativeCurrencyId = GetNativeCurrencyId;
     type OnSweep = currency::SweepFunds<Runtime, FeeAccount>;
 }
 

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -15,9 +15,9 @@ pub use frame_support::{
     dispatch::{DispatchError, DispatchResultWithPostInfo},
 };
 pub use interbtc_runtime_standalone::{
-    token_distribution, AccountId, BlockNumber, Call, CurrencyId, EscrowAnnuityInstance, Event,
-    GetCollateralCurrencyId, GetNativeCurrencyId, GetWrappedCurrencyId, Runtime, TechnicalCommitteeInstance,
-    VaultAnnuityInstance, VaultRewardsInstance, YEARS,
+    token_distribution, AccountId, BlockNumber, Call, CurrencyId, EscrowAnnuityInstance, Event, GetNativeCurrencyId,
+    GetRelayChainCurrencyId, GetWrappedCurrencyId, Runtime, TechnicalCommitteeInstance, VaultAnnuityInstance,
+    VaultRewardsInstance, YEARS,
 };
 pub use mocktopus::mocking::*;
 pub use orml_tokens::CurrencyAdapter;
@@ -112,9 +112,9 @@ pub type TokensCall = orml_tokens::Call<Runtime>;
 pub type TokensError = orml_tokens::Error<Runtime>;
 pub type TokensPallet = orml_tokens::Pallet<Runtime>;
 
-pub type CollateralCurrency = CurrencyAdapter<Runtime, GetCollateralCurrencyId>;
-pub type WrappedCurrency = CurrencyAdapter<Runtime, GetWrappedCurrencyId>;
+pub type CollateralCurrency = CurrencyAdapter<Runtime, GetRelayChainCurrencyId>;
 pub type NativeCurrency = CurrencyAdapter<Runtime, GetNativeCurrencyId>;
+pub type WrappedCurrency = CurrencyAdapter<Runtime, GetWrappedCurrencyId>;
 
 pub type OracleCall = oracle::Call<Runtime>;
 pub type OraclePallet = oracle::Pallet<Runtime>;
@@ -176,23 +176,23 @@ pub type UtilityCall = pallet_utility::Call<Runtime>;
 pub type SchedulerCall = pallet_scheduler::Call<Runtime>;
 pub type SchedulerPallet = pallet_scheduler::Pallet<Runtime>;
 
-pub const DEFAULT_TESTING_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(DOT);
+pub const DEFAULT_COLLATERAL_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(DOT);
 pub const DEFAULT_WRAPPED_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(INTERBTC);
-pub const GRIEFING_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(DOT);
-pub const WRAPPED_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(INTERBTC);
+pub const DEFAULT_NATIVE_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(INTR);
+pub const DEFAULT_GRIEFING_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = DEFAULT_NATIVE_CURRENCY;
 
 pub fn default_vault_id_of(hash: [u8; 32]) -> VaultId {
     VaultId {
         account_id: account_of(hash),
         currencies: DefaultVaultCurrencyPair::<Runtime> {
-            collateral: DEFAULT_TESTING_CURRENCY,
+            collateral: DEFAULT_COLLATERAL_CURRENCY,
             wrapped: DEFAULT_WRAPPED_CURRENCY,
         },
     }
 }
 
 pub fn dummy_vault_id_of() -> VaultId {
-    PrimitiveVaultId::new(account_of(BOB), DEFAULT_TESTING_CURRENCY, DEFAULT_WRAPPED_CURRENCY)
+    PrimitiveVaultId::new(account_of(BOB), DEFAULT_COLLATERAL_CURRENCY, DEFAULT_WRAPPED_CURRENCY)
 }
 pub fn vault_id_of(id: [u8; 32], collateral_currency: CurrencyId) -> VaultId {
     PrimitiveVaultId::new(account_of(id), collateral_currency, DEFAULT_WRAPPED_CURRENCY)
@@ -203,7 +203,16 @@ pub fn default_user_state() -> UserData {
     for currency_id in iter_collateral_currencies() {
         balances.insert(
             currency_id,
-            Balance {
+            AccountData {
+                free: default_user_free_balance(currency_id),
+                locked: default_user_locked_balance(currency_id),
+            },
+        );
+    }
+    for currency_id in iter_native_currencies() {
+        balances.insert(
+            currency_id,
+            AccountData {
                 free: default_user_free_balance(currency_id),
                 locked: default_user_locked_balance(currency_id),
             },
@@ -212,7 +221,7 @@ pub fn default_user_state() -> UserData {
     for currency_id in iter_wrapped_currencies() {
         balances.insert(
             currency_id,
-            Balance {
+            AccountData {
                 free: Amount::new(DEFAULT_USER_FREE_TOKENS.amount(), currency_id),
                 locked: Amount::new(DEFAULT_USER_LOCKED_TOKENS.amount(), currency_id),
             },
@@ -297,7 +306,7 @@ pub fn account_of(address: [u8; 32]) -> AccountId {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Balance {
+pub struct AccountData {
     pub free: Amount<Runtime>,
     pub locked: Amount<Runtime>,
 }
@@ -305,7 +314,7 @@ pub struct Balance {
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct UserData {
     // note: we use BTreeMap such that the debug print output is sorted, for easier diffing
-    pub balances: BTreeMap<CurrencyId, Balance>,
+    pub balances: BTreeMap<CurrencyId, AccountData>,
 }
 
 pub trait Wrapped {
@@ -331,12 +340,18 @@ pub fn iter_collateral_currencies() -> impl Iterator<Item = CurrencyId> {
     vec![Token(DOT), Token(KSM)].into_iter()
 }
 
+pub fn iter_native_currencies() -> impl Iterator<Item = CurrencyId> {
+    vec![Token(INTR), Token(KINT)].into_iter()
+}
+
 pub fn iter_wrapped_currencies() -> impl Iterator<Item = CurrencyId> {
     vec![Token(INTERBTC), Token(KBTC)].into_iter()
 }
 
 pub fn iter_all_currencies() -> impl Iterator<Item = CurrencyId> {
-    iter_collateral_currencies().chain(iter_wrapped_currencies())
+    iter_collateral_currencies()
+        .chain(iter_native_currencies())
+        .chain(iter_wrapped_currencies())
 }
 
 impl UserData {
@@ -347,7 +362,7 @@ impl UserData {
         for currency_id in iter_all_currencies() {
             let free = currency::get_free_balance::<Runtime>(currency_id, &account_id);
             let locked = currency::get_reserved_balance::<Runtime>(currency_id, &account_id);
-            hash_map.insert(currency_id, Balance { free, locked });
+            hash_map.insert(currency_id, AccountData { free, locked });
         }
 
         Self { balances: hash_map }
@@ -371,7 +386,7 @@ impl UserData {
             .iter()
             .chain(new.balances.iter())
             .all(
-                |(currency_id, Balance { free, locked })| free.currency() == *currency_id
+                |(currency_id, AccountData { free, locked })| free.currency() == *currency_id
                     && locked.currency() == *currency_id
             ));
 
@@ -1292,7 +1307,9 @@ impl ExtBuilder {
         let balances = balances
             .into_iter()
             .flat_map(|(account, balance)| {
-                iter_collateral_currencies().map(move |currency| (account.clone(), currency, balance))
+                iter_collateral_currencies()
+                    .chain(iter_native_currencies())
+                    .map(move |currency| (account.clone(), currency, balance))
             })
             .chain(iter_wrapped_currencies().map(move |currency| (account_of(FAUCET), currency, 1 << 60)))
             .collect();
@@ -1410,7 +1427,8 @@ impl ExtBuilder {
             .dispatch(root()));
             assert_ok!(Call::Oracle(OracleCall::feed_values {
                 values: vec![
-                    (OracleKey::ExchangeRate(Token(DOT)), FixedU128::from(1)),
+                    (OracleKey::ExchangeRate(DEFAULT_COLLATERAL_CURRENCY), FixedU128::from(1)),
+                    (OracleKey::ExchangeRate(DEFAULT_GRIEFING_CURRENCY), FixedU128::from(1)),
                     (OracleKey::FeeEstimation, FixedU128::from(3)),
                 ]
             })
@@ -1430,7 +1448,7 @@ impl ExtBuilder {
             SecurityPallet::set_active_block_number(1);
 
             assert_ok!(OraclePallet::_set_exchange_rate(
-                DEFAULT_TESTING_CURRENCY,
+                DEFAULT_COLLATERAL_CURRENCY,
                 FixedU128::one()
             ));
             set_default_thresholds();
@@ -1443,9 +1461,9 @@ impl ExtBuilder {
 }
 
 pub const fn wrapped(amount: u128) -> Amount<Runtime> {
-    Amount::new(amount, Token(INTERBTC))
+    Amount::new(amount, DEFAULT_WRAPPED_CURRENCY)
 }
 
 pub const fn griefing(amount: u128) -> Amount<Runtime> {
-    Amount::new(amount, Token(DOT))
+    Amount::new(amount, DEFAULT_GRIEFING_CURRENCY)
 }

--- a/standalone/runtime/tests/test_annuity.rs
+++ b/standalone/runtime/tests/test_annuity.rs
@@ -12,8 +12,6 @@ type VaultAnnuityEvent = annuity::Event<Runtime, VaultAnnuityInstance>;
 
 type SupplyPallet = supply::Pallet<Runtime>;
 
-const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
-
 fn get_last_reward() -> u128 {
     SystemPallet::events()
         .iter()
@@ -33,7 +31,7 @@ fn integration_test_annuity() {
     ExtBuilder::build().execute_with(|| {
         assert_ok!(Call::Tokens(TokensCall::set_balance {
             who: VaultAnnuityPallet::account_id(),
-            currency_id: NATIVE_CURRENCY_ID,
+            currency_id: DEFAULT_NATIVE_CURRENCY,
             new_free: 10_000_000_000_000,
             new_reserved: 0,
         })
@@ -87,7 +85,7 @@ fn should_distribute_vault_rewards_from_supply() {
                     call: Box::new(Call::Tokens(TokensCall::force_transfer {
                         source: SupplyPallet::account_id(),
                         dest: VaultAnnuityPallet::account_id(),
-                        currency_id: NATIVE_CURRENCY_ID,
+                        currency_id: DEFAULT_NATIVE_CURRENCY,
                         amount: Permill::from_percent(40) * total_rewards,
                     })),
                 }),
@@ -99,7 +97,7 @@ fn should_distribute_vault_rewards_from_supply() {
                     call: Box::new(Call::Tokens(TokensCall::force_transfer {
                         source: SupplyPallet::account_id(),
                         dest: VaultAnnuityPallet::account_id(),
-                        currency_id: NATIVE_CURRENCY_ID,
+                        currency_id: DEFAULT_NATIVE_CURRENCY,
                         amount: Permill::from_percent(30) * total_rewards,
                     })),
                 }),
@@ -111,7 +109,7 @@ fn should_distribute_vault_rewards_from_supply() {
                     call: Box::new(Call::Tokens(TokensCall::force_transfer {
                         source: SupplyPallet::account_id(),
                         dest: VaultAnnuityPallet::account_id(),
-                        currency_id: NATIVE_CURRENCY_ID,
+                        currency_id: DEFAULT_NATIVE_CURRENCY,
                         amount: Permill::from_percent(20) * total_rewards,
                     })),
                 }),
@@ -123,7 +121,7 @@ fn should_distribute_vault_rewards_from_supply() {
                     call: Box::new(Call::Tokens(TokensCall::force_transfer {
                         source: SupplyPallet::account_id(),
                         dest: VaultAnnuityPallet::account_id(),
-                        currency_id: NATIVE_CURRENCY_ID,
+                        currency_id: DEFAULT_NATIVE_CURRENCY,
                         amount: Permill::from_percent(10) * total_rewards,
                     })),
                 })
@@ -184,7 +182,7 @@ fn should_distribute_escrow_rewards_from_supply() {
                     call: Box::new(Call::Tokens(TokensCall::force_transfer {
                         source: SupplyPallet::account_id(),
                         dest: EscrowAnnuityPallet::account_id(),
-                        currency_id: NATIVE_CURRENCY_ID,
+                        currency_id: DEFAULT_NATIVE_CURRENCY,
                         amount: Permill::from_percent(25) * total_rewards,
                     })),
                 }),
@@ -196,7 +194,7 @@ fn should_distribute_escrow_rewards_from_supply() {
                     call: Box::new(Call::Tokens(TokensCall::force_transfer {
                         source: SupplyPallet::account_id(),
                         dest: EscrowAnnuityPallet::account_id(),
-                        currency_id: NATIVE_CURRENCY_ID,
+                        currency_id: DEFAULT_NATIVE_CURRENCY,
                         amount: Permill::from_percent(25) * total_rewards,
                     })),
                 }),
@@ -208,7 +206,7 @@ fn should_distribute_escrow_rewards_from_supply() {
                     call: Box::new(Call::Tokens(TokensCall::force_transfer {
                         source: SupplyPallet::account_id(),
                         dest: EscrowAnnuityPallet::account_id(),
-                        currency_id: NATIVE_CURRENCY_ID,
+                        currency_id: DEFAULT_NATIVE_CURRENCY,
                         amount: Permill::from_percent(25) * total_rewards,
                     })),
                 }),
@@ -220,7 +218,7 @@ fn should_distribute_escrow_rewards_from_supply() {
                     call: Box::new(Call::Tokens(TokensCall::force_transfer {
                         source: SupplyPallet::account_id(),
                         dest: EscrowAnnuityPallet::account_id(),
-                        currency_id: NATIVE_CURRENCY_ID,
+                        currency_id: DEFAULT_NATIVE_CURRENCY,
                         amount: Permill::from_percent(25) * total_rewards,
                     })),
                 })

--- a/standalone/runtime/tests/test_fee_pool.rs
+++ b/standalone/runtime/tests/test_fee_pool.rs
@@ -51,7 +51,7 @@ fn test_with<R>(execute: impl Fn(CurrencyId) -> R) {
 }
 
 fn withdraw_vault_global_pool_rewards(vault_id: &VaultId) -> i128 {
-    let amount = VaultRewardsPallet::compute_reward(Token(INTERBTC), vault_id).unwrap();
+    let amount = VaultRewardsPallet::compute_reward(vault_id.wrapped_currency(), vault_id).unwrap();
     assert_ok!(Call::Fee(FeeCall::withdraw_rewards {
         vault_id: vault_id.clone(),
         index: None

--- a/standalone/runtime/tests/test_governance.rs
+++ b/standalone/runtime/tests/test_governance.rs
@@ -26,12 +26,10 @@ type TreasuryPallet = pallet_treasury::Pallet<Runtime>;
 
 type VestingCall = orml_vesting::Call<Runtime>;
 
-const COLLATERAL_CURRENCY_ID: CurrencyId = Token(DOT);
-const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
 const INITIAL_VOTING_POWER: u128 = 5_000_000_000_000;
 
 fn get_max_locked(account_id: AccountId) -> Balance {
-    TokensPallet::locks(&account_id, NATIVE_CURRENCY_ID)
+    TokensPallet::locks(&account_id, DEFAULT_NATIVE_CURRENCY)
         .iter()
         .map(|balance_lock| balance_lock.amount)
         .max()
@@ -49,7 +47,7 @@ fn create_lock(account_id: AccountId, amount: Balance) {
 fn set_free_balance(account: AccountId, amount: Balance) {
     assert_ok!(Call::Tokens(TokensCall::set_balance {
         who: account,
-        currency_id: NATIVE_CURRENCY_ID,
+        currency_id: DEFAULT_NATIVE_CURRENCY,
         new_free: amount,
         new_reserved: 0,
     })
@@ -67,7 +65,7 @@ fn test_with<R>(execute: impl Fn() -> R) {
 fn set_balance_proposal(who: AccountId, value: u128) -> Vec<u8> {
     Call::Tokens(TokensCall::set_balance {
         who: who,
-        currency_id: COLLATERAL_CURRENCY_ID,
+        currency_id: DEFAULT_COLLATERAL_CURRENCY,
         new_free: value,
         new_reserved: 0,
     })
@@ -210,7 +208,7 @@ fn can_recover_from_shutdown_using_root() {
         assert_noop!(
             Call::Tokens(TokensCall::transfer {
                 dest: account_of(ALICE),
-                currency_id: NATIVE_CURRENCY_ID,
+                currency_id: DEFAULT_NATIVE_CURRENCY,
                 amount: 123,
             })
             .dispatch(origin_of(account_of(ALICE))),
@@ -228,7 +226,7 @@ fn can_recover_from_shutdown_using_root() {
         // verify that we can execute normal calls again
         assert_ok!(Call::Tokens(TokensCall::transfer {
             dest: account_of(ALICE),
-            currency_id: NATIVE_CURRENCY_ID,
+            currency_id: DEFAULT_NATIVE_CURRENCY,
             amount: 123,
         })
         .dispatch(origin_of(account_of(ALICE))));

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -385,8 +385,8 @@ mod request_issue_tests {
                 ParachainState::get(&vault_id),
                 ParachainState::get_default(&vault_id).with_changes(|user, vault, _, _| {
                     vault.to_be_issued += vault_id.wrapped(10_000);
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).free -= DEFAULT_GRIEFING_COLLATERAL;
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).locked += DEFAULT_GRIEFING_COLLATERAL;
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).free -= DEFAULT_GRIEFING_COLLATERAL;
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked += DEFAULT_GRIEFING_COLLATERAL;
                 })
             );
 
@@ -823,8 +823,8 @@ mod execute_issue_tests {
             assert_eq!(
                 ParachainState::get(&vault_id),
                 post_request_state.with_changes(|user, vault, _, fee_pool| {
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
                     (*user.balances.get_mut(&vault_id.wrapped_currency()).unwrap()).free += issue.amount();
 
                     *fee_pool.rewards_for(&vault_id) += issue.fee();
@@ -867,9 +867,9 @@ mod execute_issue_tests {
                 ParachainState::get(&vault_id),
                 post_request_state.with_changes(|user, vault, _, fee_pool| {
                     // user loses 75% of griefing collateral for having only fulfilled 25%
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).free += returned_griefing_collateral;
-                    *vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += slashed_griefing_collateral;
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).free += returned_griefing_collateral;
+                    *vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += slashed_griefing_collateral;
 
                     // token updating as if only 25% was requested
                     (*user.balances.get_mut(&vault_id.wrapped_currency()).unwrap()).free += issue.amount() / 4;
@@ -928,8 +928,8 @@ mod execute_issue_tests {
             assert_eq!(
                 ParachainState::get(&vault_id),
                 post_request_state.with_changes(|user, vault, _, fee_pool| {
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
                     (*user.balances.get_mut(&vault_id.wrapped_currency()).unwrap()).free += issue.amount() * 2;
 
                     *fee_pool.rewards_for(&vault_id) += issue.fee() * 2;
@@ -989,8 +989,8 @@ mod execute_issue_tests {
             assert_eq!(
                 ParachainState::get(&vault_id),
                 post_request_state.with_changes(|user, vault, _, fee_pool| {
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
 
                     (*user.balances.get_mut(&vault_id.wrapped_currency()).unwrap()).free += issue.amount();
                     *fee_pool.rewards_for(&vault_id) += issue.fee();
@@ -1033,8 +1033,8 @@ mod execute_issue_tests {
                 post_liquidation_status.with_changes(|user, _vault, liquidation_vault, fee_pool| {
                     (*user.balances.get_mut(&vault_id.wrapped_currency()).unwrap()).free += issue.amount();
 
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
 
                     let liquidation_vault = liquidation_vault.with_currency(&vault_id.currencies);
                     liquidation_vault.to_be_issued -= issue.amount() + issue.fee();
@@ -1116,8 +1116,8 @@ mod cancel_issue_tests {
             assert_eq!(
                 ParachainState::get(&vault_id),
                 post_request_state.with_changes(|user, vault, _, _| {
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
-                    *vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
+                    *vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += issue.griefing_collateral();
                     vault.to_be_issued -= issue.amount() + issue.fee();
                 })
             );
@@ -1155,8 +1155,8 @@ mod cancel_issue_tests {
                 ParachainState::get(&vault_id),
                 post_liquidation_status.with_changes(|user, _vault, liquidation_vault, _fee_pool| {
                     // griefing collateral released instead of slashed
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
-                    (*user.balances.get_mut(&GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
+                    (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).free += issue.griefing_collateral();
 
                     let liquidation_vault = liquidation_vault.with_currency(&vault_id.currencies);
                     liquidation_vault.to_be_issued -= issue.amount() + issue.fee();

--- a/standalone/runtime/tests/test_multisig.rs
+++ b/standalone/runtime/tests/test_multisig.rs
@@ -98,6 +98,8 @@ fn integration_test_transfer_from_multisig_to_unvested() {
         // vested transfer takes free balance of caller
         set_balance(multisig_account.clone(), Token(INTR), vesting_amount);
         set_balance(account_of(ALICE), Token(INTR), 1 << 60);
+        // clear eve's balance
+        set_balance(account_of(EVE), Token(INTR), 0);
 
         // gradually release amount over 100 periods
         let call = Call::Vesting(VestingCall::vested_transfer {

--- a/standalone/runtime/tests/test_redeem.rs
+++ b/standalone/runtime/tests/test_redeem.rs
@@ -48,7 +48,7 @@ fn consume_to_be_replaced(vault: &mut CoreVaultData, amount_btc: Amount<Runtime>
 
     vault.replace_collateral -= released_replace_collateral;
     vault.griefing_collateral -= released_replace_collateral;
-    *vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += released_replace_collateral;
+    *vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += released_replace_collateral;
 
     vault.to_be_replaced -= to_be_replaced_decrease;
 }
@@ -167,7 +167,7 @@ mod spec_based_tests {
             assert_noop!(
                 Call::Redeem(RedeemCall::mint_tokens_for_reimbursed_redeem {
                     currency_pair: VaultCurrencyPair {
-                        collateral: DEFAULT_TESTING_CURRENCY,
+                        collateral: DEFAULT_COLLATERAL_CURRENCY,
                         wrapped: DEFAULT_WRAPPED_CURRENCY
                     },
                     redeem_id: Default::default()

--- a/standalone/runtime/tests/test_relayers.rs
+++ b/standalone/runtime/tests/test_relayers.rs
@@ -39,7 +39,7 @@ fn setup_vault_for_potential_double_spend(
 
     assert_ok!(Call::VaultRegistry(VaultRegistryCall::register_vault {
         currency_pair: VaultCurrencyPair {
-            collateral: DEFAULT_TESTING_CURRENCY,
+            collateral: DEFAULT_COLLATERAL_CURRENCY,
             wrapped: DEFAULT_WRAPPED_CURRENCY,
         },
         collateral: INITIAL_BALANCE,

--- a/standalone/runtime/tests/test_replace.rs
+++ b/standalone/runtime/tests/test_replace.rs
@@ -332,7 +332,7 @@ mod request_replace_tests {
                     old_vault.to_be_replaced += amount;
                     old_vault.griefing_collateral += griefing_collateral;
                     old_vault.replace_collateral += griefing_collateral;
-                    *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() -= griefing_collateral;
+                    *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() -= griefing_collateral;
                 })
             );
         });
@@ -356,7 +356,7 @@ mod request_replace_tests {
                     old_vault.to_be_replaced += amount / 2;
                     old_vault.griefing_collateral += griefing_collateral / 2;
                     old_vault.replace_collateral += griefing_collateral / 2;
-                    *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() -= griefing_collateral / 2;
+                    *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() -= griefing_collateral / 2;
                 })
             );
         });
@@ -379,7 +379,7 @@ mod request_replace_tests {
                     old_vault.to_be_replaced += amount;
                     old_vault.griefing_collateral += griefing_collateral;
                     old_vault.replace_collateral += griefing_collateral;
-                    *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() -= griefing_collateral;
+                    *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() -= griefing_collateral;
                 })
             );
         });
@@ -399,7 +399,7 @@ mod request_replace_tests {
                 ParachainTwoVaultState::get_default(&old_vault_id, &new_vault_id).with_changes(|old_vault, _, _| {
                     old_vault.griefing_collateral += griefing_collateral;
                     old_vault.replace_collateral += griefing_collateral;
-                    *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() -= griefing_collateral;
+                    *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() -= griefing_collateral;
                 })
             );
         });
@@ -455,7 +455,7 @@ mod request_replace_tests {
                     old_vault.to_be_replaced += amount;
                     old_vault.griefing_collateral += griefing_collateral;
                     old_vault.replace_collateral += griefing_collateral;
-                    *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() -= griefing_collateral;
+                    *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() -= griefing_collateral;
                 })
             );
         });
@@ -480,7 +480,7 @@ mod withdraw_replace_tests {
                 ParachainTwoVaultState::get_default(&old_vault_id, &new_vault_id).with_changes(|old_vault, _, _| {
                     old_vault.to_be_replaced -= amount;
 
-                    *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += released_collateral;
+                    *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += released_collateral;
                     old_vault.griefing_collateral -= released_collateral;
                     old_vault.replace_collateral -= released_collateral;
                 })
@@ -504,7 +504,7 @@ mod withdraw_replace_tests {
                 ParachainTwoVaultState::get_default(&old_vault_id, &new_vault_id).with_changes(|old_vault, _, _| {
                     old_vault.to_be_replaced -= amount;
 
-                    *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += released_collateral;
+                    *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += released_collateral;
                     old_vault.griefing_collateral -= released_collateral;
                     old_vault.replace_collateral -= released_collateral;
                 })
@@ -528,7 +528,7 @@ mod withdraw_replace_tests {
                 ParachainTwoVaultState::get_default(&old_vault_id, &new_vault_id).with_changes(|old_vault, _, _| {
                     old_vault.to_be_replaced -= amount / 2;
 
-                    *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += released_collateral;
+                    *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += released_collateral;
                     old_vault.griefing_collateral -= released_collateral;
                     old_vault.replace_collateral -= released_collateral;
                 })
@@ -827,7 +827,7 @@ fn integration_test_replace_execute_replace_success() {
                 old_vault.issued -= old_vault_id.wrapped(1000);
 
                 old_vault.griefing_collateral -= replace.griefing_collateral();
-                *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
+                *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
             })
         );
     });
@@ -876,7 +876,7 @@ fn integration_test_replace_execute_replace_old_vault_liquidated() {
                 old_vault.to_be_redeemed -= old_vault_id.wrapped(1000);
                 old_vault.liquidated_collateral -= collateral_for_replace;
                 old_vault.backing_collateral += collateral_for_replace; // TODO: probably should be free
-                *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
+                *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
                 old_vault.griefing_collateral -= replace.griefing_collateral();
             })
         );
@@ -905,7 +905,7 @@ fn integration_test_replace_execute_replace_new_vault_liquidated() {
                 old_vault.issued -= old_vault_id.wrapped(1000);
 
                 old_vault.griefing_collateral -= replace.griefing_collateral();
-                *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
+                *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
             })
         );
     });
@@ -943,7 +943,7 @@ fn integration_test_replace_execute_replace_both_vaults_liquidated() {
                 old_vault.to_be_redeemed -= old_vault_id.wrapped(1000);
                 old_vault.liquidated_collateral -= collateral_for_replace;
                 old_vault.backing_collateral += collateral_for_replace; // TODO: probably should be free
-                *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
+                *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
                 old_vault.griefing_collateral -= replace.griefing_collateral();
             })
         );
@@ -968,7 +968,7 @@ fn integration_test_replace_cancel_replace_success() {
                     .free_balance
                     .get_mut(&new_vault_id.collateral_currency())
                     .unwrap() += replace.collateral().unwrap();
-                *new_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
+                *new_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
 
                 old_vault.to_be_redeemed -= old_vault_id.wrapped(1000);
 
@@ -1009,7 +1009,7 @@ fn integration_test_replace_cancel_replace_old_vault_liquidated() {
                     .free_balance
                     .get_mut(&new_vault_id.collateral_currency())
                     .unwrap() += replace.collateral().unwrap();
-                *new_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
+                *new_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
 
                 liquidation_vault.to_be_redeemed -= old_vault_id.wrapped(1000);
                 liquidation_vault.collateral += collateral_for_replace;
@@ -1035,7 +1035,7 @@ fn integration_test_replace_cancel_replace_new_vault_liquidated() {
                 old_vault.to_be_redeemed -= old_vault_id.wrapped(1000);
                 old_vault.griefing_collateral -= replace.griefing_collateral();
 
-                *new_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
+                *new_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
 
                 let new_liquidation_vault = liquidation_vault.with_currency(&new_vault_id.currencies);
                 new_liquidation_vault.to_be_issued -= old_vault_id.wrapped(1000);
@@ -1068,7 +1068,7 @@ fn integration_test_replace_cancel_replace_both_vaults_liquidated() {
                 old_vault.griefing_collateral -= replace.griefing_collateral();
                 old_vault.liquidated_collateral -= collateral_for_replace;
 
-                *new_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
+                *new_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
 
                 let old_liquidation_vault = liquidation_vault.with_currency(&old_vault_id.currencies);
                 old_liquidation_vault.to_be_redeemed -= old_vault_id.wrapped(1000);
@@ -1117,7 +1117,7 @@ fn integration_test_replace_vault_with_different_currency_succeeds() {
                 old_vault.issued -= old_vault_id.wrapped(1000);
 
                 old_vault.griefing_collateral -= replace.griefing_collateral();
-                *old_vault.free_balance.get_mut(&GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
+                *old_vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += replace.griefing_collateral();
             })
         );
     });


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

If we have the consts grouped in the currency pallet this will make it easier to query downstream.