### PR TITLE
chore: document all system accounts

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -907,12 +907,19 @@ parameter_types! {
 }
 
 parameter_types! {
+    // wd9yNSwR5jsJWJNNuqYxifekh2dwu9u15Sr1tP5kmKTJBLc4R
     pub FeeAccount: AccountId = FeePalletId::get().into_account();
+    // wd9yNSwR5jsJWJmaV4ccaRqdxXFTJUS4shu7RMuSVk3c5F3f4
     pub SupplyAccount: AccountId = SupplyPalletId::get().into_account();
+    // wd9yNSwR495PKYxKfdeuMcNyu6kqay7wKeWcLMvQ8muuWVPYj
     pub EscrowAnnuityAccount: AccountId = EscrowAnnuityPalletId::get().into_account();
+    // wd9yNSwR7YL4Y4PEtY4pUxYR2jeVdsgwyoN8fwVc9196VMAt4
     pub VaultAnnuityAccount: AccountId = VaultAnnuityPalletId::get().into_account();
+    // wd9yNSwR5jsJWJoLHrMKt4K2T7R5392YmZoRdpqijnpLGzEcT
     pub TreasuryAccount: AccountId = TreasuryPalletId::get().into_account();
+    // wd9yNSwR3jeqTuo91k53PUAcfaqX5ZCK4gCPHa5G3h1y8kBEe
     pub CollatorSelectionAccount: AccountId = CollatorPotId::get().into_account();
+    // wd9yNSwR5jsJWJrtHcnS8Wf6D5zF2dbQhxwRuvAzg9jefbhuM
     pub VaultRegistryAccount: AccountId = VaultRegistryPalletId::get().into_account();
 }
 

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -943,17 +943,17 @@ parameter_types! {
 }
 
 parameter_types! {
-    // 5EYCAe5i8QbRr5WN1PvaAVqPbfXsqazk9ocaxuzcTjgXPM1e
+    // a3cgeH7D28bBsH77KFYdoMgyiXUHdk98XT5M2Wv5EgC45Kqya
     pub FeeAccount: AccountId = FeePalletId::get().into_account();
-    // 5EYCAe5i8QbRrUhwETaRvgif6H3HA84YQri7wjgLtKzRJCML
+    // a3cgeH7D28bBsHWJtUcHf7srz25o34gCKi8SZVjky6nMyEm83
     pub SupplyAccount: AccountId = SupplyPalletId::get().into_account();
-    // 5EYCAe5gXcgF6fT7oVsD7E4bfnRZeovzMUD2wkdyvCHrYQQE
+    // a3cgeH7CzXoGgXh453eaSJRCvbbBKZN4mejwUVkic8efQUi5R
     pub EscrowAnnuityAccount: AccountId = EscrowAnnuityPalletId::get().into_account();
-    // 5EYCAe5jvsMTc6NLhunLTPVjJg5cZNweWKjNXKqz9RUqQJDY
+    // a3cgeH7D3w3wu37yHx4VZeae4EUqNTw5RobTp5KvcMsrPLWJg
     pub VaultAnnuityAccount: AccountId = VaultAnnuityPalletId::get().into_account();
-    // 5EYCAe5i8QbRrWTk2CHjZA79gSf1piYSGm2LQfxaw6id3M88
+    // a3cgeH7D28bBsHY4hGLzxkMFUcFQmjGgDa2kmxg3D9Z6AyhtL
     pub TreasuryAccount: AccountId = TreasuryPalletId::get().into_account();
-    // 5EYCAe5i8QbRra1jndPz1WAuf1q1KHQNfu2cW1EXJ231emTd
+    // a3cgeH7D28bBsHbch2n7DChKEapamDqY9yAm441K9WUQZbBGJ
     pub VaultRegistryAccount: AccountId = VaultRegistryPalletId::get().into_account();
 }
 

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -973,12 +973,19 @@ parameter_types! {
 }
 
 parameter_types! {
+    // 5EYCAe5i8QbRr5WN1PvaAVqPbfXsqazk9ocaxuzcTjgXPM1e
     pub FeeAccount: AccountId = FeePalletId::get().into_account();
+    // 5EYCAe5i8QbRrUhwETaRvgif6H3HA84YQri7wjgLtKzRJCML
     pub SupplyAccount: AccountId = SupplyPalletId::get().into_account();
+    // 5EYCAe5gXcgF6fT7oVsD7E4bfnRZeovzMUD2wkdyvCHrYQQE
     pub EscrowAnnuityAccount: AccountId = EscrowAnnuityPalletId::get().into_account();
+    // 5EYCAe5jvsMTc6NLhunLTPVjJg5cZNweWKjNXKqz9RUqQJDY
     pub VaultAnnuityAccount: AccountId = VaultAnnuityPalletId::get().into_account();
+    // 5EYCAe5i8QbRrWTk2CHjZA79gSf1piYSGm2LQfxaw6id3M88
     pub TreasuryAccount: AccountId = TreasuryPalletId::get().into_account();
+    // 5EYCAe5g8C8PTWGTuv1Ey1hN9s74EtJjP9yz9uVtqJMUoBkH
     pub CollatorSelectionAccount: AccountId = CollatorPotId::get().into_account();
+    // 5EYCAe5i8QbRra1jndPz1WAuf1q1KHQNfu2cW1EXJ231emTd
     pub VaultRegistryAccount: AccountId = VaultRegistryPalletId::get().into_account();
 }
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -567,11 +567,17 @@ parameter_types! {
 }
 
 parameter_types! {
+    // 5EYCAe5i8QbRr5WN1PvaAVqPbfXsqazk9ocaxuzcTjgXPM1e
     pub FeeAccount: AccountId = FeePalletId::get().into_account();
+    // 5EYCAe5i8QbRrUhwETaRvgif6H3HA84YQri7wjgLtKzRJCML
     pub SupplyAccount: AccountId = SupplyPalletId::get().into_account();
+    // 5EYCAe5gXcgF6fT7oVsD7E4bfnRZeovzMUD2wkdyvCHrYQQE
     pub EscrowAnnuityAccount: AccountId = EscrowAnnuityPalletId::get().into_account();
+    // 5EYCAe5jvsMTc6NLhunLTPVjJg5cZNweWKjNXKqz9RUqQJDY
     pub VaultAnnuityAccount: AccountId = VaultAnnuityPalletId::get().into_account();
+    // 5EYCAe5i8QbRrWTk2CHjZA79gSf1piYSGm2LQfxaw6id3M88
     pub TreasuryAccount: AccountId = TreasuryPalletId::get().into_account();
+    // 5EYCAe5i8QbRra1jndPz1WAuf1q1KHQNfu2cW1EXJ231emTd
     pub VaultRegistryAccount: AccountId = VaultRegistryPalletId::get().into_account();
 }
 


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Example:
```rust
println!(
    "{}",
    sp_runtime::app_crypto::Ss58Codec::to_ss58check_with_version(
        &sp_runtime::traits::AccountIdConversion::<primitives::AccountId>::into_account(&frame_support::PalletId(
            *b"mod/fees"
        )),
        42_u16.into()
    )
)
```