### PR TITLE
refactor: move some time and currency consts into constants.rs

### DIFF
--- a/parachain/runtime/interlay/src/constants.rs
+++ b/parachain/runtime/interlay/src/constants.rs
@@ -1,0 +1,41 @@
+//! A set of constant values used in the kintsugi runtime.
+
+/// Money matters.
+pub mod currency {
+    pub use primitives::{Balance, CurrencyId, CurrencyId::Token, DOT, IBTC, INTR};
+
+    pub const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
+    pub const PARENT_CURRENCY_ID: CurrencyId = Token(DOT);
+    pub const WRAPPED_CURRENCY_ID: CurrencyId = Token(IBTC);
+
+    // https://github.com/paritytech/polkadot/blob/c4ee9d463adccfa3bf436433e3e26d0de5a4abbc/runtime/polkadot/src/constants.rs#L18
+    pub const UNITS: Balance = NATIVE_CURRENCY_ID.one();
+    pub const DOLLARS: Balance = UNITS; // 10_000_000_000
+    pub const CENTS: Balance = DOLLARS / 100; // 100_000_000
+    pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000
+
+    pub const fn deposit(items: u32, bytes: u32) -> Balance {
+        items as Balance * 20 * DOLLARS + (bytes as Balance) * 100 * MILLICENTS
+    }
+}
+
+/// Time and blocks.
+pub mod time {
+    use btc_relay::TARGET_SPACING;
+    use primitives::{BlockNumber, Moment};
+
+    // The relay chain is limited to 12s to include parachain blocks.
+    pub const MILLISECS_PER_BLOCK: u64 = 12000;
+
+    pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
+
+    // These time units are defined in number of blocks.
+    pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
+    pub const HOURS: BlockNumber = MINUTES * 60;
+    pub const DAYS: BlockNumber = HOURS * 24;
+    pub const WEEKS: BlockNumber = DAYS * 7;
+    pub const YEARS: BlockNumber = DAYS * 365;
+
+    pub const BITCOIN_SPACING_MS: u32 = TARGET_SPACING * 1000;
+    pub const BITCOIN_BLOCK_SPACING: BlockNumber = BITCOIN_SPACING_MS / MILLISECS_PER_BLOCK as BlockNumber;
+}

--- a/parachain/runtime/kintsugi/src/constants.rs
+++ b/parachain/runtime/kintsugi/src/constants.rs
@@ -1,0 +1,41 @@
+//! A set of constant values used in the kintsugi runtime.
+
+/// Money matters.
+pub mod currency {
+    pub use primitives::{Balance, CurrencyId, CurrencyId::Token, KBTC, KINT, KSM};
+
+    pub const NATIVE_CURRENCY_ID: CurrencyId = Token(KINT);
+    pub const PARENT_CURRENCY_ID: CurrencyId = Token(KSM);
+    pub const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
+
+    // https://github.com/paritytech/polkadot/blob/c4ee9d463adccfa3bf436433e3e26d0de5a4abbc/runtime/kusama/src/constants.rs#L18
+    pub const UNITS: Balance = NATIVE_CURRENCY_ID.one();
+    pub const CENTS: Balance = UNITS / 30_000;
+    pub const GRAND: Balance = CENTS * 100_000;
+    pub const MILLICENTS: Balance = CENTS / 1_000;
+
+    pub const fn deposit(items: u32, bytes: u32) -> Balance {
+        items as Balance * 2_000 * CENTS + (bytes as Balance) * 100 * MILLICENTS
+    }
+}
+
+/// Time and blocks.
+pub mod time {
+    use btc_relay::TARGET_SPACING;
+    use primitives::{BlockNumber, Moment};
+
+    // The relay chain is limited to 12s to include parachain blocks.
+    pub const MILLISECS_PER_BLOCK: u64 = 12000;
+
+    pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
+
+    // These time units are defined in number of blocks.
+    pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
+    pub const HOURS: BlockNumber = MINUTES * 60;
+    pub const DAYS: BlockNumber = HOURS * 24;
+    pub const WEEKS: BlockNumber = DAYS * 7;
+    pub const YEARS: BlockNumber = DAYS * 365;
+
+    pub const BITCOIN_SPACING_MS: u32 = TARGET_SPACING * 1000;
+    pub const BITCOIN_BLOCK_SPACING: BlockNumber = BITCOIN_SPACING_MS / MILLISECS_PER_BLOCK as BlockNumber;
+}

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1,4 +1,4 @@
-//! The Substrate Node Template runtime. This can be compiled with `#[no_std]`, ready for Wasm.
+//! The kintsugi runtime. This can be compiled with `#[no_std]`, ready for Wasm.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
@@ -55,14 +55,16 @@ pub use sp_runtime::{Perbill, Permill};
 
 // interBTC exports
 pub use btc_relay::{bitcoin, Call as RelayCall, TARGET_SPACING};
