### PR TITLE
refactor!: more explicit error when vault is liquidated

### DIFF
--- a/standalone/runtime/tests/test_redeem.rs
+++ b/standalone/runtime/tests/test_redeem.rs
@@ -267,7 +267,7 @@ mod spec_based_tests {
                         vault_id: vault_id.clone(),
                     })
                     .dispatch(origin_of(account_of(ALICE))),
-                    VaultRegistryError::VaultNotFound,
+                    VaultRegistryError::VaultLiquidated,
                 );
             });
         }


### PR DESCRIPTION
Users got confused because actions on liquidated vaults were returning `VaultNotFound`