### PR TITLE
Stack overflow due to missing decode limit in do_enact_proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "sp-api",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/crates/democracy/Cargo.toml
+++ b/crates/democracy/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0.130", default-features = false, features = ["derive"], 
 codec = { package = "parity-scale-codec", version = "2.2.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }

--- a/crates/democracy/src/lib.rs
+++ b/crates/democracy/src/lib.rs
@@ -78,7 +78,7 @@
 #![recursion_limit = "256"]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode, Input, MaxEncodedLen};
+use codec::{Decode, DecodeLimit, Encode, Input, MaxEncodedLen};
 use frame_support::{
     ensure,
     traits::{
@@ -172,7 +172,7 @@ pub mod pallet {
 
     #[pallet::config]
     pub trait Config: frame_system::Config + Sized {
-        type Proposal: Parameter + UnfilteredDispatchable<Origin = Self::Origin> + From<Call<Self>>;
+        type Proposal: DecodeLimit + Parameter + UnfilteredDispatchable<Origin = Self::Origin> + From<Call<Self>>;
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
         /// Currency type for this pallet.
@@ -911,7 +911,7 @@ impl<T: Config> Pallet<T> {
             ..
         }) = preimage
         {
-            if let Ok(proposal) = T::Proposal::decode(&mut &data[..]) {
+            if let Ok(proposal) = T::Proposal::decode_with_depth_limit(sp_api::MAX_EXTRINSIC_DEPTH, &mut &data[..]) {
                 let err_amount = T::Currency::unreserve(&provider, deposit);
                 debug_assert!(err_amount.is_zero());
                 Self::deposit_event(Event::<T>::PreimageUsed(proposal_hash, provider, deposit));


### PR DESCRIPTION
Finding by [Security Research Labs](https://www.srlabs.de/).

This can be exploited by an attacker by sending a highly nested Proposal message.

Upon decoding, this will cause stack overflow.

## Risk

An attacker can crafted highly nested message, for which, because of high amount of recursive calls, the stack size is insufficient during decoding. This can cause a panic in the runtime, which could potentially cause validators to fail at block production at miss their slots.

## Mitigation

Consider using `DecodeLimit`