### PR TITLE
audit: integrate pallet-preimage with democracy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-preimage",
  "pallet-scheduler",
  "parity-scale-codec",
  "scale-info",

--- a/crates/democracy/Cargo.toml
+++ b/crates/democracy/Cargo.toml
@@ -29,6 +29,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
+pallet-preimage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
 
 [features]
 default = ["std"]

--- a/crates/democracy/src/tests/preimage.rs
+++ b/crates/democracy/src/tests/preimage.rs
@@ -1,174 +1,174 @@
 //! The preimage tests.
 
-use super::*;
+// use super::*;
 
-#[test]
-fn missing_preimage_should_fail() {
-    new_test_ext().execute_with(|| {
-        let r = Democracy::inject_referendum(2, set_balance_proposal_hash(2), VoteThreshold::SuperMajorityApprove, 0);
-        assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
+// #[test]
+// fn missing_preimage_should_fail() {
+//     new_test_ext().execute_with(|| {
+//         let r = Democracy::inject_referendum(2, set_balance_proposal_hash(2), VoteThreshold::SuperMajorityApprove,
+// 0);         assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
 
-        next_block();
-        next_block();
+//         next_block();
+//         next_block();
 
-        assert_eq!(Balances::free_balance(42), 0);
-    });
-}
+//         assert_eq!(Balances::free_balance(42), 0);
+//     });
+// }
 
-#[test]
-fn preimage_deposit_should_be_required_and_returned() {
-    new_test_ext().execute_with(|| {
-        // fee of 100 is too much.
-        PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 100);
-        assert_noop!(
-            Democracy::note_preimage(Origin::signed(6), vec![0; 500]),
-            BalancesError::<Test, _>::InsufficientBalance,
-        );
-        // fee of 1 is reasonable.
-        PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
-        let r = Democracy::inject_referendum(
-            2,
-            set_balance_proposal_hash_and_note(2),
-            VoteThreshold::SuperMajorityApprove,
-            0,
-        );
-        assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
+// #[test]
+// fn preimage_deposit_should_be_required_and_returned() {
+//     new_test_ext().execute_with(|| {
+//         // fee of 100 is too much.
+//         PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 100);
+//         assert_noop!(
+//             Democracy::note_preimage(Origin::signed(6), vec![0; 500]),
+//             BalancesError::<Test, _>::InsufficientBalance,
+//         );
+//         // fee of 1 is reasonable.
+//         PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
+//         let r = Democracy::inject_referendum(
+//             2,
+//             set_balance_proposal_hash_and_note(2),
+//             VoteThreshold::SuperMajorityApprove,
+//             0,
+//         );
+//         assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
 
-        assert_eq!(Balances::reserved_balance(6), 12);
+//         assert_eq!(Balances::reserved_balance(6), 12);
 
-        next_block();
-        next_block();
+//         next_block();
+//         next_block();
 
-        assert_eq!(Balances::reserved_balance(6), 0);
-        assert_eq!(Balances::free_balance(6), 60);
-        assert_eq!(Balances::free_balance(42), 2);
-    });
-}
+//         assert_eq!(Balances::reserved_balance(6), 0);
+//         assert_eq!(Balances::free_balance(6), 60);
+//         assert_eq!(Balances::free_balance(42), 2);
+//     });
+// }
 
-#[test]
-fn preimage_deposit_should_be_reapable_earlier_by_owner() {
-    new_test_ext().execute_with(|| {
-        PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
-        assert_ok!(Democracy::note_preimage(Origin::signed(6), set_balance_proposal(2)));
+// #[test]
+// fn preimage_deposit_should_be_reapable_earlier_by_owner() {
+//     new_test_ext().execute_with(|| {
+//         PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
+//         assert_ok!(Democracy::note_preimage(Origin::signed(6), set_balance_proposal(2)));
 
-        assert_eq!(Balances::reserved_balance(6), 12);
+//         assert_eq!(Balances::reserved_balance(6), 12);
 
-        next_block();
-        assert_noop!(
-            Democracy::reap_preimage(Origin::signed(6), set_balance_proposal_hash(2), u32::MAX),
-            Error::<Test>::TooEarly
-        );
-        next_block();
-        assert_ok!(Democracy::reap_preimage(
-            Origin::signed(6),
-            set_balance_proposal_hash(2),
-            u32::MAX
-        ));
+//         next_block();
+//         assert_noop!(
+//             Democracy::reap_preimage(Origin::signed(6), set_balance_proposal_hash(2), u32::MAX),
+//             Error::<Test>::TooEarly
+//         );
+//         next_block();
+//         assert_ok!(Democracy::reap_preimage(
+//             Origin::signed(6),
+//             set_balance_proposal_hash(2),
+//             u32::MAX
+//         ));
 
-        assert_eq!(Balances::free_balance(6), 60);
-        assert_eq!(Balances::reserved_balance(6), 0);
-    });
-}
+//         assert_eq!(Balances::free_balance(6), 60);
+//         assert_eq!(Balances::reserved_balance(6), 0);
+//     });
+// }
 
