### PR TITLE
[BREAKING] refactor!: do not require griefing collateral argument

### DIFF
--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -125,7 +125,6 @@ benchmarks! {
         let origin: T::AccountId = account("Origin", 0, 0);
         let amount = Issue::<T>::issue_btc_dust_value(get_wrapped_currency_id::<T>()).amount() + 1000u32.into();
         let vault_id = get_vault_id::<T>();
-        let griefing: u32 = 100;
         let relayer_id: T::AccountId = account("Relayer", 0, 0);
 
         mint_collateral::<T>(&origin, (1u32 << 31).into());
@@ -188,7 +187,7 @@ benchmarks! {
         BtcRelay::<T>::store_block_header(&relayer_id, block_header).unwrap();
         Security::<T>::set_active_block_number(Security::<T>::active_block_number() + BtcRelay::<T>::parachain_confirmations());
 
-    }: _(RawOrigin::Signed(origin), amount, vault_id, griefing.into())
+    }: _(RawOrigin::Signed(origin), amount, vault_id)
 
     execute_issue {
         let origin: T::AccountId = account("Origin", 0, 0);

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -27,22 +27,17 @@ fn wrapped(amount: u128) -> Amount<Test> {
     Amount::new(amount, DEFAULT_WRAPPED_CURRENCY)
 }
 
-fn request_issue(
-    origin: AccountId,
-    amount: Balance,
-    vault: DefaultVaultId<Test>,
-    collateral: Balance,
-) -> Result<H256, DispatchError> {
+fn request_issue(origin: AccountId, amount: Balance, vault: DefaultVaultId<Test>) -> Result<H256, DispatchError> {
     ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(get_dummy_request_id()));
 
     ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
     ext::vault_registry::register_deposit_address::<Test>
         .mock_safe(|_, _| MockResult::Return(Ok(BtcAddress::default())));
 
-    Issue::_request_issue(origin, amount, vault, collateral)
+    Issue::_request_issue(origin, amount, vault)
 }
 
-fn request_issue_ok(origin: AccountId, amount: Balance, vault: DefaultVaultId<Test>, collateral: Balance) -> H256 {
+fn request_issue_ok(origin: AccountId, amount: Balance, vault: DefaultVaultId<Test>) -> H256 {
     ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_| MockResult::Return(Ok(())));
 
     ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(get_dummy_request_id()));
@@ -51,7 +46,7 @@ fn request_issue_ok(origin: AccountId, amount: Balance, vault: DefaultVaultId<Te
     ext::vault_registry::register_deposit_address::<Test>
         .mock_safe(|_, _| MockResult::Return(Ok(BtcAddress::default())));
 
-    Issue::_request_issue(origin, amount, vault, collateral).unwrap()
+    Issue::_request_issue(origin, amount, vault).unwrap()
 }
 
 fn execute_issue(origin: AccountId, issue_id: &H256) -> Result<(), DispatchError> {
@@ -93,19 +88,7 @@ fn test_request_issue_banned_fails() {
                 liquidated_collateral: 0,
             },
         );
-        assert_noop!(request_issue(USER, 3, VAULT, 0), VaultRegistryError::VaultBanned);
-    })
-}
-
-#[test]
-fn test_request_issue_insufficient_collateral_fails() {
-    run_test(|| {
-        ext::vault_registry::get_active_vault_from_id::<Test>
-            .mock_safe(|_| MockResult::Return(Ok(init_zero_vault(VAULT))));
-        ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_| MockResult::Return(Ok(())));
-        convert_to.mock_safe(|_, _| MockResult::Return(Ok(10000000)));
-
-        assert_noop!(request_issue(USER, 3, VAULT, 0), TestError::InsufficientCollateral,);
+        assert_noop!(request_issue(USER, 3, VAULT), VaultRegistryError::VaultBanned);
     })
 }
 
