### PR TITLE
fix: fix kintsugi node

### DIFF
--- a/parachain/src/service.rs
+++ b/parachain/src/service.rs
@@ -8,7 +8,6 @@ use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_interface::RelayChainInterface;
 use cumulus_relay_chain_local::build_relay_chain_interface;
 
-use crate::command::IdentifyChain;
 use primitives::*;
 use sc_client_api::ExecutorProvider;
 use sc_executor::NativeElseWasmExecutor;
@@ -438,7 +437,7 @@ where
     RuntimeApi::RuntimeApi: sp_consensus_aura::AuraApi<Block, AuraId>,
     Executor: sc_executor::NativeExecutionDispatch + 'static,
 {
-    let slot_ms = if parachain_config.chain_spec.is_kintsugi() {
+    let slot_ms = if parachain_config.chain_spec.id() == "kusama" {
         6000
     } else {
         12000


### PR DESCRIPTION
The id in the [chainspec](https://github.com/interlay/interbtc/blob/master/parachain/res/kintsugi.json) is "kusama" rather than "kintsugi". We can change either the check in service, or the chainspec. I figured the risk of unforeseen consequences is smaller when going with the former approach, so that is what I did