### PR TITLE
[BREAKING] Fix!: disallow updating public key

### DIFF
--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -61,7 +61,10 @@ fn get_vault_id<T: crate::Config>() -> DefaultVaultId<T> {
 
 fn register_vault<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::register_public_key(
+        origin.into(),
+        dummy_public_key()
+    ));
     assert_ok!(VaultRegistry::<T>::_register_vault(
         vault_id.clone(),
         100000000u32.into()

--- a/crates/nomination/src/benchmarking.rs
+++ b/crates/nomination/src/benchmarking.rs
@@ -47,7 +47,10 @@ fn get_vault_id<T: crate::Config>() -> DefaultVaultId<T> {
 
 fn register_vault<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::register_public_key(
+        origin.into(),
+        dummy_public_key()
+    ));
     assert_ok!(VaultRegistry::<T>::_register_vault(
         vault_id.clone(),
         100000000u32.into()

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -42,9 +42,12 @@ fn dummy_public_key() -> BtcPublicKey {
     ])
 }
 
-fn set_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
+fn register_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::register_public_key(
+        origin.into(),
+        dummy_public_key()
+    ));
 }
 
 fn deposit_tokens<T: crate::Config>(currency_id: CurrencyId, account_id: &T::AccountId, amount: BalanceOf<T>) {
@@ -174,7 +177,7 @@ benchmarks! {
 
         initialize_oracle::<T>();
 
-        set_public_key::<T>(vault_id.clone());
+        register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
             wallet: Wallet::new(),
@@ -204,7 +207,7 @@ benchmarks! {
         let vault_id = get_vault_id::<T>();
         let amount = 1000;
 
-        set_public_key::<T>(vault_id.clone());
+        register_public_key::<T>(vault_id.clone());
 
         VaultRegistry::<T>::insert_vault(
             &vault_id,
@@ -240,7 +243,7 @@ benchmarks! {
         redeem_request.btc_address = origin_btc_address;
         Redeem::<T>::insert_redeem_request(&redeem_id, &redeem_request);
 
-        set_public_key::<T>(vault_id.clone());
+        register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
             wallet: Wallet::new(),
@@ -331,7 +334,7 @@ BtcRelay::<T>::parachain_confirmations() + 1u32.into());
         mine_blocks_until_expiry::<T>(&redeem_request);
         Security::<T>::set_active_block_number(Security::<T>::active_block_number() + Redeem::<T>::redeem_period() + 100u32.into());
 
-        set_public_key::<T>(vault_id.clone());
+        register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
             wallet: Wallet::new(),
@@ -366,7 +369,7 @@ BtcRelay::<T>::parachain_confirmations() + 1u32.into());
         mine_blocks_until_expiry::<T>(&redeem_request);
         Security::<T>::set_active_block_number(Security::<T>::active_block_number() + Redeem::<T>::redeem_period() + 100u32.into());
 
-        set_public_key::<T>(vault_id.clone());
+        register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
             wallet: Wallet::new(),

--- a/crates/refund/src/benchmarking.rs
+++ b/crates/refund/src/benchmarking.rs
@@ -59,7 +59,7 @@ benchmarks! {
         Refund::<T>::insert_refund_request(&refund_id, &refund_request);
 
         let origin = RawOrigin::Signed(vault_id.account_id.clone());
-        assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
+        assert_ok!(VaultRegistry::<T>::register_public_key(origin.into(), dummy_public_key()));
 
         let vault = Vault::new(vault_id.clone());
 

--- a/crates/relay/src/benchmarking.rs
+++ b/crates/relay/src/benchmarking.rs
@@ -48,9 +48,12 @@ fn mint_collateral<T: crate::Config>(account_id: &T::AccountId, amount: BalanceO
     deposit_tokens::<T>(get_native_currency_id::<T>(), account_id, amount);
 }
 
-fn set_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
+fn register_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::register_public_key(
+        origin.into(),
+        dummy_public_key()
+    ));
 }
 
 benchmarks! {
@@ -118,7 +121,7 @@ benchmarks! {
             <T as currency::Config>::GetWrappedCurrencyId::get()
         );
 
-        set_public_key::<T>(vault_id.clone());
+        register_public_key::<T>(vault_id.clone());
 
         let mut vault = Vault {
             wallet: Wallet::new(),

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -145,13 +145,16 @@ fn get_vault_id<T: crate::Config>(name: &'static str) -> DefaultVaultId<T> {
     )
 }
 
-fn set_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
+fn register_public_key<T: crate::Config>(vault_id: DefaultVaultId<T>) {
     let origin = RawOrigin::Signed(vault_id.account_id);
-    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::register_public_key(
+        origin.into(),
+        dummy_public_key()
+    ));
 }
 
 fn register_vault<T: crate::Config>(vault_id: DefaultVaultId<T>) {
-    set_public_key::<T>(vault_id.clone());
+    register_public_key::<T>(vault_id.clone());
     assert_ok!(VaultRegistry::<T>::_register_vault(
         vault_id.clone(),
         100000000u32.into()
@@ -166,7 +169,7 @@ benchmarks! {
         // TODO: calculate from exchange rate
         let griefing = 1000u32.into();
 
-        set_public_key::<T>(vault_id.clone());
+        register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
             wallet: Wallet::new(),

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -48,7 +48,10 @@ fn get_currency_pair<T: crate::Config>() -> DefaultVaultCurrencyPair<T> {
 
 fn register_vault_with_collateral<T: crate::Config>(vault_id: DefaultVaultId<T>, collateral: u32) {
     let origin = RawOrigin::Signed(vault_id.account_id.clone());
-    assert_ok!(VaultRegistry::<T>::set_public_key(origin.into(), dummy_public_key()));
+    assert_ok!(VaultRegistry::<T>::register_public_key(
+        origin.into(),
+        dummy_public_key()
+    ));
     assert_ok!(VaultRegistry::<T>::_register_vault(vault_id.clone(), collateral.into()));
 }
 
@@ -59,7 +62,7 @@ benchmarks! {
         let amount: u32 = 100;
         let origin = RawOrigin::Signed(vault_id.account_id.clone());
         let public_key = BtcPublicKey::default();
-        VaultRegistry::<T>::set_public_key(origin.clone().into(), public_key).unwrap();
+        VaultRegistry::<T>::register_public_key(origin.clone().into(), public_key).unwrap();
     }: _(origin, vault_id.currencies.clone(), amount.into())
 
     deposit_collateral {
@@ -82,7 +85,7 @@ benchmarks! {
         ).unwrap();
     }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone(), amount)
 
-    set_public_key {
+    register_public_key {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
     }: _(RawOrigin::Signed(vault_id.account_id), BtcPublicKey::default())

--- a/crates/vault-registry/src/default_weights.rs
+++ b/crates/vault-registry/src/default_weights.rs
@@ -37,7 +37,7 @@ pub trait WeightInfo {
 	fn register_vault() -> Weight;
 	fn deposit_collateral() -> Weight;
 	fn withdraw_collateral() -> Weight;
-	fn set_public_key() -> Weight;
+	fn register_public_key() -> Weight;
 	fn register_address() -> Weight;
 	fn accept_new_issues() -> Weight;
 	fn set_minimum_collateral() -> Weight;
@@ -110,7 +110,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))
 	}
 	// Storage: VaultRegistry Vaults (r:1 w:1)
-	fn set_public_key() -> Weight {
+	fn register_public_key() -> Weight {
 		(27_632_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
@@ -243,7 +243,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(8 as Weight))
 	}
 	// Storage: VaultRegistry Vaults (r:1 w:1)
-	fn set_public_key() -> Weight {
+	fn register_public_key() -> Weight {
 		(27_632_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -262,9 +262,9 @@ pub mod pallet {
         ///
         /// # Arguments
         /// * `public_key` - the BTC public key of the vault to update
-        #[pallet::weight(<T as Config>::WeightInfo::set_public_key())]
+        #[pallet::weight(<T as Config>::WeightInfo::register_public_key())]
         #[transactional]
-        pub fn set_public_key(origin: OriginFor<T>, public_key: BtcPublicKey) -> DispatchResultWithPostInfo {
+        pub fn register_public_key(origin: OriginFor<T>, public_key: BtcPublicKey) -> DispatchResultWithPostInfo {
             let account_id = ensure_signed(origin)?;
 
             VaultBitcoinPublicKey::<T>::insert(&account_id, &public_key);

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -267,6 +267,11 @@ pub mod pallet {
         pub fn register_public_key(origin: OriginFor<T>, public_key: BtcPublicKey) -> DispatchResultWithPostInfo {
             let account_id = ensure_signed(origin)?;
 
+            ensure!(
+                !VaultBitcoinPublicKey::<T>::get(&account_id).is_some(),
+                Error::<T>::PublicKeyAlreadyRegistered
+            );
+
             VaultBitcoinPublicKey::<T>::insert(&account_id, &public_key);
 
             Self::deposit_event(Event::<T>::UpdatePublicKey { account_id, public_key });
@@ -561,6 +566,8 @@ pub mod pallet {
         VaultLiquidated,
         /// No bitcoin public key is registered for the vault.
         NoBitcoinPublicKey,
+        /// A bitcoin public key was already registered for this account.
+        PublicKeyAlreadyRegistered,
 
         // Errors used exclusively in RPC functions
         /// Collateralization is infinite if no tokens are issued

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -74,7 +74,7 @@ fn create_vault_with_collateral(id: &DefaultVaultId<Test>, collateral: u128) {
         .mock_safe(move |currency_id| MockResult::Return(Amount::new(collateral, currency_id)));
     let origin = Origin::signed(id.account_id.clone());
 
-    assert_ok!(VaultRegistry::set_public_key(origin.clone(), dummy_public_key()));
+    assert_ok!(VaultRegistry::register_public_key(origin.clone(), dummy_public_key()));
     assert_ok!(VaultRegistry::register_vault(origin, id.currencies.clone(), collateral));
 }
 
@@ -149,7 +149,7 @@ fn register_vault_fails_when_given_collateral_too_low() {
         let collateral = 100;
 
         let origin = Origin::signed(id.account_id);
-        assert_ok!(VaultRegistry::set_public_key(origin.clone(), dummy_public_key()));
+        assert_ok!(VaultRegistry::register_public_key(origin.clone(), dummy_public_key()));
 
         let result = VaultRegistry::register_vault(origin, id.currencies.clone(), collateral);
         assert_err!(result, TestError::InsufficientVaultCollateralAmount);
@@ -166,7 +166,7 @@ fn register_vault_fails_when_account_funds_too_low() {
         let collateral = DEFAULT_COLLATERAL + 1;
 
         let origin = Origin::signed(DEFAULT_ID.account_id);
-        assert_ok!(VaultRegistry::set_public_key(origin.clone(), dummy_public_key()));
+        assert_ok!(VaultRegistry::register_public_key(origin.clone(), dummy_public_key()));
 
         let result = VaultRegistry::register_vault(origin, DEFAULT_ID.currencies, collateral);
         assert_err!(result, TokensError::BalanceTooLow);

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -141,6 +141,20 @@ fn register_vault_succeeds() {
 }
 
 #[test]
+fn registering_public_key_twice_fails() {
+    run_test(|| {
+        let origin = Origin::signed(DEFAULT_ID.account_id);
+        let public_key_1 = BtcPublicKey([0u8; 33]);
+        let public_key_2 = BtcPublicKey([1u8; 33]);
+        assert_ok!(VaultRegistry::register_public_key(origin.clone(), public_key_1));
+        assert_err!(
+            VaultRegistry::register_public_key(origin.clone(), public_key_2),
+            TestError::PublicKeyAlreadyRegistered
+        );
+    })
+}
+
+#[test]
 fn register_vault_fails_when_given_collateral_too_low() {
     run_test(|| {
         VaultRegistry::get_minimum_collateral_vault

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -950,8 +950,10 @@ pub fn dummy_public_key() -> BtcPublicKey {
 }
 
 pub fn register_vault_with_public_key(vault_id: &VaultId, collateral: Amount<Runtime>, public_key: BtcPublicKey) {
-    assert_ok!(Call::VaultRegistry(VaultRegistryCall::set_public_key { public_key })
-        .dispatch(origin_of(vault_id.account_id.clone())));
+    assert_ok!(
+        Call::VaultRegistry(VaultRegistryCall::register_public_key { public_key })
+            .dispatch(origin_of(vault_id.account_id.clone()))
+    );
     assert_ok!(Call::VaultRegistry(VaultRegistryCall::register_vault {
         currency_pair: vault_id.currencies.clone(),
         collateral: collateral.amount(),
@@ -965,7 +967,7 @@ pub fn register_vault(vault_id: &VaultId, collateral: Amount<Runtime>) {
 
 pub fn get_register_vault_result(vault_id: &VaultId, collateral: Amount<Runtime>) -> DispatchResultWithPostInfo {
     assert_eq!(vault_id.collateral_currency(), collateral.currency());
-    assert_ok!(Call::VaultRegistry(VaultRegistryCall::set_public_key {
+    assert_ok!(Call::VaultRegistry(VaultRegistryCall::register_public_key {
         public_key: dummy_public_key()
     })
     .dispatch(origin_of(vault_id.account_id.clone())));

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -950,10 +950,12 @@ pub fn dummy_public_key() -> BtcPublicKey {
 }
 
 pub fn register_vault_with_public_key(vault_id: &VaultId, collateral: Amount<Runtime>, public_key: BtcPublicKey) {
-    assert_ok!(
-        Call::VaultRegistry(VaultRegistryCall::register_public_key { public_key })
-            .dispatch(origin_of(vault_id.account_id.clone()))
-    );
+    if VaultRegistryPallet::get_bitcoin_public_key(&vault_id.account_id).is_err() {
+        assert_ok!(
+            Call::VaultRegistry(VaultRegistryCall::register_public_key { public_key })
+                .dispatch(origin_of(vault_id.account_id.clone()))
+        );
+    }
     assert_ok!(Call::VaultRegistry(VaultRegistryCall::register_vault {
         currency_pair: vault_id.currencies.clone(),
         collateral: collateral.amount(),
@@ -967,10 +969,12 @@ pub fn register_vault(vault_id: &VaultId, collateral: Amount<Runtime>) {
 
 pub fn get_register_vault_result(vault_id: &VaultId, collateral: Amount<Runtime>) -> DispatchResultWithPostInfo {
     assert_eq!(vault_id.collateral_currency(), collateral.currency());
-    assert_ok!(Call::VaultRegistry(VaultRegistryCall::register_public_key {
-        public_key: dummy_public_key()
-    })
-    .dispatch(origin_of(vault_id.account_id.clone())));
+    if VaultRegistryPallet::get_bitcoin_public_key(&vault_id.account_id).is_err() {
+        assert_ok!(Call::VaultRegistry(VaultRegistryCall::register_public_key {
+            public_key: dummy_public_key()
+        })
+        .dispatch(origin_of(vault_id.account_id.clone())));
+    }
     Call::VaultRegistry(VaultRegistryCall::register_vault {
         currency_pair: vault_id.currencies.clone(),
         collateral: collateral.amount(),

--- a/standalone/runtime/tests/test_vault_registry.rs
+++ b/standalone/runtime/tests/test_vault_registry.rs
@@ -222,7 +222,7 @@ fn integration_test_vault_registry_with_parachain_shutdown_fails() {
             SystemError::CallFiltered
         );
         assert_noop!(
-            Call::VaultRegistry(VaultRegistryCall::set_public_key {
+            Call::VaultRegistry(VaultRegistryCall::register_public_key {
                 public_key: Default::default()
             })
             .dispatch(origin_of(account_of(VAULT))),


### PR DESCRIPTION
Breaking because I renamed set_public_key -> register_public_key to reflect it's a one-time operation