### PR TITLE
refactor!: update minimum and maximum proposal bonds

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -549,8 +549,8 @@ impl pallet_multisig::Config for Runtime {
 
 parameter_types! {
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub ProposalBondMinimum: Balance = 5;
-    pub ProposalBondMaximum: Option<Balance> = None;
+    pub ProposalBondMinimum: Balance = 5 * UNITS;
+    pub ProposalBondMaximum: Balance = 25 * UNITS;
     pub const SpendPeriod: BlockNumber = 7 * DAYS;
     pub const Burn: Permill = Permill::from_percent(0);
     pub const MaxApprovals: u32 = 100;

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -547,12 +547,13 @@ impl pallet_multisig::Config for Runtime {
     type WeightInfo = ();
 }
 
+// https://github.com/paritytech/polkadot/blob/d7d75cef73b1294f5e5200f7e18f53d26a22eb63/runtime/polkadot/src/lib.rs#L769-L786
 parameter_types! {
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub ProposalBondMinimum: Balance = 5 * UNITS;
-    pub ProposalBondMaximum: Balance = 25 * UNITS;
-    pub const SpendPeriod: BlockNumber = 7 * DAYS;
-    pub const Burn: Permill = Permill::from_percent(0);
+    pub ProposalBondMinimum: Balance = 100 * DOLLARS;
+    pub ProposalBondMaximum: Balance = 500 * DOLLARS;
+    pub const SpendPeriod: BlockNumber = 24 * DAYS;
+    pub const Burn: Permill = Permill::from_percent(1);
     pub const MaxApprovals: u32 = 100;
 }
 

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -509,8 +509,8 @@ impl pallet_multisig::Config for Runtime {
 
 parameter_types! {
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub ProposalBondMinimum: Balance = 5;
-    pub ProposalBondMaximum: Option<Balance> = None;
+    pub ProposalBondMinimum: Balance = 5 * UNITS;
+    pub ProposalBondMaximum: Balance = 25 * UNITS;
     pub const SpendPeriod: BlockNumber = 7 * DAYS;
     pub const Burn: Permill = Permill::from_percent(0);
     pub const MaxApprovals: u32 = 100;

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -507,12 +507,13 @@ impl pallet_multisig::Config for Runtime {
     type WeightInfo = ();
 }
 
+// https://github.com/paritytech/polkadot/blob/d7d75cef73b1294f5e5200f7e18f53d26a22eb63/runtime/kusama/src/lib.rs#L737-L754
 parameter_types! {
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub ProposalBondMinimum: Balance = 5 * UNITS;
-    pub ProposalBondMaximum: Balance = 25 * UNITS;
-    pub const SpendPeriod: BlockNumber = 7 * DAYS;
-    pub const Burn: Permill = Permill::from_percent(0);
+    pub ProposalBondMinimum: Balance = 2000 * CENTS;
+    pub ProposalBondMaximum: Balance = 1 * GRAND;
+    pub const SpendPeriod: BlockNumber = 6 * DAYS;
+    pub const Burn: Permill = Permill::from_perthousand(2);
     pub const MaxApprovals: u32 = 100;
 }
 

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -518,12 +518,13 @@ impl pallet_multisig::Config for Runtime {
     type WeightInfo = ();
 }
 
+// https://github.com/paritytech/polkadot/blob/d7d75cef73b1294f5e5200f7e18f53d26a22eb63/runtime/kusama/src/lib.rs#L737-L754
 parameter_types! {
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub ProposalBondMinimum: Balance = 5 * UNITS;
-    pub ProposalBondMaximum: Balance = 25 * UNITS;
-    pub const SpendPeriod: BlockNumber = 7 * DAYS;
-    pub const Burn: Permill = Permill::from_percent(0);
+    pub ProposalBondMinimum: Balance = 2000 * CENTS;
+    pub ProposalBondMaximum: Balance = 1 * GRAND;
+    pub const SpendPeriod: BlockNumber = 6 * DAYS;
+    pub const Burn: Permill = Permill::from_perthousand(2);
     pub const MaxApprovals: u32 = 100;
 }
 

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -520,8 +520,8 @@ impl pallet_multisig::Config for Runtime {
 
 parameter_types! {
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub ProposalBondMinimum: Balance = 5;
-    pub ProposalBondMaximum: Option<Balance> = None;
+    pub ProposalBondMinimum: Balance = 5 * UNITS;
+    pub ProposalBondMaximum: Balance = 25 * UNITS;
     pub const SpendPeriod: BlockNumber = 7 * DAYS;
     pub const Burn: Permill = Permill::from_percent(0);
     pub const MaxApprovals: u32 = 100;

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -476,8 +476,8 @@ impl democracy::Config for Runtime {
 
 parameter_types! {
     pub const ProposalBond: Permill = Permill::from_percent(5);
-    pub ProposalBondMinimum: Balance = 5;
-    pub ProposalBondMaximum: Option<Balance> = None;
+    pub ProposalBondMinimum: Balance = 5 * UNITS;
+    pub ProposalBondMaximum: Balance = 25 * UNITS;
     pub const SpendPeriod: BlockNumber = 7 * DAYS;
     pub const Burn: Permill = Permill::from_percent(0);
     pub const MaxApprovals: u32 = 100;


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

It is currently very cheap (`.000000000005` KINT) to submit a treasury proposal which opens us up to spam. There was also no maximum set. This PR uses the parameters defined in the Kusama and Polkadot runtimes for Kintsugi and Interlay respectively.