### PR TITLE
fix: allow unpaid xcm messages in the testnet runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11625,6 +11625,7 @@ dependencies = [
  "hex-literal 0.3.4",
  "interbtc-primitives",
  "issue",
+ "log",
  "mocktopus",
  "module-btc-relay-rpc-runtime-api",
  "module-issue-rpc-runtime-api",

--- a/parachain/runtime/testnet/Cargo.toml
+++ b/parachain/runtime/testnet/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0.130", default-features = false, features = ["derive"], 
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.3.1" }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
+log = { version = "0.4.14", default-features = false }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16", default-features = false }


### PR DESCRIPTION
Without this, we can't send tokens to the sibling chain in the rococo-local setup. 