### PR TITLE
test(standalone): Escrow

### DIFF
--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -171,6 +171,10 @@ pub type NominationError = nomination::Error<Runtime>;
 pub type NominationEvent = nomination::Event<Runtime>;
 pub type NominationPallet = nomination::Pallet<Runtime>;
 
+pub type EscrowCall = escrow::Call<Runtime>;
+pub type EscrowError = escrow::Error<Runtime>;
+pub type EscrowPallet = escrow::Pallet<Runtime>;
+
 pub type UtilityCall = pallet_utility::Call<Runtime>;
 
 pub type SchedulerCall = pallet_scheduler::Call<Runtime>;

--- a/standalone/runtime/tests/test_escrow.rs
+++ b/standalone/runtime/tests/test_escrow.rs
@@ -1,0 +1,53 @@
+mod mock;
+
+use mock::{assert_eq, *};
+use primitives::VaultCurrencyPair;
+use sp_core::H256;
+
+#[test]
+fn integration_test_individual_balance_and_total_supply() {
+    ExtBuilder::build().execute_with(|| {
+        let span = <Runtime as escrow::Config>::Span::get();
+        let current_height = SystemPallet::block_number();
+        let amount_1 = 1000_000_000_000_000;
+
+        assert_ok!(Call::Tokens(TokensCall::set_balance {
+            who: account_of(ALICE),
+            currency_id: Token(INTR),
+            new_free: amount_1,
+            new_reserved: 0,
+        })
+        .dispatch(root()));
+
+        assert_ok!(Call::Escrow(EscrowCall::create_lock {
+            amount: amount_1,
+            unlock_height: current_height + span
+        })
+        .dispatch(origin_of(account_of(ALICE))));
+
+        let height_to_check = current_height + 4 * span / 10;
+
+        assert_eq!(
+            EscrowPallet::balance_at(&account_of(ALICE), Some(height_to_check)),
+            EscrowPallet::total_supply(Some(height_to_check))
+        );
+
+        let amount_2 = 600_000_000_000_000;
+
+        assert_ok!(Call::Tokens(TokensCall::set_balance {
+            who: account_of(BOB),
+            currency_id: Token(INTR),
+            new_free: amount_2,
+            new_reserved: 0,
+        })
+        .dispatch(root()));
+
+        assert_ok!(Call::Escrow(EscrowCall::create_lock {
+            amount: amount_2,
+            unlock_height: current_height + span
+        })
+        .dispatch(origin_of(account_of(BOB))));
+
+        assert_eq!(EscrowPallet::total_supply(Some(height_to_check)), 4615308283904);
+    });
+}

--- a/standalone/runtime/tests/test_governance.rs
+++ b/standalone/runtime/tests/test_governance.rs
@@ -15,9 +15,6 @@ type DemocracyPallet = democracy::Pallet<Runtime>;
 type DemocracyEvent = democracy::Event<Runtime>;
 type DemocracyError = democracy::Error<Runtime>;
 
-type EscrowCall = escrow::Call<Runtime>;
-type EscrowError = escrow::Error<Runtime>;
-
 type TechnicalCommitteeCall = pallet_collective::Call<Runtime, TechnicalCommitteeInstance>;
 type TechnicalCommitteeEvent = pallet_collective::Event<Runtime, TechnicalCommitteeInstance>;
 


### PR DESCRIPTION
Adds an integration test to ensure that for a single user locking governance tokens, the `balance_at` and `total_supply` of vote currency is equal. Also checks the literal value of `total_supply` after a second user locks, to reuse in the JS implementation test. 