### PR TITLE
fix: add xcm storage and config in construct_runtime

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1283,7 +1283,7 @@ construct_runtime! {
 
         // XCM helpers.
         XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 40,
-        PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin} = 41,
+        PolkadotXcm: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config} = 41,
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin} = 42,
         DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 43,
 

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1322,7 +1322,7 @@ construct_runtime! {
 
         // XCM helpers.
         XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 37,
-        PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin} = 38,
+        PolkadotXcm: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config} = 38,
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin} = 39,
         DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 40,
 

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -1348,7 +1348,7 @@ construct_runtime! {
 
         // XCM helpers.
         XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 40,
-        PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin} = 41,
+        PolkadotXcm: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config} = 41,
         CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin} = 42,
         DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 43,
 

--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -586,6 +586,9 @@ fn testnet_genesis(
             start_height: testnet_runtime::YEARS * 4,
             inflation: FixedU128::checked_from_rational(2, 100).unwrap(), // 2%
         },
+        polkadot_xcm: testnet_runtime::PolkadotXcmConfig {
+            safe_xcm_version: Some(2),
+        },
     }
 }
 
@@ -738,6 +741,9 @@ fn kintsugi_mainnet_genesis(
             // start of year 5
             start_height: kintsugi_runtime::YEARS * 4,
             inflation: FixedU128::checked_from_rational(2, 100).unwrap(), // 2%
+        },
+        polkadot_xcm: kintsugi_runtime::PolkadotXcmConfig {
+            safe_xcm_version: Some(2),
         },
     }
 }
@@ -930,6 +936,9 @@ fn interlay_mainnet_genesis(
             // start of year 5
             start_height: interlay_runtime::YEARS * 4,
             inflation: FixedU128::checked_from_rational(2, 100).unwrap(), // 2%
+        },
+        polkadot_xcm: interlay_runtime::PolkadotXcmConfig {
+            safe_xcm_version: Some(2),
         },
     }
 }


### PR DESCRIPTION
Adding storage adds storage metadata, such that it is visible in the chain explorer. Adding the config sets a default xcm version, such that we don't have to sudo forceXcmVersion.

Addresses the finding of the HydraDX team