### PR TITLE
chore: allow opt-out out of slow tests

### DIFF
--- a/crates/vault-registry/Cargo.toml
+++ b/crates/vault-registry/Cargo.toml
@@ -83,3 +83,4 @@ runtime-benchmarks = [
 integration-tests = [
   "visibility"
 ]
+skip-slow-tests = []

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -866,6 +866,7 @@ fn calculate_max_wrapped_from_collateral_for_threshold_succeeds() {
 }
 
 #[test]
+#[cfg_attr(feature = "skip-slow-tests", ignore)]
 fn test_threshold_equivalent_to_legacy_calculation() {
     /// old version
     fn legacy_calculate_max_wrapped_from_collateral_for_threshold(
@@ -905,6 +906,7 @@ fn test_threshold_equivalent_to_legacy_calculation() {
 }
 
 #[test]
+#[cfg_attr(feature = "skip-slow-tests", ignore)]
 fn test_get_required_collateral_threshold_equivalent_to_legacy_calculation_() {
     // old version
     fn legacy_get_required_collateral_for_wrapped_with_threshold(

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -212,3 +212,4 @@ runtime-benchmarks = [
   "escrow/runtime-benchmarks",
 ]
 disable-runtime-api = []
+skip-slow-tests = []

--- a/standalone/runtime/tests/test_btc_relay.rs
+++ b/standalone/runtime/tests/test_btc_relay.rs
@@ -8,6 +8,7 @@ use mock::{assert_eq, *};
 type BTCRelayError = btc_relay::Error<Runtime>;
 
 #[test]
+#[cfg_attr(feature = "skip-slow-tests", ignore)]
 fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
     ExtBuilder::build().execute_without_relay_init(|| {
         // ensure that difficulty check is enabled


### PR DESCRIPTION
Allow opting out out of slow tests - this greatly speeds up tests locally. I chose to make it opt-out instead of opt-int so we can be sure that the CI includes everything. 

I  suggest setting up your vs code to use `cargo test --workspace --features skip-slow-tests --lib --bins --tests`. This skips 3 slow tests and skips doc-tests (which we do not use, but are slow to run even so). This runs in 13 seconds, compared to the 2m25s that `cargo test --workspace` takes.