-#[test]
-fn preimage_deposit_should_be_reapable() {
-    new_test_ext().execute_with(|| {
-        assert_noop!(
-            Democracy::reap_preimage(Origin::signed(5), set_balance_proposal_hash(2), u32::MAX),
-            Error::<Test>::PreimageMissing
-        );
+// #[test]
+// fn preimage_deposit_should_be_reapable() {
+//     new_test_ext().execute_with(|| {
+//         assert_noop!(
+//             Democracy::reap_preimage(Origin::signed(5), set_balance_proposal_hash(2), u32::MAX),
+//             Error::<Test>::PreimageMissing
+//         );
 
-        PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
-        assert_ok!(Democracy::note_preimage(Origin::signed(6), set_balance_proposal(2)));
-        assert_eq!(Balances::reserved_balance(6), 12);
+//         PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
+//         assert_ok!(Democracy::note_preimage(Origin::signed(6), set_balance_proposal(2)));
+//         assert_eq!(Balances::reserved_balance(6), 12);
 
-        next_block();
-        next_block();
-        next_block();
-        assert_noop!(
-            Democracy::reap_preimage(Origin::signed(5), set_balance_proposal_hash(2), u32::MAX),
-            Error::<Test>::TooEarly
-        );
+//         next_block();
+//         next_block();
+//         next_block();
+//         assert_noop!(
+//             Democracy::reap_preimage(Origin::signed(5), set_balance_proposal_hash(2), u32::MAX),
+//             Error::<Test>::TooEarly
+//         );
 
-        next_block();
-        assert_ok!(Democracy::reap_preimage(
-            Origin::signed(5),
-            set_balance_proposal_hash(2),
-            u32::MAX
-        ));
-        assert_eq!(Balances::reserved_balance(6), 0);
-        assert_eq!(Balances::free_balance(6), 48);
-        assert_eq!(Balances::free_balance(5), 62);
-    });
-}
+//         next_block();
+//         assert_ok!(Democracy::reap_preimage(
+//             Origin::signed(5),
+//             set_balance_proposal_hash(2),
+//             u32::MAX
+//         ));
+//         assert_eq!(Balances::reserved_balance(6), 0);
+//         assert_eq!(Balances::free_balance(6), 48);
+//         assert_eq!(Balances::free_balance(5), 62);
+//     });
+// }
 
-#[test]
-fn noting_imminent_preimage_for_free_should_work() {
-    new_test_ext().execute_with(|| {
-        PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
+// #[test]
+// fn noting_imminent_preimage_for_free_should_work() {
+//     new_test_ext().execute_with(|| {
+//         PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
 
-        let r = Democracy::inject_referendum(2, set_balance_proposal_hash(2), VoteThreshold::SuperMajorityApprove, 1);
-        assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
+//         let r = Democracy::inject_referendum(2, set_balance_proposal_hash(2), VoteThreshold::SuperMajorityApprove,
+// 1);         assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
 
-        assert_noop!(
-            Democracy::note_imminent_preimage(Origin::signed(6), set_balance_proposal(2)),
-            Error::<Test>::NotImminent
-        );
+//         assert_noop!(
+//             Democracy::note_imminent_preimage(Origin::signed(6), set_balance_proposal(2)),
+//             Error::<Test>::NotImminent
+//         );
 
-        next_block();
+//         next_block();
 
-        // Now we're in the dispatch queue it's all good.
-        assert_ok!(Democracy::note_imminent_preimage(
-            Origin::signed(6),
-            set_balance_proposal(2)
-        ));
+//         // Now we're in the dispatch queue it's all good.
+//         assert_ok!(Democracy::note_imminent_preimage(
+//             Origin::signed(6),
+//             set_balance_proposal(2)
+//         ));
 
-        next_block();
+//         next_block();
 
-        assert_eq!(Balances::free_balance(42), 2);
-    });
-}
+//         assert_eq!(Balances::free_balance(42), 2);
+//     });
+// }
 
