### PR TITLE
chore: increase expected redeem tx input size

### DIFF
--- a/parachain/src/chain_spec.rs
+++ b/parachain/src/chain_spec.rs
@@ -143,7 +143,7 @@ fn interlay_properties() -> Map<String, Value> {
 fn expected_transaction_size() -> u32 {
     virtual_transaction_size(
         TransactionInputMetadata {
-            count: 2,
+            count: 4,
             script_type: InputType::P2WPKHv0,
         },
         TransactionOutputMetadata {

--- a/standalone/src/chain_spec.rs
+++ b/standalone/src/chain_spec.rs
@@ -221,7 +221,7 @@ fn default_pair(currency_id: CurrencyId) -> VaultCurrencyPair<CurrencyId> {
 fn expected_transaction_size() -> u32 {
     virtual_transaction_size(
         TransactionInputMetadata {
-            count: 2,
+            count: 4,
             script_type: InputType::P2WPKHv0,
         },
         TransactionOutputMetadata {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Opening this also for discussion since I'm not sure how to best parameterize this - what is clear however is that the previous input size is too low.