### PR TITLE
chore!: remove orml-xcm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,7 +3549,6 @@ dependencies = [
  "orml-traits",
  "orml-unknown-tokens",
  "orml-vesting",
- "orml-xcm",
  "orml-xcm-support",
  "orml-xtokens",
  "pallet-aura",
@@ -3987,7 +3986,6 @@ dependencies = [
  "orml-traits",
  "orml-unknown-tokens",
  "orml-vesting",
- "orml-xcm",
  "orml-xcm-support",
  "orml-xtokens",
  "pallet-aura",
@@ -5763,20 +5761,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "orml-xcm"
-version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=63b32194e7b9aff6a6350d2d4434525de4eec7c1#63b32194e7b9aff6a6350d2d4434525de4eec7c1"
-dependencies = [
- "frame-support",
- "frame-system",
- "pallet-xcm",
- "parity-scale-codec",
- "scale-info",
- "sp-std",
- "xcm",
 ]
 
 [[package]]
@@ -11647,7 +11631,6 @@ dependencies = [
  "orml-traits",
  "orml-unknown-tokens",
  "orml-vesting",
- "orml-xcm",
  "orml-xcm-support",
  "orml-xtokens",
  "pallet-aura",

--- a/parachain/runtime/interlay/Cargo.toml
+++ b/parachain/runtime/interlay/Cargo.toml
@@ -112,7 +112,6 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
-orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     spec_version: 1,
     impl_version: 1,
-    transaction_version: 2, // added orml-xcm
+    transaction_version: 2, // added preimage
     apis: RUNTIME_API_VERSIONS,
     state_version: 1,
 };
@@ -1239,11 +1239,6 @@ impl nomination::Config for Runtime {
     type WeightInfo = ();
 }
 
-impl orml_xcm::Config for Runtime {
-    type Event = Event;
-    type SovereignOrigin = EnsureRoot<AccountId>;
-}
-
 construct_runtime! {
     pub enum Runtime where
         Block = Block,
@@ -1308,7 +1303,6 @@ construct_runtime! {
         XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>},
         PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin},
-        OrmlXcm: orml_xcm::{Pallet, Call, Event<T>},
         DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>},
 
         XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},

--- a/parachain/runtime/kintsugi/Cargo.toml
+++ b/parachain/runtime/kintsugi/Cargo.toml
@@ -109,7 +109,6 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
-orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -96,7 +96,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     spec_version: 9, // 1.5.9
     impl_version: 1,
-    transaction_version: 3, // added orml-xcm
+    transaction_version: 3, // added preimage
     apis: RUNTIME_API_VERSIONS,
     state_version: 1,
 };
@@ -812,11 +812,6 @@ pub type LocalAssetTransactor = MultiCurrencyAdapter<
 
 pub use currency_id_convert::CurrencyIdConvert;
 
-impl orml_xcm::Config for Runtime {
-    type Event = Event;
-    type SovereignOrigin = EnsureRoot<AccountId>;
-}
-
 mod currency_id_convert {
     use super::*;
     use codec::{Decode, Encode};
@@ -1329,7 +1324,6 @@ construct_runtime! {
         XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>},
         PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin},
-        OrmlXcm: orml_xcm::{Pallet, Call, Event<T>},
         DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>},
 
         XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},

--- a/parachain/runtime/testnet/Cargo.toml
+++ b/parachain/runtime/testnet/Cargo.toml
@@ -112,7 +112,6 @@ orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
-orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "63b32194e7b9aff6a6350d2d4434525de4eec7c1", default-features = false }
 

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -96,7 +96,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     authoring_version: 1,
     spec_version: 0,
     impl_version: 1,
-    transaction_version: 1, // added orml-xcm
+    transaction_version: 1, // added preimage
     apis: RUNTIME_API_VERSIONS,
     state_version: 1,
 };
@@ -1264,11 +1264,6 @@ impl nomination::Config for Runtime {
     type WeightInfo = ();
 }
 
-impl orml_xcm::Config for Runtime {
-    type Event = Event;
-    type SovereignOrigin = EnsureRoot<AccountId>;
-}
-
 construct_runtime! {
     pub enum Runtime where
         Block = Block,
@@ -1333,7 +1328,6 @@ construct_runtime! {
         XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>},
         PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin},
-        OrmlXcm: orml_xcm::{Pallet, Call, Event<T>},
         DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>},
 
         XTokens: orml_xtokens::{Pallet, Storage, Call, Event<T>},


### PR DESCRIPTION
I added the pallet to be able to execute functions on the relay chain with our sovereign account as origin, but it turns out the same can be achieved by calling the regular xcm's `send` function with `root` as origin.