+pub use constants::{currency::*, time::*};
 pub use module_oracle_rpc_runtime_api::BalanceWrapper;
 pub use security::StatusCode;
 
 pub use primitives::{
-    self, AccountId, Balance, BlockNumber, CurrencyId, CurrencyId::Token, CurrencyInfo, Hash, Moment, Nonce, Signature,
-    SignedFixedPoint, SignedInner, UnsignedFixedPoint, UnsignedInner, KBTC, KINT, KSM,
+    self, AccountId, Balance, BlockNumber, CurrencyInfo, Hash, Moment, Nonce, Signature, SignedFixedPoint, SignedInner,
+    UnsignedFixedPoint, UnsignedInner,
 };
 
+pub mod constants;
 pub mod xcm_config;
 
 type VaultId = primitives::VaultId<AccountId, CurrencyId>;
@@ -85,21 +87,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     apis: RUNTIME_API_VERSIONS,
     state_version: 0,
 };
-
-// The relay chain is limited to 12s to include parachain blocks.
-pub const MILLISECS_PER_BLOCK: u64 = 12000;
-
-pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
-
-// These time units are defined in number of blocks.
-pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
-pub const HOURS: BlockNumber = MINUTES * 60;
-pub const DAYS: BlockNumber = HOURS * 24;
-pub const WEEKS: BlockNumber = DAYS * 7;
-pub const YEARS: BlockNumber = DAYS * 365;
-
-pub const BITCOIN_SPACING_MS: u32 = TARGET_SPACING * 1000;
-pub const BITCOIN_BLOCK_SPACING: BlockNumber = BITCOIN_SPACING_MS / MILLISECS_PER_BLOCK as BlockNumber;
 
 pub mod token_distribution {
     use super::*;
@@ -439,16 +426,6 @@ impl frame_support::traits::OnRuntimeUpgrade for SchedulerMigrationV3 {
     }
 }
 
-// https://github.com/paritytech/polkadot/blob/c4ee9d463adccfa3bf436433e3e26d0de5a4abbc/runtime/kusama/src/constants.rs#L18
-pub const UNITS: Balance = NATIVE_CURRENCY_ID.one();
-pub const CENTS: Balance = UNITS / 30_000;
-pub const GRAND: Balance = CENTS * 100_000;
-pub const MILLICENTS: Balance = CENTS / 1_000;
-
-pub const fn deposit(items: u32, bytes: u32) -> Balance {
-    items as Balance * 2_000 * CENTS + (bytes as Balance) * 100 * MILLICENTS
-}
-
 type EnsureRootOrAllTechnicalCommittee = EnsureOneOf<
     EnsureRoot<AccountId>,
     pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
@@ -599,10 +576,6 @@ impl btc_relay::Config for Runtime {
     type WeightInfo = ();
     type ParachainBlocksPerBitcoinBlock = ParachainBlocksPerBitcoinBlock;
 }
