### PR TITLE
feat!: allow some democracy proposals to be baked immediately

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -502,6 +502,18 @@ type EnsureRootOrAllTechnicalCommittee = EnsureOneOf<
     pallet_collective::EnsureProportionAtLeast<_1, _1, AccountId, TechnicalCommitteeInstance>,
 >;
 
+pub struct ImminentFilter;
+impl Contains<Call> for ImminentFilter {
+    fn contains(call: &Call) -> bool {
+        matches!(
+            call,
+            Call::Treasury(
+                pallet_treasury::Call::approve_proposal { .. } | pallet_treasury::Call::reject_proposal { .. }
+            )
+        )
+    }
+}
+
 parameter_types! {
     pub const LaunchPeriod: BlockNumber = 7 * DAYS;
     pub const VotingPeriod: BlockNumber = 7 * DAYS;
@@ -534,6 +546,7 @@ impl democracy::Config for Runtime {
     type MaxVotes = MaxVotes;
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
+    type ImminentFilter = ImminentFilter;
 }
 
 parameter_types! {

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -468,6 +468,18 @@ type EnsureRootOrAllTechnicalCommittee = EnsureOneOf<
     pallet_collective::EnsureProportionAtLeast<_1, _1, AccountId, TechnicalCommitteeInstance>,
 >;
 
+pub struct ImminentFilter;
+impl Contains<Call> for ImminentFilter {
+    fn contains(call: &Call) -> bool {
+        matches!(
+            call,
+            Call::Treasury(
+                pallet_treasury::Call::approve_proposal { .. } | pallet_treasury::Call::reject_proposal { .. }
+            )
+        )
+    }
+}
+
 parameter_types! {
     pub const LaunchPeriod: BlockNumber = 7 * DAYS;
     pub const VotingPeriod: BlockNumber = 7 * DAYS;
@@ -501,6 +513,7 @@ impl democracy::Config for Runtime {
     type MaxVotes = MaxVotes;
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
+    type ImminentFilter = ImminentFilter;
 }
 
 parameter_types! {

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -473,6 +473,18 @@ type EnsureRootOrAllTechnicalCommittee = EnsureOneOf<
     pallet_collective::EnsureProportionAtLeast<_1, _1, AccountId, TechnicalCommitteeInstance>,
 >;
 
+pub struct ImminentFilter;
+impl Contains<Call> for ImminentFilter {
+    fn contains(call: &Call) -> bool {
+        matches!(
+            call,
+            Call::Treasury(
+                pallet_treasury::Call::approve_proposal { .. } | pallet_treasury::Call::reject_proposal { .. }
+            )
+        )
+    }
+}
+
 parameter_types! {
     pub const LaunchPeriod: BlockNumber = 7 * DAYS;
     pub const VotingPeriod: BlockNumber = 7 * DAYS;
@@ -506,6 +518,7 @@ impl democracy::Config for Runtime {
     type MaxVotes = MaxVotes;
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
+    type ImminentFilter = ImminentFilter;
 }
 
 parameter_types! {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -443,6 +443,18 @@ type EnsureRootOrAllTechnicalCommittee = EnsureOneOf<
     pallet_collective::EnsureProportionAtLeast<_1, _1, AccountId, TechnicalCommitteeInstance>,
 >;
 
+pub struct ImminentFilter;
+impl Contains<Call> for ImminentFilter {
+    fn contains(call: &Call) -> bool {
+        matches!(
+            call,
+            Call::Treasury(
+                pallet_treasury::Call::approve_proposal { .. } | pallet_treasury::Call::reject_proposal { .. }
+            )
+        )
+    }
+}
+
 parameter_types! {
     pub const LaunchPeriod: BlockNumber = 2 * MINUTES;
     pub const VotingPeriod: BlockNumber = 5 * MINUTES;
@@ -473,6 +485,7 @@ impl democracy::Config for Runtime {
     type MaxVotes = MaxVotes;
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
+    type ImminentFilter = ImminentFilter;
 }
 
 parameter_types! {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

This allows treasury proposals to be converted into referenda immediately instead of having to wait for this to be done in the `on_initialize` hook if `now % T::LaunchPeriod::get() == 0`.