### PR TITLE
feat: re-purpose cancel_proposal for non-root

### DIFF
--- a/crates/democracy/src/lib.rs
+++ b/crates/democracy/src/lib.rs
@@ -85,6 +85,7 @@ use frame_support::{
         schedule::{DispatchTime, Named as ScheduleNamed},
         BalanceStatus, Currency, Get, LockIdentifier, OnUnbalanced, ReservableCurrency, UnfilteredDispatchable,
     },
+    transactional,
     weights::Weight,
 };
 use scale_info::TypeInfo;
@@ -376,6 +377,8 @@ pub mod pallet {
         PreimageInvalid,
         /// No proposals waiting
         NoneWaiting,
+        /// The given account did not make this proposal.
+        NotProposer,
         /// The given account did not vote on the referendum.
         NotVoter,
         /// Too high a balance was provided that the account cannot afford.
@@ -580,16 +583,23 @@ pub mod pallet {
 
         /// Remove a proposal.
         ///
-        /// The dispatch origin of this call must be _Root_.
-        ///
         /// - `prop_index`: The index of the proposal to cancel.
         ///
         /// Weight: `O(p)` where `p = PublicProps::<T>::decode_len()`
         #[pallet::weight(T::WeightInfo::cancel_proposal(T::MaxProposals::get()))]
+        #[transactional]
         pub fn cancel_proposal(origin: OriginFor<T>, #[pallet::compact] prop_index: PropIndex) -> DispatchResult {
-            ensure_root(origin)?;
+            let who = ensure_signed(origin)?;
 
-            PublicProps::<T>::mutate(|props| props.retain(|p| p.0 != prop_index));
+            PublicProps::<T>::try_mutate(|props| {
+                if let Some(i) = props.iter().position(|p| p.0 == prop_index) {
+                    let (_, _, proposer) = props.remove(i);
+                    ensure!(proposer == who, Error::<T>::NotProposer);
+                    Ok(())
+                } else {
+                    Err(Error::<T>::ProposalMissing)
+                }
+            })?;
             if let Some((whos, amount)) = DepositOf::<T>::take(prop_index) {
                 for who in whos.into_iter() {
                     T::Currency::unreserve(&who, amount);

--- a/crates/democracy/src/tests/public_proposals.rs
+++ b/crates/democracy/src/tests/public_proposals.rs
@@ -29,6 +29,24 @@ fn deposit_for_proposals_should_be_taken() {
 }
 
 #[test]
+fn only_author_should_cancel_proposal() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(propose_set_balance_and_note(1, 2, 5));
+        assert_noop!(
+            Democracy::cancel_proposal(Origin::signed(2), 0),
+            Error::<Test>::NotProposer
+        );
+        assert_ok!(Democracy::cancel_proposal(Origin::signed(1), 0));
+        assert_noop!(
+            Democracy::cancel_proposal(Origin::signed(1), 0),
+            Error::<Test>::ProposalMissing
+        );
+        // deposit is returned if cancelled
+        assert_eq!(Balances::free_balance(1), 10);
+    });
+}
+
+#[test]
 fn deposit_for_proposals_should_be_returned() {
     new_test_ext().execute_with(|| {
         assert_ok!(propose_set_balance_and_note(1, 2, 5));

--- a/crates/democracy/src/tests/public_proposals.rs
+++ b/crates/democracy/src/tests/public_proposals.rs
@@ -47,6 +47,18 @@ fn only_author_should_cancel_proposal() {
 }
 
 #[test]
+fn root_can_cancel_any_proposal() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(propose_set_balance_and_note(1, 2, 5));
+        assert_ok!(Democracy::cancel_proposal(Origin::root(), 0));
+        assert_noop!(
+            Democracy::cancel_proposal(Origin::root(), 0),
+            Error::<Test>::ProposalMissing
+        );
+    });
+}
+
+#[test]
 fn deposit_for_proposals_should_be_returned() {
     new_test_ext().execute_with(|| {
         assert_ok!(propose_set_balance_and_note(1, 2, 5));


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Currently there is no way for an author to remove a wayward proposal (and free up the deposit) without going again through governance. This re-purposes the `cancel_proposal` extrinsic to allow non-root users to remove their proposals. Note that no changes have been made to the external interface so it is not marked as a breaking change.