@@ -126,7 +109,7 @@ fn test_request_issue_succeeds() {
         ext::fee::get_issue_griefing_collateral::<Test>
             .mock_safe(move |_| MockResult::Return(Ok(griefing(issue_griefing_collateral))));
 
-        let issue_id = request_issue_ok(origin, amount, vault.clone(), issue_griefing_collateral);
+        let issue_id = request_issue_ok(origin, amount, vault.clone());
 
         let request_issue_event = TestEvent::Issue(Event::RequestIssue {
             issue_id,
@@ -162,7 +145,7 @@ fn test_execute_issue_succeeds() {
 
         ext::fee::get_issue_fee::<Test>.mock_safe(move |_| MockResult::Return(Ok(wrapped(1))));
 
-        let issue_id = request_issue_ok(USER, 3, VAULT, 20);
+        let issue_id = request_issue_ok(USER, 3, VAULT);
         <security::Pallet<Test>>::set_active_block_number(5);
 
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
@@ -192,7 +175,7 @@ fn test_execute_issue_overpayment_succeeds() {
             .mock_safe(|_| MockResult::Return(Ok(init_zero_vault(VAULT))));
         ext::vault_registry::issue_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
 
-        let issue_id = request_issue_ok(USER, 3, VAULT, 20);
+        let issue_id = request_issue_ok(USER, 3, VAULT);
         <security::Pallet<Test>>::set_active_block_number(5);
 
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
@@ -232,7 +215,7 @@ fn test_execute_issue_refund_succeeds() {
             .mock_safe(|_| MockResult::Return(Ok(init_zero_vault(VAULT))));
         ext::vault_registry::issue_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
 
-        let issue_id = request_issue_ok(USER, 3, VAULT, 20);
+        let issue_id = request_issue_ok(USER, 3, VAULT);
         <security::Pallet<Test>>::set_active_block_number(5);
 
         // pay 103 instead of the expected 3
@@ -278,7 +261,7 @@ fn test_cancel_issue_not_expired_fails() {
         ext::vault_registry::get_active_vault_from_id::<Test>
             .mock_safe(|_| MockResult::Return(Ok(init_zero_vault(VAULT))));
 
-        let issue_id = request_issue_ok(USER, 3, VAULT, 20);
+        let issue_id = request_issue_ok(USER, 3, VAULT);
         // issue period is 10, we issued at block 1, so at block 5 the cancel should fail
         <security::Pallet<Test>>::set_active_block_number(5);
         assert_noop!(cancel_issue(USER, &issue_id), TestError::TimeNotExpired,);

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -117,9 +117,8 @@ pub(crate) mod vault_registry {
     pub fn try_increase_to_be_replaced_tokens<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
         amount: &Amount<T>,
-        griefing_collateral: &Amount<T>,
     ) -> Result<(Amount<T>, Amount<T>), DispatchError> {
-        <vault_registry::Pallet<T>>::try_increase_to_be_replaced_tokens(vault_id, amount, griefing_collateral)
+        <vault_registry::Pallet<T>>::try_increase_to_be_replaced_tokens(vault_id, amount)
     }
 
     pub fn decrease_to_be_replaced_tokens<T: crate::Config>(

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -117,7 +117,7 @@ pub(crate) mod vault_registry {
     pub fn try_increase_to_be_replaced_tokens<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
         amount: &Amount<T>,
-    ) -> Result<(Amount<T>, Amount<T>), DispatchError> {
+    ) -> Result<Amount<T>, DispatchError> {
         <vault_registry::Pallet<T>>::try_increase_to_be_replaced_tokens(vault_id, amount)
     }
 

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -106,6 +106,8 @@ pub mod pallet {
 
     #[pallet::error]
     pub enum Error<T> {
+        /// Replace requires non-zero increase.
+        ReplaceAmountZero,
         /// Replace amount is too small.
         AmountBelowDustAmount,
         /// No replace request found.

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -59,7 +59,7 @@ mod request_replace_tests {
         ext::vault_registry::requestable_to_be_replaced_tokens::<Test>
             .mock_safe(move |_| MockResult::Return(Ok(wrapped(1000000))));
         ext::vault_registry::try_increase_to_be_replaced_tokens::<Test>
-            .mock_safe(|_, _, _| MockResult::Return(Ok((wrapped(2), griefing(20)))));
+            .mock_safe(|_, _| MockResult::Return(Ok((wrapped(2), griefing(20)))));
         ext::fee::get_replace_griefing_collateral::<Test>.mock_safe(move |_| MockResult::Return(Ok(griefing(20))));
         ext::vault_registry::transfer_funds::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
     }
@@ -68,11 +68,11 @@ mod request_replace_tests {
     fn test_request_replace_total_to_be_replace_above_dust_succeeds() {
         run_test(|| {
             setup_mocks();
-            assert_ok!(Replace::_request_replace(OLD_VAULT, 1, 10));
+            assert_ok!(Replace::_request_replace(OLD_VAULT, 1));
             assert_event_matches!(Event::RequestReplace {
                 old_vault_id: OLD_VAULT,
                 amount: 1,
-                griefing_collateral: 10
+                ..
             });
         })
     }
@@ -83,11 +83,11 @@ mod request_replace_tests {
             setup_mocks();
             ext::vault_registry::requestable_to_be_replaced_tokens::<Test>
                 .mock_safe(move |_| MockResult::Return(Ok(wrapped(5))));
-            assert_ok!(Replace::_request_replace(OLD_VAULT, 10, 20));
+            assert_ok!(Replace::_request_replace(OLD_VAULT, 10));
             assert_event_matches!(Event::RequestReplace {
                 old_vault_id: OLD_VAULT,
                 amount: 5,
-                griefing_collateral: 10
+                ..
             });
         })
     }
@@ -97,22 +97,10 @@ mod request_replace_tests {
         run_test(|| {
             setup_mocks();
             ext::vault_registry::try_increase_to_be_replaced_tokens::<Test>
-                .mock_safe(|_, _, _| MockResult::Return(Ok((wrapped(1), griefing(10)))));
+                .mock_safe(|_, _| MockResult::Return(Ok((wrapped(1), griefing(10)))));
             assert_err!(
-                Replace::_request_replace(OLD_VAULT, 1, 10),
+                Replace::_request_replace(OLD_VAULT, 1),
                 TestError::AmountBelowDustAmount
-            );
-        })
-    }
-
-    #[test]
-    fn test_request_replace_with_insufficient_griefing_collateral_fails() {
-        run_test(|| {
-            setup_mocks();
-            ext::fee::get_replace_griefing_collateral::<Test>.mock_safe(move |_| MockResult::Return(Ok(griefing(25))));
-            assert_err!(
-                Replace::_request_replace(OLD_VAULT, 1, 10),
-                TestError::InsufficientCollateral
             );
         })
     }

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -59,7 +59,7 @@ mod request_replace_tests {
         ext::vault_registry::requestable_to_be_replaced_tokens::<Test>
             .mock_safe(move |_| MockResult::Return(Ok(wrapped(1000000))));
         ext::vault_registry::try_increase_to_be_replaced_tokens::<Test>
-            .mock_safe(|_, _| MockResult::Return(Ok((wrapped(2), griefing(20)))));
+            .mock_safe(|_, _| MockResult::Return(Ok(wrapped(2))));
         ext::fee::get_replace_griefing_collateral::<Test>.mock_safe(move |_| MockResult::Return(Ok(griefing(20))));
         ext::vault_registry::transfer_funds::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
     }
@@ -97,11 +97,21 @@ mod request_replace_tests {
         run_test(|| {
             setup_mocks();
             ext::vault_registry::try_increase_to_be_replaced_tokens::<Test>
-                .mock_safe(|_, _| MockResult::Return(Ok((wrapped(1), griefing(10)))));
+                .mock_safe(|_, _| MockResult::Return(Ok(wrapped(1))));
             assert_err!(
                 Replace::_request_replace(OLD_VAULT, 1),
                 TestError::AmountBelowDustAmount
             );
+        })
+    }
+
+    #[test]
+    fn request_replace_should_fail_with_replace_amount_zero() {
+        run_test(|| {
+            setup_mocks();
+            ext::vault_registry::try_increase_to_be_replaced_tokens::<Test>
+                .mock_safe(|_, _| MockResult::Return(Ok(wrapped(1))));
+            assert_err!(Replace::_request_replace(OLD_VAULT, 0), TestError::ReplaceAmountZero);
         })
     }
 }
@@ -133,8 +143,8 @@ mod accept_replace_tests {
             ));
             assert_event_matches!(Event::AcceptReplace{
                 replace_id: _, 
-                old_vault_id: OLD_VAULT, 
-                new_vault_id: NEW_VAULT, 
+                old_vault_id: OLD_VAULT,
+                new_vault_id: NEW_VAULT,
                 amount: 5, 
                 collateral: 10, 
                 btc_address: addr} if addr == BtcAddress::default());

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -1015,12 +1015,10 @@ impl<T: Config> Pallet<T> {
     pub fn try_increase_to_be_replaced_tokens(
         vault_id: &DefaultVaultId<T>,
         tokens: &Amount<T>,
-        griefing_collateral: &Amount<T>,
     ) -> Result<(Amount<T>, Amount<T>), DispatchError> {
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
 
         let new_to_be_replaced = vault.to_be_replaced_tokens().checked_add(&tokens)?;
-        let new_collateral = vault.replace_collateral().checked_add(&griefing_collateral)?;
         let total_decreasing_tokens = new_to_be_replaced.checked_add(&vault.to_be_redeemed_tokens())?;
 
         ensure!(
@@ -1035,7 +1033,7 @@ impl<T: Config> Pallet<T> {
             increase: tokens.amount(),
         });
 
-        Ok((new_to_be_replaced, new_collateral))
+        Ok((new_to_be_replaced, vault.replace_collateral()))
     }
 
     pub fn decrease_to_be_replaced_tokens(

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -1015,7 +1015,7 @@ impl<T: Config> Pallet<T> {
     pub fn try_increase_to_be_replaced_tokens(
         vault_id: &DefaultVaultId<T>,
         tokens: &Amount<T>,
-    ) -> Result<(Amount<T>, Amount<T>), DispatchError> {
+    ) -> Result<Amount<T>, DispatchError> {
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;
 
         let new_to_be_replaced = vault.to_be_replaced_tokens().checked_add(&tokens)?;
@@ -1033,7 +1033,7 @@ impl<T: Config> Pallet<T> {
             increase: tokens.amount(),
         });
 
-        Ok((new_to_be_replaced, vault.replace_collateral()))
+        Ok(new_to_be_replaced)
     }
 
     pub fn decrease_to_be_replaced_tokens(

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -350,8 +350,7 @@ fn try_increase_to_be_replaced_tokens_succeeds() {
 
         assert_ok!(VaultRegistry::try_increase_to_be_issued_tokens(&id, &wrapped(50)),);
         assert_ok!(VaultRegistry::issue_tokens(&id, &wrapped(50)));
-        let res = VaultRegistry::try_increase_to_be_replaced_tokens(&id, &wrapped(50));
-        assert_ok!(res);
+        assert_ok!(VaultRegistry::try_increase_to_be_replaced_tokens(&id, &wrapped(50)));
         let vault = VaultRegistry::get_active_rich_vault_from_id(&id).unwrap();
         assert_eq!(vault.data.issued_tokens, 50);
         assert_eq!(vault.data.to_be_replaced_tokens, 50);
@@ -367,10 +366,11 @@ fn try_increase_to_be_replaced_tokens_fails_with_insufficient_tokens() {
     run_test(|| {
         let id = create_sample_vault();
 
-        let res = VaultRegistry::try_increase_to_be_replaced_tokens(&id, &wrapped(50));
-
         // important: should not change the storage state
-        assert_noop!(res, TestError::InsufficientTokensCommitted);
+        assert_noop!(
+            VaultRegistry::try_increase_to_be_replaced_tokens(&id, &wrapped(50)),
+            TestError::InsufficientTokensCommitted
+        );
     });
 }
 
@@ -1438,10 +1438,8 @@ fn test_try_increase_to_be_replaced_tokens() {
             &wrapped(1)
         ));
 
-        let (total_wrapped, previous_griefing_collateral) =
-            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(2)).unwrap();
+        let total_wrapped = VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(2)).unwrap();
         assert!(total_wrapped == wrapped(2));
-        assert!(previous_griefing_collateral == griefing(0));
 
         // check that we can't request more than we have issued tokens
         assert_noop!(
@@ -1458,10 +1456,8 @@ fn test_try_increase_to_be_replaced_tokens() {
         let mut vault = VaultRegistry::get_active_rich_vault_from_id(&vault_id).unwrap();
         vault.increase_available_replace_collateral(&griefing(10)).unwrap();
 
-        let (total_wrapped, previous_griefing_collateral) =
-            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(1)).unwrap();
+        let total_wrapped = VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(1)).unwrap();
         assert_eq!(total_wrapped, wrapped(3));
-        assert_eq!(previous_griefing_collateral, griefing(10));
 
         // check that to_be_replaced_tokens is was written to storage
         let vault = VaultRegistry::get_active_vault_from_id(&vault_id).unwrap();

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -350,7 +350,7 @@ fn try_increase_to_be_replaced_tokens_succeeds() {
 
         assert_ok!(VaultRegistry::try_increase_to_be_issued_tokens(&id, &wrapped(50)),);
         assert_ok!(VaultRegistry::issue_tokens(&id, &wrapped(50)));
-        let res = VaultRegistry::try_increase_to_be_replaced_tokens(&id, &wrapped(50), &griefing(50));
+        let res = VaultRegistry::try_increase_to_be_replaced_tokens(&id, &wrapped(50));
         assert_ok!(res);
         let vault = VaultRegistry::get_active_rich_vault_from_id(&id).unwrap();
         assert_eq!(vault.data.issued_tokens, 50);
@@ -367,7 +367,7 @@ fn try_increase_to_be_replaced_tokens_fails_with_insufficient_tokens() {
     run_test(|| {
         let id = create_sample_vault();
 
-        let res = VaultRegistry::try_increase_to_be_replaced_tokens(&id, &wrapped(50), &griefing(50));
+        let res = VaultRegistry::try_increase_to_be_replaced_tokens(&id, &wrapped(50));
 
         // important: should not change the storage state
         assert_noop!(res, TestError::InsufficientTokensCommitted);
@@ -1438,30 +1438,30 @@ fn test_try_increase_to_be_replaced_tokens() {
             &wrapped(1)
         ));
 
-        let (total_wrapped, total_griefing_collateral) =
-            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(2), &griefing(10)).unwrap();
+        let (total_wrapped, previous_griefing_collateral) =
+            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(2)).unwrap();
         assert!(total_wrapped == wrapped(2));
-        assert!(total_griefing_collateral == griefing(10));
+        assert!(previous_griefing_collateral == griefing(0));
 
         // check that we can't request more than we have issued tokens
         assert_noop!(
-            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(3), &griefing(10)),
+            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(3)),
             TestError::InsufficientTokensCommitted
         );
 
         // check that we can't request replacement for tokens that are marked as to-be-redeemed
         assert_noop!(
-            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(2), &griefing(10)),
+            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(2)),
             TestError::InsufficientTokensCommitted
         );
 
         let mut vault = VaultRegistry::get_active_rich_vault_from_id(&vault_id).unwrap();
         vault.increase_available_replace_collateral(&griefing(10)).unwrap();
 
-        let (total_wrapped, total_griefing_collateral) =
-            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(1), &griefing(20)).unwrap();
+        let (total_wrapped, previous_griefing_collateral) =
+            VaultRegistry::try_increase_to_be_replaced_tokens(&vault_id, &wrapped(1)).unwrap();
         assert_eq!(total_wrapped, wrapped(3));
-        assert_eq!(total_griefing_collateral, griefing(30));
+        assert_eq!(previous_griefing_collateral, griefing(10));
 
         // check that to_be_replaced_tokens is was written to storage
         let vault = VaultRegistry::get_active_vault_from_id(&vault_id).unwrap();
@@ -1478,7 +1478,6 @@ fn test_decrease_to_be_replaced_tokens_over_capacity() {
         assert_ok!(VaultRegistry::try_increase_to_be_replaced_tokens(
             &vault_id,
             &wrapped(4),
-            &griefing(10)
         ));
         let mut vault = VaultRegistry::get_active_rich_vault_from_id(&vault_id).unwrap();
         vault.increase_available_replace_collateral(&griefing(10)).unwrap();
@@ -1498,7 +1497,6 @@ fn test_decrease_to_be_replaced_tokens_below_capacity() {
         assert_ok!(VaultRegistry::try_increase_to_be_replaced_tokens(
             &vault_id,
             &wrapped(4),
-            &griefing(10)
         ));
         let mut vault = VaultRegistry::get_active_rich_vault_from_id(&vault_id).unwrap();
         vault.increase_available_replace_collateral(&griefing(10)).unwrap();

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -368,10 +368,6 @@ impl<T: Config> RichVault<T> {
         Amount::new(self.data.liquidated_collateral, self.data.id.currencies.collateral)
     }
 
-    pub(crate) fn replace_collateral(&self) -> Amount<T> {
-        Amount::new(self.data.replace_collateral, T::GetGriefingCollateralCurrencyId::get())
-    }
-
     pub fn get_vault_collateral(&self) -> Result<Amount<T>, DispatchError> {
         Pallet::<T>::compute_collateral(&self.id())
     }

--- a/standalone/runtime/tests/mock/issue_testing_utils.rs
+++ b/standalone/runtime/tests/mock/issue_testing_utils.rs
@@ -19,7 +19,6 @@ pub struct RequestIssueBuilder {
     amount_btc: Balance,
     vault_id: VaultId,
     user: [u8; 32],
-    griefing_collateral: Balance,
 }
 
 impl RequestIssueBuilder {
@@ -28,17 +27,11 @@ impl RequestIssueBuilder {
             amount_btc: amount_btc.amount(),
             vault_id: vault_id.clone(),
             user: USER,
-            griefing_collateral: DEFAULT_COLLATERAL,
         }
     }
 
     pub fn with_vault(&mut self, vault: VaultId) -> &mut Self {
         self.vault_id = vault;
-        self
-    }
-
-    pub fn with_collateral(&mut self, collateral: Amount<Runtime>) -> &mut Self {
-        self.griefing_collateral = collateral.amount();
         self
     }
 
@@ -56,7 +49,6 @@ impl RequestIssueBuilder {
         assert_ok!(Call::Issue(IssueCall::request_issue {
             amount: self.amount_btc,
             vault_id: self.vault_id.clone(),
-            griefing_collateral: self.griefing_collateral
         })
         .dispatch(origin_of(account_of(self.user))));
 

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -630,7 +630,6 @@ impl CoreVaultData {
         assert_ok!(VaultRegistryPallet::try_increase_to_be_replaced_tokens(
             &vault_id,
             &state.to_be_replaced,
-            &state.replace_collateral
         ));
         VaultRegistryPallet::collateral_integrity_check();
 

--- a/standalone/runtime/tests/test_nomination.rs
+++ b/standalone/runtime/tests/test_nomination.rs
@@ -477,7 +477,6 @@ fn integration_test_nominated_collateral_prevents_replace_requests() {
             Call::Replace(ReplaceCall::request_replace {
                 currency_pair: vault_id.currencies.clone(),
                 amount: 0,
-                griefing_collateral: DEFAULT_BACKING_COLLATERAL
             })
             .dispatch(origin_of(vault_id.account_id.clone())),
             ReplaceError::VaultHasEnabledNomination
@@ -489,12 +488,10 @@ fn integration_test_nominated_collateral_prevents_replace_requests() {
 fn integration_test_vaults_with_zero_nomination_cannot_request_replacement() {
     test_with_nomination_enabled_and_vault_opted_in(|vault_id| {
         let amount = DEFAULT_VAULT_ISSUED - DEFAULT_VAULT_TO_BE_REDEEMED - DEFAULT_VAULT_TO_BE_REPLACED;
-        let griefing_collateral = 200;
         assert_noop!(
             Call::Replace(ReplaceCall::request_replace {
                 currency_pair: vault_id.currencies.clone(),
                 amount: amount.amount(),
-                griefing_collateral: griefing_collateral
             })
             .dispatch(origin_of(vault_id.account_id.clone())),
             ReplaceError::VaultHasEnabledNomination

--- a/standalone/runtime/tests/test_redeem.rs
+++ b/standalone/runtime/tests/test_redeem.rs
@@ -1225,7 +1225,6 @@ fn integration_test_redeem_parachain_status_shutdown_fails() {
             Call::Issue(IssueCall::request_issue {
                 amount: 0,
                 vault_id: vault_id.clone(),
-                griefing_collateral: 0
             })
             .dispatch(origin_of(account_of(ALICE))),
             SystemError::CallFiltered,

--- a/standalone/runtime/tests/test_relayers.rs
+++ b/standalone/runtime/tests/test_relayers.rs
@@ -420,11 +420,7 @@ fn integration_test_double_spend_replace() {
         CoreVaultData::force_to(&stealing_vault_id, default_vault_state(&stealing_vault_id));
         CoreVaultData::force_to(&new_vault_id, default_vault_state(&new_vault_id));
 
-        assert_ok!(request_replace(
-            &stealing_vault_id,
-            issued_tokens,
-            DEFAULT_GRIEFING_COLLATERAL
-        ));
+        request_replace(&stealing_vault_id, issued_tokens);
         let (replace, replace_id) = setup_replace(&stealing_vault_id, &new_vault_id, replace_amount);
         let current_block_number = 1;
 

--- a/standalone/runtime/tests/test_replace.rs
+++ b/standalone/runtime/tests/test_replace.rs
@@ -684,10 +684,14 @@ fn integration_test_replace_with_parachain_shutdown_fails() {
     test_with(|old_vault_id, new_vault_id| {
         SecurityPallet::set_status(StatusCode::Shutdown);
 
-        // assert_noop!(
-        //     request_replace(&old_vault_id, old_vault_id.wrapped(0), griefing(0)),
-        //     SystemError::CallFiltered,
-        // );
+        assert_noop!(
+            Call::Replace(ReplaceCall::request_replace {
+                currency_pair: old_vault_id.currencies.clone(),
+                amount: old_vault_id.wrapped(0).amount(),
+            })
+            .dispatch(origin_of(old_vault_id.account_id.clone())),
+            SystemError::CallFiltered,
+        );
         assert_noop!(
             withdraw_replace(&old_vault_id, old_vault_id.wrapped(0)),
             SystemError::CallFiltered


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

This PR removes the griefing collateral parameters from `request_issue` and `request_replace` since we anyway override the value and it is complicated to determine ahead-of-time.