### PR TITLE
Fix: interlay xcm config

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -22,7 +22,7 @@ use frame_system::{
     limits::{BlockLength, BlockWeights},
     EnsureRoot, RawOrigin,
 };
-use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key};
+use orml_traits::parameter_type_with_key;
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, H256};

--- a/parachain/runtime/interlay/src/xcm_config.rs
+++ b/parachain/runtime/interlay/src/xcm_config.rs
@@ -1,13 +1,21 @@
 use super::*;
+use codec::Encode;
 use cumulus_primitives_core::ParaId;
+use frame_support::{
+    parameter_types,
+    traits::{Everything, Get, Nothing},
+    weights::Weight,
+};
+use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key, MultiCurrency};
 use orml_xcm_support::{DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use xcm::latest::prelude::*;
 use xcm_builder::{
-    AccountId32Aliases, AllowTopLevelPaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds, LocationInverter,
-    NativeAsset, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-    SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+    AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom,
+    EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, LocationInverter, NativeAsset, ParentIsPreset,
+    RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+    SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue, TakeWeightCredit,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -49,18 +57,92 @@ pub type XcmOriginToTransactDispatchOrigin = (
     XcmPassthrough<Origin>,
 );
 
+pub type Barrier = (
+    TakeWeightCredit,
+    AllowTopLevelPaidExecutionFrom<Everything>,
+    AllowKnownQueryResponses<PolkadotXcm>,
+    AllowSubscriptionsFrom<Everything>,
+); // required for others to keep track of our xcm version
+
 parameter_types! {
     // One XCM operation is 200_000_000 weight, cross-chain transfer ~= 2x of transfer.
     pub UnitWeightCost: Weight = 200_000_000;
-}
-
-pub type Barrier = (TakeWeightCredit, AllowTopLevelPaidExecutionFrom<Everything>);
-
-parameter_types! {
     pub const MaxInstructions: u32 = 100;
 }
 
 pub struct XcmConfig;
+
+// the ksm cost to to execute a no-op extrinsic
+fn base_tx_in_ksm() -> Balance {
+    KSM.one() / 50_000
+}
+
+pub fn ksm_per_second() -> u128 {
+    let base_weight = Balance::from(ExtrinsicBaseWeight::get());
+    let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;
+    base_tx_per_second * base_tx_in_ksm()
+}
+
+parameter_types! {
+    pub KsmPerSecond: (AssetId, u128) = (MultiLocation::parent().into(), ksm_per_second());
+    pub KintPerSecond: (AssetId, u128) = ( // can be removed once we no longer need to support polkadot < 0.9.16
+        MultiLocation::new(
+            1,
+            X2(Parachain(ParachainInfo::get().into()), GeneralKey(Token(KINT).encode())),
+        ).into(),
+        // KINT:KSM = 4:3
+        (ksm_per_second() * 4) / 3
+    );
+    pub KbtcPerSecond: (AssetId, u128) = ( // can be removed once we no longer need to support polkadot < 0.9.16
+        MultiLocation::new(
+            1,
+            X2(Parachain(ParachainInfo::get().into()), GeneralKey(Token(KBTC).encode())),
+        ).into(),
+        // KBTC:KSM = 1:150 & Satoshi:Planck = 1:10_000
+        ksm_per_second() / 1_500_000
+    );
+    pub CanonicalizedKintPerSecond: (AssetId, u128) = (
+        MultiLocation::new(
+            0,
+            X1(GeneralKey(Token(KINT).encode())),
+        ).into(),
+        // KINT:KSM = 4:3
+        (ksm_per_second() * 4) / 3
+    );
+    pub CanonicalizedKbtcPerSecond: (AssetId, u128) = (
+        MultiLocation::new(
+            0,
+            X1(GeneralKey(Token(KBTC).encode())),
+        ).into(),
+        // KBTC:KSM = 1:150 & Satoshi:Planck = 1:10_000
+        ksm_per_second() / 1_500_000
+    );
+}
+
+pub struct ToTreasury;
+impl TakeRevenue for ToTreasury {
+    fn take_revenue(revenue: MultiAsset) {
+        if let MultiAsset {
+            id: Concrete(location),
+            fun: Fungible(amount),
+        } = revenue
+        {
+            if let Some(currency_id) = CurrencyIdConvert::convert(location) {
+                // Note: we should ensure that treasury account has existential deposit for all of the cross-chain
+                // asset. Ignore the result.
+                let _ = Tokens::deposit(currency_id, &TreasuryAccount::get(), amount);
+            }
+        }
+    }
+}
+
+pub type Trader = (
+    FixedRateOfFungible<KsmPerSecond, ToTreasury>,
+    FixedRateOfFungible<KintPerSecond, ToTreasury>,
+    FixedRateOfFungible<KbtcPerSecond, ToTreasury>,
+    FixedRateOfFungible<CanonicalizedKintPerSecond, ToTreasury>,
+    FixedRateOfFungible<CanonicalizedKbtcPerSecond, ToTreasury>,
+);
 
 impl Config for XcmConfig {
     type Call = Call;
@@ -73,13 +155,7 @@ impl Config for XcmConfig {
     type LocationInverter = LocationInverter<Ancestry>;
     type Barrier = Barrier;
     type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-    type Trader = UsingComponents<
-        IdentityFee<Balance>,
-        ParentLocation,
-        AccountId,
-        orml_tokens::CurrencyAdapter<Runtime, GetRelayChainCurrencyId>,
-        (),
-    >;
+    type Trader = Trader;
     type ResponseHandler = PolkadotXcm;
     type SubscriptionService = PolkadotXcm;
     type AssetTrap = PolkadotXcm;
@@ -219,11 +295,11 @@ mod currency_id_convert {
 
 parameter_types! {
     pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::get().into())));
-    pub const MaxAssetsForTransfer: usize = 2;
+    pub const MaxAssetsForTransfer: usize = 2; // potentially useful to send both kint and kbtc at once
 }
 
 parameter_type_with_key! {
-    // Only used for transferring parachain tokens to other parachains using DOT as fee currency. Currently we do not support this, hence return MAX.
+    // Only used for transferring parachain tokens to other parachains using KSM as fee currency. Currently we do not support this, hence return MAX.
     // See: https://github.com/open-web3-stack/open-runtime-module-library/blob/cadcc9fb10b8212f92668138fc8f83dc0c53acf5/xtokens/README.md#transfer-multiple-currencies
     pub ParachainMinFee: |location: MultiLocation| -> u128 {
         #[allow(clippy::match_ref_pats)] // false positive


### PR DESCRIPTION
I copied the config from Kintsugi and made changes to use the other currencies. They are in separate commits, I recommend only looking at the second.

I wasn't sure what to use for the value of IntrPerSecond because we don't have an exchange rate for intr yet, so I left it unchanged with respect to the kintsugi value.

One other notable change compared to kintsugi is that I transfer the xcm fees to the block author rather than to treasury.

Also I removed the non-canonicalized trader items.