### PR TITLE
fix: only use 6 second slot time for kintsugi

### DIFF
--- a/parachain/src/command.rs
+++ b/parachain/src/command.rs
@@ -37,7 +37,7 @@ use std::{io::Write, net::SocketAddr};
 
 const DEFAULT_PARA_ID: u32 = 2121;
 
-trait IdentifyChain {
+pub trait IdentifyChain {
     fn is_interlay(&self) -> bool;
     fn is_kintsugi(&self) -> bool;
     fn is_testnet(&self) -> bool;


### PR DESCRIPTION
This doesn't fix the actual slot time on kintsugi, this is only an intermediate solution so that we can build nodes that will work for both kintsugi and testnets again. The slot time fix as described by Basti seems to be impossible - see element (there _is_ a way to fix it, but it involves stopping block production until the nodes are upgrade; this is the probably the best way forward in the long term)