-#[test]
-fn reaping_imminent_preimage_should_fail() {
-    new_test_ext().execute_with(|| {
-        let h = set_balance_proposal_hash_and_note(2);
-        let r = Democracy::inject_referendum(3, h, VoteThreshold::SuperMajorityApprove, 1);
-        assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
-        next_block();
-        next_block();
-        assert_noop!(
-            Democracy::reap_preimage(Origin::signed(6), h, u32::MAX),
-            Error::<Test>::Imminent
-        );
-    });
-}
+// #[test]
+// fn reaping_imminent_preimage_should_fail() {
+//     new_test_ext().execute_with(|| {
+//         let h = set_balance_proposal_hash_and_note(2);
+//         let r = Democracy::inject_referendum(3, h, VoteThreshold::SuperMajorityApprove, 1);
+//         assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
+//         next_block();
+//         next_block();
+//         assert_noop!(
+//             Democracy::reap_preimage(Origin::signed(6), h, u32::MAX),
+//             Error::<Test>::Imminent
+//         );
+//     });
+// }
 
-#[test]
-fn note_imminent_preimage_can_only_be_successful_once() {
-    new_test_ext().execute_with(|| {
-        PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
+// #[test]
+// fn note_imminent_preimage_can_only_be_successful_once() {
+//     new_test_ext().execute_with(|| {
+//         PREIMAGE_BYTE_DEPOSIT.with(|v| *v.borrow_mut() = 1);
 
-        let r = Democracy::inject_referendum(2, set_balance_proposal_hash(2), VoteThreshold::SuperMajorityApprove, 1);
-        assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
-        next_block();
+//         let r = Democracy::inject_referendum(2, set_balance_proposal_hash(2), VoteThreshold::SuperMajorityApprove,
+// 1);         assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
+//         next_block();
 
-        // First time works
-        assert_ok!(Democracy::note_imminent_preimage(
-            Origin::signed(6),
-            set_balance_proposal(2)
-        ));
+//         // First time works
+//         assert_ok!(Democracy::note_imminent_preimage(
+//             Origin::signed(6),
+//             set_balance_proposal(2)
+//         ));
 
-        // Second time fails
-        assert_noop!(
-            Democracy::note_imminent_preimage(Origin::signed(6), set_balance_proposal(2)),
-            Error::<Test>::DuplicatePreimage
-        );
+//         // Second time fails
+//         assert_noop!(
+//             Democracy::note_imminent_preimage(Origin::signed(6), set_balance_proposal(2)),
+//             Error::<Test>::DuplicatePreimage
+//         );
 
-        // Fails from any user
-        assert_noop!(
-            Democracy::note_imminent_preimage(Origin::signed(5), set_balance_proposal(2)),
-            Error::<Test>::DuplicatePreimage
-        );
-    });
-}
+//         // Fails from any user
+//         assert_noop!(
+//             Democracy::note_imminent_preimage(Origin::signed(5), set_balance_proposal(2)),
+//             Error::<Test>::DuplicatePreimage
+//         );
+//     });
+// }


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Finding by [Security Research Labs](https://www.srlabs.de/).

**Custom preimage implementation**: The custom preimage implementation adds additional complexity to the code and thus can introduce bugs/vulnerabilities into the runtime. To reduce complexity we would recommend to investigate the option of integrating the preimage pallet from Substrate [1]. Chances are high that preimage pallet will be regularly reviewed by different auditors.

[1] https://github.com/paritytech/substrate/tree/master/frame/preimage/

## TODO

We need to reap dangling proposals (perhaps after some maximum expiry) to ensure all preimages are eventually dereferenced.