-
-const NATIVE_CURRENCY_ID: CurrencyId = Token(KINT);
-const PARENT_CURRENCY_ID: CurrencyId = Token(KSM);
-const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
 
 parameter_types! {
     pub const GetNativeCurrencyId: CurrencyId = NATIVE_CURRENCY_ID;

--- a/parachain/runtime/testnet/src/constants.rs
+++ b/parachain/runtime/testnet/src/constants.rs
@@ -1,0 +1,41 @@
+//! A set of constant values used in the testnet runtime.
+
+/// Money matters.
+pub mod currency {
+    pub use primitives::{Balance, CurrencyId, CurrencyId::Token, KBTC, KINT, KSM};
+
+    pub const NATIVE_CURRENCY_ID: CurrencyId = Token(KINT);
+    pub const PARENT_CURRENCY_ID: CurrencyId = Token(KSM);
+    pub const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
+
+    // https://github.com/paritytech/polkadot/blob/c4ee9d463adccfa3bf436433e3e26d0de5a4abbc/runtime/kusama/src/constants.rs#L18
+    pub const UNITS: Balance = NATIVE_CURRENCY_ID.one();
+    pub const CENTS: Balance = UNITS / 30_000;
+    pub const GRAND: Balance = CENTS * 100_000;
+    pub const MILLICENTS: Balance = CENTS / 1_000;
+
+    pub const fn deposit(items: u32, bytes: u32) -> Balance {
+        items as Balance * 2_000 * CENTS + (bytes as Balance) * 100 * MILLICENTS
+    }
+}
+
+/// Time and blocks.
+pub mod time {
+    use btc_relay::TARGET_SPACING;
+    use primitives::{BlockNumber, Moment};
+
+    // The relay chain is limited to 12s to include parachain blocks.
+    pub const MILLISECS_PER_BLOCK: u64 = 12000;
+
+    pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
+
+    // These time units are defined in number of blocks.
+    pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
+    pub const HOURS: BlockNumber = MINUTES * 60;
+    pub const DAYS: BlockNumber = HOURS * 24;
+    pub const WEEKS: BlockNumber = DAYS * 7;
+    pub const YEARS: BlockNumber = DAYS * 365;
+
+    pub const BITCOIN_SPACING_MS: u32 = TARGET_SPACING * 1000;
+    pub const BITCOIN_BLOCK_SPACING: BlockNumber = BITCOIN_SPACING_MS / MILLISECS_PER_BLOCK as BlockNumber;
+}

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -1,4 +1,4 @@
-//! The Substrate Node Template runtime. This can be compiled with `#[no_std]`, ready for Wasm.
+//! The testnet runtime. This can be compiled with `#[no_std]`, ready for Wasm.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
@@ -57,12 +57,13 @@ pub use sp_runtime::{Perbill, Permill};
 
 // interBTC exports
 pub use btc_relay::{bitcoin, Call as RelayCall, TARGET_SPACING};
+pub use constants::{currency::*, time::*};
 pub use module_oracle_rpc_runtime_api::BalanceWrapper;
 pub use security::StatusCode;
 
 pub use primitives::{
-    self, AccountId, Balance, BlockNumber, CurrencyId, CurrencyId::Token, CurrencyInfo, Hash, Moment, Nonce, Signature,
-    SignedFixedPoint, SignedInner, UnsignedFixedPoint, UnsignedInner, KBTC, KINT, KSM,
+    self, AccountId, BlockNumber, CurrencyInfo, Hash, Moment, Nonce, Signature, SignedFixedPoint, SignedInner,
+    UnsignedFixedPoint, UnsignedInner,
 };
 
 // XCM imports
@@ -70,6 +71,7 @@ use pallet_xcm::{EnsureXcm, IsMajorityOfBody};
 use xcm::opaque::latest::BodyId;
 use xcm_config::ParentLocation;
 
+pub mod constants;
 pub mod xcm_config;
 
 type VaultId = primitives::VaultId<AccountId, CurrencyId>;
@@ -92,21 +94,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     apis: RUNTIME_API_VERSIONS,
     state_version: 0,
 };
-
-// The relay chain is limited to 12s to include parachain blocks.
-pub const MILLISECS_PER_BLOCK: u64 = 12000;
-
-pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
-
-// These time units are defined in number of blocks.
-pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
-pub const HOURS: BlockNumber = MINUTES * 60;
-pub const DAYS: BlockNumber = HOURS * 24;
-pub const WEEKS: BlockNumber = DAYS * 7;
-pub const YEARS: BlockNumber = DAYS * 365;
-
-pub const BITCOIN_SPACING_MS: u32 = TARGET_SPACING * 1000;
-pub const BITCOIN_BLOCK_SPACING: BlockNumber = BITCOIN_SPACING_MS / MILLISECS_PER_BLOCK as BlockNumber;
 
 pub mod token_distribution {
     use super::*;
@@ -450,16 +437,6 @@ impl frame_support::traits::OnRuntimeUpgrade for SchedulerMigrationV3 {
     }
 }
 
-// https://github.com/paritytech/polkadot/blob/c4ee9d463adccfa3bf436433e3e26d0de5a4abbc/runtime/kusama/src/constants.rs#L18
-pub const UNITS: Balance = NATIVE_CURRENCY_ID.one();
-pub const CENTS: Balance = UNITS / 30_000;
-pub const GRAND: Balance = CENTS * 100_000;
-pub const MILLICENTS: Balance = CENTS / 1_000;
-
-pub const fn deposit(items: u32, bytes: u32) -> Balance {
-    items as Balance * 2_000 * CENTS + (bytes as Balance) * 100 * MILLICENTS
-}
-
 type EnsureRootOrAllTechnicalCommittee = EnsureOneOf<
     EnsureRoot<AccountId>,
     pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
@@ -610,10 +587,6 @@ impl btc_relay::Config for Runtime {
     type WeightInfo = ();
     type ParachainBlocksPerBitcoinBlock = ParachainBlocksPerBitcoinBlock;
 }
-
-const NATIVE_CURRENCY_ID: CurrencyId = Token(KINT);
-const PARENT_CURRENCY_ID: CurrencyId = Token(KSM);
-const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
 
 parameter_types! {
     pub const GetNativeCurrencyId: CurrencyId = NATIVE_CURRENCY_ID;


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

### Examples
- [Kusama](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/lib.rs)
- [Polkadot](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/constants/src/lib.rs)
- [Karura](https://github.com/AcalaNetwork/Acala/blob/master/runtime/karura/src/constants.rs)
- [Acala](https://github.com/AcalaNetwork/Acala/blob/master/runtime/acala/src/constants.rs)