### PR TITLE
[BREAKING] feat!: shared public key

### DIFF
--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -59,6 +59,15 @@ fn get_vault_id<T: crate::Config>() -> DefaultVaultId<T> {
     )
 }
 
+fn register_vault<T: crate::Config>(vault_id: DefaultVaultId<T>) {
+    let origin = RawOrigin::Signed(vault_id.account_id.clone());
+    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::_register_vault(
+        vault_id.clone(),
+        100000000u32.into()
+    ));
+}
+
 fn mine_blocks_until_expiry<T: crate::Config>(request: &DefaultIssueRequest<T>) {
     let period = Issue::<T>::issue_period().max(request.period);
     let expiry_height = BtcRelay::<T>::bitcoin_expiry_height(request.btc_height, period).unwrap();
@@ -135,7 +144,7 @@ benchmarks! {
         Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(), <T as currency::Config>::UnsignedFixedPoint::one()).unwrap();
         VaultRegistry::<T>::_set_secure_collateral_threshold(get_currency_pair::<T>(), <T as currency::Config>::UnsignedFixedPoint::checked_from_rational(1, 100000).unwrap());// 0.001%
         VaultRegistry::<T>::_set_system_collateral_ceiling(get_currency_pair::<T>(), 1_000_000_000u32.into());
-        VaultRegistry::<T>::_register_vault(vault_id.clone(), 100000000u32.into(), dummy_public_key()).unwrap();
+        register_vault::<T>(vault_id.clone());
 
         // initialize relay
 
@@ -275,7 +284,7 @@ benchmarks! {
         VaultRegistry::<T>::_set_system_collateral_ceiling(get_currency_pair::<T>(), 1_000_000_000u32.into());
         VaultRegistry::<T>::_set_secure_collateral_threshold(get_currency_pair::<T>(), <T as currency::Config>::UnsignedFixedPoint::checked_from_rational(1, 100000).unwrap());
         Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(), <T as currency::Config>::UnsignedFixedPoint::one()).unwrap();
-        VaultRegistry::<T>::_register_vault(vault_id.clone(), 100000000u32.into(), dummy_public_key()).unwrap();
+        register_vault::<T>(vault_id.clone());
 
         VaultRegistry::<T>::try_increase_to_be_issued_tokens(&vault_id, &value).unwrap();
         let secure_id = Security::<T>::get_secure_id(&vault_id.account_id);
@@ -316,7 +325,7 @@ benchmarks! {
         VaultRegistry::<T>::_set_system_collateral_ceiling(get_currency_pair::<T>(), 1_000_000_000u32.into());
         VaultRegistry::<T>::_set_secure_collateral_threshold(get_currency_pair::<T>(), <T as currency::Config>::UnsignedFixedPoint::checked_from_rational(1, 100000).unwrap());
         Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(), <T as currency::Config>::UnsignedFixedPoint::one()).unwrap();
-        VaultRegistry::<T>::_register_vault(vault_id.clone(), 100000000u32.into(), dummy_public_key()).unwrap();
+        register_vault::<T>(vault_id.clone());
 
         VaultRegistry::<T>::try_increase_to_be_issued_tokens(&vault_id, &value).unwrap();
         let secure_id = Security::<T>::get_secure_id(&vault_id.account_id);

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -61,7 +61,7 @@ fn get_vault_id<T: crate::Config>() -> DefaultVaultId<T> {
 
 fn register_vault<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
     assert_ok!(VaultRegistry::<T>::_register_vault(
         vault_id.clone(),
         100000000u32.into()

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -49,7 +49,7 @@ pub(crate) mod vault_registry {
     use sp_core::H256;
     use vault_registry::{
         types::{CurrencySource, DefaultVault},
-        Amount,
+        Amount, BtcPublicKey,
     };
 
     pub fn transfer_funds<T: crate::Config>(
@@ -82,6 +82,10 @@ pub(crate) mod vault_registry {
         secure_id: H256,
     ) -> Result<BtcAddress, DispatchError> {
         <vault_registry::Pallet<T>>::register_deposit_address(vault_id, secure_id)
+    }
+
+    pub fn get_bitcoin_public_key<T: crate::Config>(account_id: &T::AccountId) -> Result<BtcPublicKey, DispatchError> {
+        <vault_registry::Pallet<T>>::get_bitcoin_public_key(account_id)
     }
 
     pub fn issue_tokens<T: crate::Config>(vault_id: &DefaultVaultId<T>, amount: &Amount<T>) -> DispatchResult {

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -312,13 +312,14 @@ impl<T: Config> Pallet<T> {
 
         let issue_id = ext::security::get_secure_id::<T>(&requester);
         let btc_address = ext::vault_registry::register_deposit_address::<T>(&vault_id, issue_id)?;
+        let btc_public_key = ext::vault_registry::get_bitcoin_public_key::<T>(&vault_id.account_id)?;
 
         let request = IssueRequest {
             vault: vault_id,
             opentime: ext::security::active_block_number::<T>(),
             requester,
             btc_address,
-            btc_public_key: vault.wallet.public_key,
+            btc_public_key,
             amount: amount_user.amount(),
             fee: fee.amount(),
             griefing_collateral: griefing_collateral.amount(),

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -48,6 +48,7 @@ fn request_issue_ok(origin: AccountId, amount: Balance, vault: DefaultVaultId<Te
     ext::security::get_secure_id::<Test>.mock_safe(|_| MockResult::Return(get_dummy_request_id()));
 
     ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+    ext::vault_registry::get_bitcoin_public_key::<Test>.mock_safe(|_| MockResult::Return(Ok(BtcPublicKey::default())));
     ext::vault_registry::register_deposit_address::<Test>
         .mock_safe(|_, _| MockResult::Return(Ok(BtcAddress::default())));
 
@@ -63,7 +64,7 @@ fn cancel_issue(origin: AccountId, issue_id: &H256) -> Result<(), DispatchError>
 }
 
 fn init_zero_vault(id: DefaultVaultId<Test>) -> DefaultVault<Test> {
-    Vault::new(id, Default::default())
+    Vault::new(id)
 }
 
 fn get_dummy_request_id() -> H256 {
@@ -87,7 +88,7 @@ fn test_request_issue_banned_fails() {
                 to_be_redeemed_tokens: 0,
                 replace_collateral: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(BtcPublicKey::default()),
+                wallet: Wallet::new(),
                 banned_until: Some(1),
                 status: VaultStatus::Active(true),
                 liquidated_collateral: 0,

--- a/crates/nomination/src/benchmarking.rs
+++ b/crates/nomination/src/benchmarking.rs
@@ -45,6 +45,15 @@ fn get_vault_id<T: crate::Config>() -> DefaultVaultId<T> {
     )
 }
 
+fn register_vault<T: crate::Config>(vault_id: DefaultVaultId<T>) {
+    let origin = RawOrigin::Signed(vault_id.account_id.clone());
+    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::_register_vault(
+        vault_id.clone(),
+        100000000u32.into()
+    ));
+}
+
 benchmarks! {
     set_nomination_enabled {
     }: _(RawOrigin::Root, true)
@@ -55,7 +64,7 @@ benchmarks! {
 
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
-        assert_ok!(VaultRegistry::<T>::_register_vault(vault_id.clone(), 100000000u32.into(), dummy_public_key()));
+        register_vault::<T>(vault_id.clone());
 
     }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone())
 
@@ -65,7 +74,7 @@ benchmarks! {
 
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
-        assert_ok!(VaultRegistry::<T>::_register_vault(vault_id.clone(), 100000000u32.into(), dummy_public_key()));
+        register_vault::<T>(vault_id.clone());
 
         <Vaults<T>>::insert(&vault_id, true);
 
@@ -77,7 +86,7 @@ benchmarks! {
 
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
-        assert_ok!(VaultRegistry::<T>::_register_vault(vault_id.clone(), 100000000u32.into(), dummy_public_key()));
+        register_vault::<T>(vault_id.clone());
 
         <Vaults<T>>::insert(&vault_id, true);
 
@@ -93,7 +102,7 @@ benchmarks! {
 
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
-        assert_ok!(VaultRegistry::<T>::_register_vault(vault_id.clone(), 100000000u32.into(), dummy_public_key()));
+        register_vault::<T>(vault_id.clone());
 
         <Vaults<T>>::insert(&vault_id, true);
 

--- a/crates/nomination/src/benchmarking.rs
+++ b/crates/nomination/src/benchmarking.rs
@@ -47,7 +47,7 @@ fn get_vault_id<T: crate::Config>() -> DefaultVaultId<T> {
 
 fn register_vault<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
     assert_ok!(VaultRegistry::<T>::_register_vault(
         vault_id.clone(),
         100000000u32.into()

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -44,7 +44,7 @@ fn dummy_public_key() -> BtcPublicKey {
 
 fn set_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
 }
 
 fn deposit_tokens<T: crate::Config>(currency_id: CurrencyId, account_id: &T::AccountId, amount: BalanceOf<T>) {

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -42,6 +42,11 @@ fn dummy_public_key() -> BtcPublicKey {
     ])
 }
 
+fn set_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
+    let origin = RawOrigin::Signed(vault_id.account_id.clone());
+    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+}
+
 fn deposit_tokens<T: crate::Config>(currency_id: CurrencyId, account_id: &T::AccountId, amount: BalanceOf<T>) {
     assert_ok!(<orml_tokens::Pallet<T>>::deposit(currency_id, account_id, amount));
 }
@@ -169,11 +174,13 @@ benchmarks! {
 
         initialize_oracle::<T>();
 
+        set_public_key::<T>(vault_id.clone());
+
         let vault = Vault {
-            wallet: Wallet::new(dummy_public_key()),
+            wallet: Wallet::new(),
             issued_tokens: amount,
             id: vault_id.clone(),
-            ..Vault::new(vault_id.clone(), Default::default())
+            ..Vault::new(vault_id.clone())
         };
 
         VaultRegistry::<T>::insert_vault(
@@ -197,9 +204,11 @@ benchmarks! {
         let vault_id = get_vault_id::<T>();
         let amount = 1000;
 
+        set_public_key::<T>(vault_id.clone());
+
         VaultRegistry::<T>::insert_vault(
             &vault_id,
-            Vault::new(vault_id.clone(), dummy_public_key())
+            Vault::new(vault_id.clone())
         );
 
         mint_wrapped::<T>(&origin, amount.into());
@@ -231,10 +240,12 @@ benchmarks! {
         redeem_request.btc_address = origin_btc_address;
         Redeem::<T>::insert_redeem_request(&redeem_id, &redeem_request);
 
+        set_public_key::<T>(vault_id.clone());
+
         let vault = Vault {
-            wallet: Wallet::new(dummy_public_key()),
+            wallet: Wallet::new(),
             id: vault_id.clone(),
-            ..Vault::new(vault_id.clone(), Default::default())
+            ..Vault::new(vault_id.clone())
         };
 
         VaultRegistry::<T>::insert_vault(
@@ -320,10 +331,12 @@ BtcRelay::<T>::parachain_confirmations() + 1u32.into());
         mine_blocks_until_expiry::<T>(&redeem_request);
         Security::<T>::set_active_block_number(Security::<T>::active_block_number() + Redeem::<T>::redeem_period() + 100u32.into());
 
+        set_public_key::<T>(vault_id.clone());
+
         let vault = Vault {
-            wallet: Wallet::new(dummy_public_key()),
+            wallet: Wallet::new(),
             id: vault_id.clone(),
-            ..Vault::new(vault_id.clone(), Default::default())
+            ..Vault::new(vault_id.clone())
         };
         VaultRegistry::<T>::insert_vault(
             &vault_id,
@@ -353,10 +366,12 @@ BtcRelay::<T>::parachain_confirmations() + 1u32.into());
         mine_blocks_until_expiry::<T>(&redeem_request);
         Security::<T>::set_active_block_number(Security::<T>::active_block_number() + Redeem::<T>::redeem_period() + 100u32.into());
 
+        set_public_key::<T>(vault_id.clone());
+
         let vault = Vault {
-            wallet: Wallet::new(dummy_public_key()),
+            wallet: Wallet::new(),
             id: vault_id.clone(),
-            ..Vault::new(vault_id.clone(), Default::default())
+            ..Vault::new(vault_id.clone())
         };
         VaultRegistry::<T>::insert_vault(
             &vault_id,

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -2,7 +2,7 @@ use crate::{ext, mock::*};
 
 use crate::types::{RedeemRequest, RedeemRequestStatus};
 use bitcoin::types::{MerkleProof, Transaction};
-use btc_relay::{BtcAddress, BtcPublicKey};
+use btc_relay::BtcAddress;
 use currency::Amount;
 use frame_support::{assert_err, assert_noop, assert_ok, dispatch::DispatchError};
 use mocktopus::mocking::*;
@@ -49,13 +49,6 @@ fn inject_redeem_request(key: H256, value: RedeemRequest<AccountId, BlockNumber,
     Redeem::insert_redeem_request(&key, &value)
 }
 
-fn dummy_public_key() -> BtcPublicKey {
-    BtcPublicKey([
-        2, 205, 114, 218, 156, 16, 235, 172, 106, 37, 18, 153, 202, 140, 176, 91, 207, 51, 187, 55, 18, 45, 222, 180,
-        119, 54, 243, 97, 173, 150, 161, 169, 230,
-    ])
-}
-
 fn default_vault() -> DefaultVault<Test> {
     vault_registry::Vault {
         id: VAULT,
@@ -65,7 +58,7 @@ fn default_vault() -> DefaultVault<Test> {
         replace_collateral: 0,
         to_be_redeemed_tokens: 0,
         active_replace_collateral: 0,
-        wallet: Wallet::new(dummy_public_key()),
+        wallet: Wallet::new(),
         banned_until: None,
         status: VaultStatus::Active(true),
         liquidated_collateral: 0,
@@ -99,7 +92,7 @@ fn test_request_redeem_fails_with_amount_below_minimum() {
                 replace_collateral: 0,
                 to_be_redeemed_tokens: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(dummy_public_key()),
+                wallet: Wallet::new(),
                 banned_until: None,
                 status: VaultStatus::Active(true),
                 liquidated_collateral: 0,
@@ -171,7 +164,7 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
                 to_be_redeemed_tokens: 0,
                 replace_collateral: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(dummy_public_key()),
+                wallet: Wallet::new(),
                 banned_until: None,
                 status: VaultStatus::Active(true),
                 liquidated_collateral: 0,
@@ -255,7 +248,7 @@ fn test_request_redeem_succeeds_with_self_redeem() {
                 to_be_redeemed_tokens: 0,
                 active_replace_collateral: 0,
                 replace_collateral: 0,
-                wallet: Wallet::new(dummy_public_key()),
+                wallet: Wallet::new(),
                 banned_until: None,
                 status: VaultStatus::Active(true),
                 liquidated_collateral: 0,
@@ -384,7 +377,7 @@ fn test_execute_redeem_succeeds_with_another_account() {
                 to_be_redeemed_tokens: 200,
                 replace_collateral: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(dummy_public_key()),
+                wallet: Wallet::new(),
                 banned_until: None,
                 status: VaultStatus::Active(true),
                 liquidated_collateral: 0,
@@ -465,7 +458,7 @@ fn test_execute_redeem_succeeds() {
                 to_be_redeemed_tokens: 200,
                 replace_collateral: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(dummy_public_key()),
+                wallet: Wallet::new(),
                 banned_until: None,
                 status: VaultStatus::Active(true),
                 liquidated_collateral: 0,
@@ -635,7 +628,7 @@ fn test_cancel_redeem_succeeds() {
         ext::vault_registry::get_vault_from_id::<Test>.mock_safe(|_| {
             MockResult::Return(Ok(vault_registry::types::Vault {
                 status: VaultStatus::Active(true),
-                ..vault_registry::types::Vault::new(VAULT, Default::default())
+                ..vault_registry::types::Vault::new(VAULT)
             }))
         });
         ext::vault_registry::decrease_to_be_redeemed_tokens::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
@@ -823,7 +816,7 @@ mod spec_based_tests {
                     issued_tokens: 200,
                     to_be_redeemed_tokens: 200,
                     replace_collateral: 0,
-                    wallet: Wallet::new(dummy_public_key()),
+                    wallet: Wallet::new(),
                     banned_until: None,
                     status: VaultStatus::Active(true),
                     ..default_vault()

--- a/crates/refund/src/benchmarking.rs
+++ b/crates/refund/src/benchmarking.rs
@@ -58,7 +58,10 @@ benchmarks! {
     };
         Refund::<T>::insert_refund_request(&refund_id, &refund_request);
 
-        let vault = Vault::new(vault_id.clone(), dummy_public_key());
+        let origin = RawOrigin::Signed(vault_id.account_id.clone());
+        assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+
+        let vault = Vault::new(vault_id.clone());
 
         VaultRegistry::<T>::insert_vault(
             &vault_id,

--- a/crates/refund/src/benchmarking.rs
+++ b/crates/refund/src/benchmarking.rs
@@ -59,7 +59,7 @@ benchmarks! {
         Refund::<T>::insert_refund_request(&refund_id, &refund_request);
 
         let origin = RawOrigin::Signed(vault_id.account_id.clone());
-        assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+        assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
 
         let vault = Vault::new(vault_id.clone());
 

--- a/crates/relay/src/benchmarking.rs
+++ b/crates/relay/src/benchmarking.rs
@@ -48,6 +48,11 @@ fn mint_collateral<T: crate::Config>(account_id: &T::AccountId, amount: BalanceO
     deposit_tokens::<T>(get_native_currency_id::<T>(), account_id, amount);
 }
 
+fn set_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
+    let origin = RawOrigin::Signed(vault_id.account_id.clone());
+    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+}
+
 benchmarks! {
 
     initialize {
@@ -112,10 +117,13 @@ benchmarks! {
             T::GetGriefingCollateralCurrencyId::get(),
             <T as currency::Config>::GetWrappedCurrencyId::get()
         );
+
+        set_public_key::<T>(vault_id.clone());
+
         let mut vault = Vault {
-            wallet: Wallet::new(dummy_public_key()),
+            wallet: Wallet::new(),
             id: vault_id.clone(),
-            ..Vault::new(vault_id.clone(), Default::default())
+            ..Vault::new(vault_id.clone())
         };
         vault.wallet.add_btc_address(vault_address);
         VaultRegistry::<T>::insert_vault(

--- a/crates/relay/src/benchmarking.rs
+++ b/crates/relay/src/benchmarking.rs
@@ -50,7 +50,7 @@ fn mint_collateral<T: crate::Config>(account_id: &T::AccountId, amount: BalanceO
 
 fn set_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
 }
 
 benchmarks! {

--- a/crates/relay/src/tests.rs
+++ b/crates/relay/src/tests.rs
@@ -38,8 +38,8 @@ fn dummy_merkle_proof() -> MerkleProof {
 /// Mocking functions
 fn init_zero_vault(id: DefaultVaultId<Test>, btc_addresses: Vec<BtcAddress>) -> DefaultVault<Test> {
     let mut vault = Vault {
-        wallet: Wallet::new(dummy_public_key()),
-        ..Vault::new(id, Default::default())
+        wallet: Wallet::new(),
+        ..Vault::new(id)
     };
 
     for btc_address in btc_addresses.iter() {
@@ -224,7 +224,7 @@ fn test_is_valid_merge_transaction_fails() {
         let address1 = BtcAddress::P2PKH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let transaction1 = build_dummy_transaction_with_output(vec![address1]);
         assert_eq!(
-            Relay::is_valid_merge_transaction(&transaction1, &Wallet::new(dummy_public_key())),
+            Relay::is_valid_merge_transaction(&transaction1, &Wallet::new()),
             false,
             "payment to unknown recipient"
         );
@@ -232,7 +232,7 @@ fn test_is_valid_merge_transaction_fails() {
         let address2 = BtcAddress::P2PKH(H160::from_str(&"5f69790b72c98041330644bbd50f2ebb5d073c36").unwrap());
         let transaction2 = build_dummy_transaction_with_output(vec![address2]);
         assert_eq!(
-            Relay::is_valid_merge_transaction(&transaction2, &Wallet::new(dummy_public_key())),
+            Relay::is_valid_merge_transaction(&transaction2, &Wallet::new()),
             false,
             "migration should not have op_returns"
         );
@@ -249,7 +249,7 @@ fn test_is_valid_merge_transaction_succeeds() {
         let address = BtcAddress::P2PKH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let transaction = build_dummy_transaction_with_output(vec![address]);
 
-        let mut wallet = Wallet::new(dummy_public_key());
+        let mut wallet = Wallet::new();
         wallet.add_btc_address(address);
 
         assert_eq!(Relay::is_valid_merge_transaction(&transaction, &wallet), true);
@@ -295,7 +295,7 @@ fn test_is_valid_request_transaction_overpayment_fails() {
 
         let address2 = BtcAddress::P2PKH(H160::from_str(&"5f69790b72c98041330644bbd50f2ebb5d073c36").unwrap());
 
-        let mut wallet = Wallet::new(dummy_public_key());
+        let mut wallet = Wallet::new();
         wallet.add_btc_address(address2);
 
         let actual_value = 101;
@@ -323,7 +323,7 @@ fn test_is_valid_request_transaction_underpayment_fails() {
 
         let address2 = BtcAddress::P2PKH(H160::from_str(&"5f69790b72c98041330644bbd50f2ebb5d073c36").unwrap());
 
-        let mut wallet = Wallet::new(dummy_public_key());
+        let mut wallet = Wallet::new();
         wallet.add_btc_address(address2);
 
         let actual_value = 99;
@@ -351,7 +351,7 @@ fn test_is_valid_request_transaction_succeeds() {
         let request_value = 100;
         let change_value = 50;
 
-        let mut wallet = Wallet::new(dummy_public_key());
+        let mut wallet = Wallet::new();
         wallet.add_btc_address(vault_address);
 
         let transaction = build_dummy2_transaction_with(
@@ -379,13 +379,13 @@ fn test_is_transaction_invalid_fails_with_valid_merge_transaction() {
             126, 125, 148, 208, 221, 194, 29, 131, 191, 188, 252, 119, 152, 228, 84, 126, 223, 8, 50, 170,
         ]));
 
-        let mut wallet = Wallet::new(dummy_public_key());
+        let mut wallet = Wallet::new();
         wallet.add_btc_address(address);
 
         ext::vault_registry::get_active_vault_from_id::<Test>.mock_safe(move |_| {
             MockResult::Return(Ok(Vault {
                 wallet: wallet.clone(),
-                ..Vault::new(BOB, dummy_public_key())
+                ..Vault::new(BOB)
             }))
         });
 
@@ -428,7 +428,7 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
             41, 40, 244, 58, 241, 141, 45, 96, 232, 168, 67, 84, 13, 128, 134, 179, 5, 52, 19, 57,
         ]));
 
-        let mut wallet = Wallet::new(dummy_public_key());
+        let mut wallet = Wallet::new();
         wallet.add_btc_address(vault_address);
 
         let recipient_address = BtcAddress::P2PKH(H160::from_str(&"5f69790b72c98041330644bbd50f2ebb5d073c36").unwrap());
@@ -436,7 +436,7 @@ fn test_is_transaction_invalid_fails_with_valid_request_or_redeem() {
         ext::vault_registry::get_active_vault_from_id::<Test>.mock_safe(move |_| {
             MockResult::Return(Ok(Vault {
                 wallet: wallet.clone(),
-                ..Vault::new(BOB, dummy_public_key())
+                ..Vault::new(BOB)
             }))
         });
 
@@ -579,7 +579,7 @@ fn test_is_transaction_invalid_fails_with_valid_merge_testnet_transaction() {
             &hex::decode("d0a46d39dafa3012c2a7ed4d82d644b428e4586b").unwrap(),
         ));
 
-        let mut wallet = Wallet::new(dummy_public_key());
+        let mut wallet = Wallet::new();
         wallet.add_btc_address(vault_btc_address_0);
         wallet.add_btc_address(vault_btc_address_1);
         wallet.add_btc_address(vault_btc_address_2);
@@ -587,7 +587,7 @@ fn test_is_transaction_invalid_fails_with_valid_merge_testnet_transaction() {
         ext::vault_registry::get_active_vault_from_id::<Test>.mock_safe(move |_| {
             MockResult::Return(Ok(Vault {
                 wallet: wallet.clone(),
-                ..Vault::new(BOB, dummy_public_key())
+                ..Vault::new(BOB)
             }))
         });
 

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -147,7 +147,7 @@ fn get_vault_id<T: crate::Config>(name: &'static str) -> DefaultVaultId<T> {
 
 fn set_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id);
-    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
 }
 
 fn register_vault<T: crate::Config>(vault_id: DefaultVaultId<T>) {

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -48,7 +48,7 @@ fn get_currency_pair<T: crate::Config>() -> DefaultVaultCurrencyPair<T> {
 
 fn register_vault_with_collateral<T: crate::Config>(vault_id: DefaultVaultId<T>, collateral: u32) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
     assert_ok!(VaultRegistry::<T>::_register_vault(vault_id.clone(), collateral.into()));
 }
 
@@ -59,7 +59,7 @@ benchmarks! {
         let amount: u32 = 100;
         let origin = RawOrigin::Signed(vault_id.account_id.clone());
         let public_key = BtcPublicKey::default();
-        VaultRegistry::<T>::update_public_key(origin.clone().into(), public_key).unwrap();
+        VaultRegistry::<T>::set_public_key(origin.clone().into(), public_key).unwrap();
     }: _(origin, vault_id.currencies.clone(), amount.into())
 
     deposit_collateral {
@@ -82,7 +82,7 @@ benchmarks! {
         ).unwrap();
     }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone(), amount)
 
-    update_public_key {
+    set_public_key {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
     }: _(RawOrigin::Signed(vault_id.account_id), BtcPublicKey::default())

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -46,19 +46,27 @@ fn get_currency_pair<T: crate::Config>() -> DefaultVaultCurrencyPair<T> {
     }
 }
 
+fn register_vault_with_collateral<T: crate::Config>(vault_id: DefaultVaultId<T>, collateral: u32) {
+    let origin = RawOrigin::Signed(vault_id.account_id.clone());
+    assert_ok!(VaultRegistry::<T>::update_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::_register_vault(vault_id.clone(), collateral.into()));
+}
+
 benchmarks! {
     register_vault {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
         let amount: u32 = 100;
+        let origin = RawOrigin::Signed(vault_id.account_id.clone());
         let public_key = BtcPublicKey::default();
-    }: _(RawOrigin::Signed(vault_id.account_id.clone()), vault_id.currencies.clone(), amount.into(), public_key)
+        VaultRegistry::<T>::update_public_key(origin.clone().into(), public_key).unwrap();
+    }: _(origin, vault_id.currencies.clone(), amount.into())
 
     deposit_collateral {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
         let amount = 100u32.into();
-        VaultRegistry::<T>::_register_vault(vault_id.clone(), amount, dummy_public_key()).unwrap();
+        register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
         Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(),
             UnsignedFixedPoint::<T>::one()
         ).unwrap();
@@ -68,7 +76,7 @@ benchmarks! {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
         let amount = 100u32.into();
-        VaultRegistry::<T>::_register_vault(vault_id.clone(), amount, dummy_public_key()).unwrap();
+        register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
         Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(),
             UnsignedFixedPoint::<T>::one()
         ).unwrap();
@@ -77,19 +85,18 @@ benchmarks! {
     update_public_key {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
-        VaultRegistry::<T>::_register_vault(vault_id.clone(), 1234u32.into(), dummy_public_key()).unwrap();
-    }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone(), BtcPublicKey::default())
+    }: _(RawOrigin::Signed(vault_id.account_id), BtcPublicKey::default())
 
     register_address {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
-        VaultRegistry::<T>::_register_vault(vault_id.clone(), 1234u32.into(), dummy_public_key()).unwrap();
+        register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
     }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone(), BtcAddress::default())
 
     accept_new_issues {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
-        VaultRegistry::<T>::_register_vault(vault_id.clone(), 1234u32.into(), dummy_public_key()).unwrap();
+        register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
     }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone(), true)
 
     set_minimum_collateral {
@@ -112,7 +119,7 @@ benchmarks! {
         let origin: T::AccountId = account("Origin", 0, 0);
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
 
-        VaultRegistry::<T>::_register_vault(vault_id.clone(), 10_000u32.into(), dummy_public_key()).unwrap();
+        register_vault_with_collateral::<T>(vault_id.clone(), 10_000);
         Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::one()).unwrap();
 
         VaultRegistry::<T>::try_increase_to_be_issued_tokens(&vault_id, &wrapped(5_000)).unwrap();

--- a/crates/vault-registry/src/default_weights.rs
+++ b/crates/vault-registry/src/default_weights.rs
@@ -37,7 +37,7 @@ pub trait WeightInfo {
 	fn register_vault() -> Weight;
 	fn deposit_collateral() -> Weight;
 	fn withdraw_collateral() -> Weight;
-	fn update_public_key() -> Weight;
+	fn set_public_key() -> Weight;
 	fn register_address() -> Weight;
 	fn accept_new_issues() -> Weight;
 	fn set_minimum_collateral() -> Weight;
@@ -110,7 +110,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))
 	}
 	// Storage: VaultRegistry Vaults (r:1 w:1)
-	fn update_public_key() -> Weight {
+	fn set_public_key() -> Weight {
 		(27_632_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
@@ -243,7 +243,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(8 as Weight))
 	}
 	// Storage: VaultRegistry Vaults (r:1 w:1)
-	fn update_public_key() -> Weight {
+	fn set_public_key() -> Weight {
 		(27_632_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -262,9 +262,9 @@ pub mod pallet {
         ///
         /// # Arguments
         /// * `public_key` - the BTC public key of the vault to update
-        #[pallet::weight(<T as Config>::WeightInfo::update_public_key())]
+        #[pallet::weight(<T as Config>::WeightInfo::set_public_key())]
         #[transactional]
-        pub fn update_public_key(origin: OriginFor<T>, public_key: BtcPublicKey) -> DispatchResultWithPostInfo {
+        pub fn set_public_key(origin: OriginFor<T>, public_key: BtcPublicKey) -> DispatchResultWithPostInfo {
             let account_id = ensure_signed(origin)?;
 
             VaultBitcoinPublicKey::<T>::insert(&account_id, &public_key);

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -131,6 +131,10 @@ pub mod pallet {
             log::info!("Off-chain worker started on block {:?}", n);
             Self::_offchain_worker();
         }
+
+        fn on_runtime_upgrade() -> Weight {
+            crate::types::v2::migrate_v2_to_v3::<T>()
+        }
     }
 
     #[pallet::validate_unsigned]
@@ -697,7 +701,7 @@ pub mod pallet {
             for (currency_pair, threshold) in self.liquidation_collateral_threshold.iter() {
                 LiquidationCollateralThreshold::<T>::insert(currency_pair, threshold);
             }
-            StorageVersion::<T>::put(Version::V1);
+            StorageVersion::<T>::put(Version::V3);
         }
     }
 }

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -74,7 +74,7 @@ fn create_vault_with_collateral(id: &DefaultVaultId<Test>, collateral: u128) {
         .mock_safe(move |currency_id| MockResult::Return(Amount::new(collateral, currency_id)));
     let origin = Origin::signed(id.account_id.clone());
 
-    assert_ok!(VaultRegistry::update_public_key(origin.clone(), dummy_public_key()));
+    assert_ok!(VaultRegistry::set_public_key(origin.clone(), dummy_public_key()));
     assert_ok!(VaultRegistry::register_vault(origin, id.currencies.clone(), collateral));
 }
 
@@ -149,7 +149,7 @@ fn register_vault_fails_when_given_collateral_too_low() {
         let collateral = 100;
 
         let origin = Origin::signed(id.account_id);
-        assert_ok!(VaultRegistry::update_public_key(origin.clone(), dummy_public_key()));
+        assert_ok!(VaultRegistry::set_public_key(origin.clone(), dummy_public_key()));
 
         let result = VaultRegistry::register_vault(origin, id.currencies.clone(), collateral);
         assert_err!(result, TestError::InsufficientVaultCollateralAmount);
@@ -166,7 +166,7 @@ fn register_vault_fails_when_account_funds_too_low() {
         let collateral = DEFAULT_COLLATERAL + 1;
 
         let origin = Origin::signed(DEFAULT_ID.account_id);
-        assert_ok!(VaultRegistry::update_public_key(origin.clone(), dummy_public_key()));
+        assert_ok!(VaultRegistry::set_public_key(origin.clone(), dummy_public_key()));
 
         let result = VaultRegistry::register_vault(origin, DEFAULT_ID.currencies, collateral);
         assert_err!(result, TokensError::BalanceTooLow);

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -27,6 +27,8 @@ pub enum Version {
     V1,
     /// added replace_collateral to vault, changed vaultStatus enum
     V2,
+    /// moved public_key out of the vault struct
+    V3,
 }
 
 #[derive(Debug, PartialEq)]
@@ -101,6 +103,232 @@ pub type CurrencyId<T> = <T as orml_tokens::Config>::CurrencyId;
 pub type DefaultVaultId<T> = VaultId<<T as frame_system::Config>::AccountId, CurrencyId<T>>;
 
 pub type DefaultVaultCurrencyPair<T> = VaultCurrencyPair<CurrencyId<T>>;
+
+pub mod v2 {
+    use super::*;
+
+    #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo)]
+    struct WalletV2 {
+        // store all addresses for `report_vault_theft` checks
+        pub addresses: BTreeSet<BtcAddress>,
+        // we use this public key to generate new addresses
+        pub public_key: BtcPublicKey,
+    }
+
+    #[derive(Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
+    #[cfg_attr(feature = "std", derive(Debug))]
+    struct VaultV2<AccountId, BlockNumber, Balance, CurrencyId: Copy> {
+        /// Account identifier of the Vault
+        pub id: VaultId<AccountId, CurrencyId>,
+        /// Bitcoin address of this Vault (P2PKH, P2SH, P2WPKH, P2WSH)
+        pub wallet: WalletV2,
+        /// Current status of the vault
+        pub status: super::VaultStatus,
+        /// Block height until which this Vault is banned from being used for
+        /// Issue, Redeem (except during automatic liquidation) and Replace.
+        pub banned_until: Option<BlockNumber>,
+        /// Number of tokens pending issue
+        pub to_be_issued_tokens: Balance,
+        /// Number of issued tokens
+        pub issued_tokens: Balance,
+        /// Number of tokens pending redeem
+        pub to_be_redeemed_tokens: Balance,
+        /// Number of tokens that have been requested for a replace through
+        /// `request_replace`, but that have not been accepted yet by a new_vault.
+        pub to_be_replaced_tokens: Balance,
+        /// Amount of collateral that is available as griefing collateral to vaults accepting
+        /// a replace request. It is to be payed out if the old_vault fails to call execute_replace.
+        pub replace_collateral: Balance,
+        /// Amount of collateral locked for accepted replace requests.
+        pub active_replace_collateral: Balance,
+        /// Amount of collateral that is locked for remaining to_be_redeemed
+        /// tokens upon liquidation.
+        pub liquidated_collateral: Balance,
+    }
+
+    type DefaultVaultV2<T> = VaultV2<
+        <T as frame_system::Config>::AccountId,
+        <T as frame_system::Config>::BlockNumber,
+        BalanceOf<T>,
+        CurrencyId<T>,
+    >;
+
+    pub fn migrate_v2_to_v3<T: Config>() -> frame_support::weights::Weight {
+        use sp_runtime::traits::Saturating;
+
+        if !matches!(
+            crate::StorageVersion::<T>::get(),
+            Version::V0 | Version::V1 | Version::V2
+        ) {
+            log::info!("Not running vault storage migration");
+            return T::DbWeight::get().reads(1); // already upgraded; don't run migration
+        }
+        let mut num_migrated_vaults = 0u64;
+
+        crate::Vaults::<T>::translate::<DefaultVaultV2<T>, _>(|_key, vault_v2| {
+            num_migrated_vaults.saturating_inc();
+
+            crate::VaultBitcoinPublicKey::<T>::insert(
+                vault_v2.id.account_id.clone(),
+                vault_v2.wallet.public_key.clone(),
+            );
+            Some(Vault {
+                id: vault_v2.id,
+                wallet: Wallet {
+                    addresses: vault_v2.wallet.addresses,
+                },
+                status: vault_v2.status,
+                banned_until: vault_v2.banned_until,
+                to_be_issued_tokens: vault_v2.to_be_issued_tokens,
+                issued_tokens: vault_v2.issued_tokens,
+                to_be_redeemed_tokens: vault_v2.to_be_redeemed_tokens,
+                to_be_replaced_tokens: vault_v2.to_be_replaced_tokens,
+                replace_collateral: vault_v2.replace_collateral,
+                active_replace_collateral: vault_v2.active_replace_collateral,
+                liquidated_collateral: vault_v2.liquidated_collateral,
+            })
+        });
+        crate::StorageVersion::<T>::put(Version::V3);
+
+        log::info!("Migrated {num_migrated_vaults} vaults");
+
+        T::DbWeight::get().reads_writes(num_migrated_vaults, num_migrated_vaults)
+    }
+
+    #[cfg(test)]
+    #[test]
+    fn test_migration() {
+        use crate::mock::Test;
+        use bitcoin::types::H160;
+        use frame_support::{storage::migration, Blake2_128Concat, StorageHasher};
+        use primitives::{CurrencyId::Token, KBTC, KSM};
+        use sp_runtime::traits::TrailingZeroInput;
+
+        crate::mock::run_test(|| {
+            crate::StorageVersion::<Test>::put(Version::V2);
+
+            let vault1: DefaultVaultV2<Test> = VaultV2 {
+                id: VaultId {
+                    account_id: Decode::decode(&mut TrailingZeroInput::new(&[1u8; 32])).unwrap(),
+                    currencies: VaultCurrencyPair {
+                        collateral: Token(KSM),
+                        wrapped: Token(KBTC),
+                    },
+                },
+                wallet: WalletV2 {
+                    addresses: [
+                        BtcAddress::P2PKH(H160::from([1; 20])),
+                        BtcAddress::P2PKH(H160::from([2; 20])),
+                    ]
+                    .into(),
+                    public_key: BtcPublicKey::from([2u8; 33]),
+                },
+                banned_until: None,
+                status: VaultStatus::Active(true),
+                issued_tokens: Default::default(),
+                liquidated_collateral: Default::default(),
+                replace_collateral: Default::default(),
+                to_be_issued_tokens: Default::default(),
+                to_be_redeemed_tokens: Default::default(),
+                to_be_replaced_tokens: Default::default(),
+                active_replace_collateral: Default::default(),
+            };
+            let vault2: DefaultVaultV2<crate::mock::Test> = VaultV2 {
+                id: VaultId {
+                    account_id: Decode::decode(&mut TrailingZeroInput::new(&[2u8; 32])).unwrap(),
+                    currencies: VaultCurrencyPair {
+                        collateral: Token(KBTC),
+                        wrapped: Token(KBTC),
+                    },
+                },
+                wallet: WalletV2 {
+                    addresses: [
+                        BtcAddress::P2PKH(H160::from([3; 20])),
+                        BtcAddress::P2PKH(H160::from([4; 20])),
+                    ]
+                    .into(),
+                    public_key: BtcPublicKey::from([3u8; 33]),
+                },
+                banned_until: Some(123),
+                status: VaultStatus::Active(false),
+                issued_tokens: 1,
+                liquidated_collateral: 2,
+                replace_collateral: 3,
+                to_be_issued_tokens: 4,
+                to_be_redeemed_tokens: 5,
+                to_be_replaced_tokens: 6,
+                active_replace_collateral: 7,
+            };
+            migration::put_storage_value(
+                b"VaultRegistry",
+                b"Vaults",
+                &Blake2_128Concat::hash(&vault1.id.encode()),
+                &vault1,
+            );
+            migration::put_storage_value(
+                b"VaultRegistry",
+                b"Vaults",
+                &Blake2_128Concat::hash(&vault2.id.encode()),
+                &vault2,
+            );
+
+            migrate_v2_to_v3::<Test>();
+
+            let expected_migrated_vault1 = Vault {
+                id: vault1.id.clone(),
+                wallet: Wallet {
+                    addresses: vault1.wallet.addresses.clone(),
+                },
+                status: vault1.status.clone(),
+                banned_until: vault1.banned_until,
+                to_be_issued_tokens: vault1.to_be_issued_tokens,
+                issued_tokens: vault1.issued_tokens,
+                to_be_redeemed_tokens: vault1.to_be_redeemed_tokens,
+                to_be_replaced_tokens: vault1.to_be_replaced_tokens,
+                replace_collateral: vault1.replace_collateral,
+                active_replace_collateral: vault1.active_replace_collateral,
+                liquidated_collateral: vault1.liquidated_collateral,
+            };
+
+            let expected_migrated_vault2 = Vault {
+                id: vault2.id.clone(),
+                wallet: Wallet {
+                    addresses: vault2.wallet.addresses.clone(),
+                },
+                status: vault2.status.clone(),
+                banned_until: vault2.banned_until,
+                to_be_issued_tokens: vault2.to_be_issued_tokens,
+                issued_tokens: vault2.issued_tokens,
+                to_be_redeemed_tokens: vault2.to_be_redeemed_tokens,
+                to_be_replaced_tokens: vault2.to_be_replaced_tokens,
+                replace_collateral: vault2.replace_collateral,
+                active_replace_collateral: vault2.active_replace_collateral,
+                liquidated_collateral: vault2.liquidated_collateral,
+            };
+
+            // check that vault struct was migrated correctly
+            assert_eq!(
+                crate::Vaults::<Test>::iter().collect::<Vec<_>>(),
+                vec![
+                    (expected_migrated_vault2.id.clone(), expected_migrated_vault2),
+                    (expected_migrated_vault1.id.clone(), expected_migrated_vault1),
+                ]
+            );
+
+            // check that public key is set
+            assert_eq!(
+                crate::VaultBitcoinPublicKey::<Test>::iter().collect::<Vec<_>>(),
+                vec![
+                    (vault2.id.account_id.clone(), vault2.wallet.public_key),
+                    (vault1.id.account_id.clone(), vault1.wallet.public_key),
+                ]
+            );
+
+            // check that storage version is bumped
+            assert!(crate::StorageVersion::<Test>::get() == Version::V3);
+        });
+    }
+}
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo)]
 pub struct Wallet {

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -950,7 +950,7 @@ pub fn dummy_public_key() -> BtcPublicKey {
 }
 
 pub fn register_vault_with_public_key(vault_id: &VaultId, collateral: Amount<Runtime>, public_key: BtcPublicKey) {
-    assert_ok!(Call::VaultRegistry(VaultRegistryCall::update_public_key { public_key })
+    assert_ok!(Call::VaultRegistry(VaultRegistryCall::set_public_key { public_key })
         .dispatch(origin_of(vault_id.account_id.clone())));
     assert_ok!(Call::VaultRegistry(VaultRegistryCall::register_vault {
         currency_pair: vault_id.currencies.clone(),
@@ -965,7 +965,7 @@ pub fn register_vault(vault_id: &VaultId, collateral: Amount<Runtime>) {
 
 pub fn get_register_vault_result(vault_id: &VaultId, collateral: Amount<Runtime>) -> DispatchResultWithPostInfo {
     assert_eq!(vault_id.collateral_currency(), collateral.currency());
-    assert_ok!(Call::VaultRegistry(VaultRegistryCall::update_public_key {
+    assert_ok!(Call::VaultRegistry(VaultRegistryCall::set_public_key {
         public_key: dummy_public_key()
     })
     .dispatch(origin_of(vault_id.account_id.clone())));

--- a/standalone/runtime/tests/mock/nomination_testing_utils.rs
+++ b/standalone/runtime/tests/mock/nomination_testing_utils.rs
@@ -29,21 +29,21 @@ pub fn disable_nomination() {
     );
 }
 
-pub fn register_vault(currency_id: CurrencyId, vault: [u8; 32]) -> DispatchResultWithPostInfo {
-    Call::VaultRegistry(VaultRegistryCall::register_vault {
-        currency_pair: VaultCurrencyPair {
-            collateral: currency_id,
-            wrapped: DEFAULT_WRAPPED_CURRENCY,
-        },
-        collateral: DEFAULT_BACKING_COLLATERAL,
-        public_key: dummy_public_key(),
-    })
-    .dispatch(origin_of(account_of(vault)))
-}
-
-pub fn assert_register_vault(currency_id: CurrencyId, vault: [u8; 32]) {
-    assert_ok!(register_vault(currency_id, vault));
-}
+// pub fn register_vault(currency_id: CurrencyId, vault: [u8; 32]) -> DispatchResultWithPostInfo {
+//     Call::VaultRegistry(VaultRegistryCall::register_vault {
+//         currency_pair: VaultCurrencyPair {
+//             collateral: currency_id,
+//             wrapped: DEFAULT_WRAPPED_CURRENCY,
+//         },
+//         collateral: DEFAULT_BACKING_COLLATERAL,
+//         public_key: dummy_public_key(),
+//     })
+//     .dispatch(origin_of(account_of(vault)))
+// }
+//
+// pub fn assert_register_vault(currency_id: CurrencyId, vault: [u8; 32]) {
+//     assert_ok!(register_vault(currency_id, vault));
+// }
 
 pub fn nomination_opt_in(vault_id: &DefaultVaultId<Runtime>) -> DispatchResultWithPostInfo {
     Call::Nomination(NominationCall::opt_in_to_nomination {

--- a/standalone/runtime/tests/mock/nomination_testing_utils.rs
+++ b/standalone/runtime/tests/mock/nomination_testing_utils.rs
@@ -29,22 +29,6 @@ pub fn disable_nomination() {
     );
 }
 
-// pub fn register_vault(currency_id: CurrencyId, vault: [u8; 32]) -> DispatchResultWithPostInfo {
-//     Call::VaultRegistry(VaultRegistryCall::register_vault {
-//         currency_pair: VaultCurrencyPair {
-//             collateral: currency_id,
-//             wrapped: DEFAULT_WRAPPED_CURRENCY,
-//         },
-//         collateral: DEFAULT_BACKING_COLLATERAL,
-//         public_key: dummy_public_key(),
-//     })
-//     .dispatch(origin_of(account_of(vault)))
-// }
-//
-// pub fn assert_register_vault(currency_id: CurrencyId, vault: [u8; 32]) {
-//     assert_ok!(register_vault(currency_id, vault));
-// }
-
 pub fn nomination_opt_in(vault_id: &DefaultVaultId<Runtime>) -> DispatchResultWithPostInfo {
     Call::Nomination(NominationCall::opt_in_to_nomination {
         currency_pair: vault_id.currencies.clone(),

--- a/standalone/runtime/tests/test_escrow.rs
+++ b/standalone/runtime/tests/test_escrow.rs
@@ -1,7 +1,6 @@
 mod mock;
 
 use mock::{assert_eq, *};
-use primitives::VaultCurrencyPair;
 use reward::Rewards;
 use sp_core::H256;
 

--- a/standalone/runtime/tests/test_multisig.rs
+++ b/standalone/runtime/tests/test_multisig.rs
@@ -4,7 +4,6 @@ use frame_support::traits::WrapperKeepOpaque;
 use mock::{assert_eq, *};
 use orml_tokens::AccountData;
 use orml_vesting::VestingSchedule;
-use primitives::VaultCurrencyPair;
 use sp_core::{crypto::Ss58Codec, Encode, H256};
 use sp_std::str::FromStr;
 

--- a/standalone/runtime/tests/test_nomination.rs
+++ b/standalone/runtime/tests/test_nomination.rs
@@ -2,7 +2,6 @@ mod mock;
 
 use currency::Amount;
 use mock::{assert_eq, nomination_testing_utils::*, *};
-use primitives::VaultCurrencyPair;
 use sp_runtime::traits::{CheckedDiv, CheckedSub};
 
 fn test_with<R>(execute: impl Fn(VaultId) -> R) {
@@ -389,8 +388,12 @@ mod spec_based_tests {
 #[test]
 fn integration_test_regular_vaults_are_not_opted_in_to_nomination() {
     test_with_nomination_enabled(|vault_id| {
-        assert_register_vault(vault_id.collateral_currency(), CAROL);
-        assert_eq!(NominationPallet::is_opted_in(&vault_id).unwrap(), false);
+        let new_vault_id = VaultId {
+            account_id: account_of(CAROL),
+            ..vault_id
+        };
+        register_vault(&new_vault_id, Amount::new(1000000, new_vault_id.collateral_currency()));
+        assert_eq!(NominationPallet::is_opted_in(&new_vault_id).unwrap(), false);
     })
 }
 

--- a/standalone/runtime/tests/test_vault_registry.rs
+++ b/standalone/runtime/tests/test_vault_registry.rs
@@ -222,7 +222,7 @@ fn integration_test_vault_registry_with_parachain_shutdown_fails() {
             SystemError::CallFiltered
         );
         assert_noop!(
-            Call::VaultRegistry(VaultRegistryCall::update_public_key {
+            Call::VaultRegistry(VaultRegistryCall::set_public_key {
                 public_key: Default::default()
             })
             .dispatch(origin_of(account_of(VAULT))),

--- a/standalone/runtime/tests/test_vault_registry.rs
+++ b/standalone/runtime/tests/test_vault_registry.rs
@@ -201,7 +201,6 @@ fn integration_test_vault_registry_with_parachain_shutdown_fails() {
             Call::VaultRegistry(VaultRegistryCall::register_vault {
                 currency_pair: vault_id.currencies.clone(),
                 collateral: 0,
-                public_key: Default::default()
             })
             .dispatch(origin_of(account_of(VAULT))),
             SystemError::CallFiltered
@@ -224,7 +223,6 @@ fn integration_test_vault_registry_with_parachain_shutdown_fails() {
         );
         assert_noop!(
             Call::VaultRegistry(VaultRegistryCall::update_public_key {
-                currency_pair: vault_id.currencies.clone(),
                 public_key: Default::default()
             })
             .dispatch(origin_of(account_of(VAULT))),
@@ -291,25 +289,20 @@ fn integration_test_vault_registry_register_respects_fund_limit() {
         (*user_data.balances.get_mut(&currency_id).unwrap()).free = Amount::new(FUND_LIMIT_CEILING + 1, currency_id);
 
         UserData::force_to(USER, user_data);
+        let user_vault_id = VaultId {
+            account_id: account_of(USER),
+            ..vault_id.clone()
+        };
 
         let current = VaultRegistryPallet::get_total_user_vault_collateral(&vault_id.currencies).unwrap();
-        let remaining = FUND_LIMIT_CEILING - current.amount();
+        let remaining = Amount::new(FUND_LIMIT_CEILING, current.currency()) - current;
 
-        assert_noop!(
-            Call::VaultRegistry(VaultRegistryCall::register_vault {
-                currency_pair: vault_id.currencies.clone(),
-                collateral: remaining + 1,
-                public_key: Default::default(),
-            })
-            .dispatch(origin_of(account_of(USER))),
+        // not asserting noop since this func registers a public key first
+        assert_err!(
+            get_register_vault_result(&user_vault_id, remaining.with_amount(|x| x + 1)),
             VaultRegistryError::CurrencyCeilingExceeded
         );
 
-        assert_ok!(Call::VaultRegistry(VaultRegistryCall::register_vault {
-            currency_pair: vault_id.currencies.clone(),
-            collateral: remaining,
-            public_key: Default::default(),
-        })
-        .dispatch(origin_of(account_of(USER))),);
+        assert_ok!(get_register_vault_result(&user_vault_id, remaining));
     });
 }


### PR DESCRIPTION
With this change, the bitcoin public key is shared among all vaultids that share the same accountid.

Prior to calling `register_vault`, the vault _must_ call `update_public_key`, which sets the public key in the new `VaultBitcoinPublicKey` map.

A note to downstream: the `UpdatePublicKey` event type has changed, as well as the `register_vault` and `update_public_key` functions.

Note to reviewer: this PR is neatly split up into separate commits which may be useful in reviewing. Please also check the migration carefully.

