### PR TITLE
feat: add instant-seal for dev chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,6 +3556,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",
+ "futures 0.3.21",
  "hex-literal 0.2.2",
  "interbtc-primitives",
  "interbtc-rpc",
@@ -3582,6 +3583,7 @@ dependencies = [
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
+ "sc-consensus-manual-seal",
  "sc-executor",
  "sc-network",
  "sc-rpc",
@@ -3638,6 +3640,7 @@ dependencies = [
  "module-replace-rpc",
  "module-vault-registry-rpc",
  "pallet-transaction-payment-rpc",
+ "sc-consensus-manual-seal",
  "sc-rpc",
  "sc-rpc-api",
  "sc-transaction-pool-api",
@@ -10192,6 +10195,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-consensus-manual-seal"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.18#fc3fd073d3a0acf9933c3994b660ebd7b5833f65"
+dependencies = [
+ "assert_matches",
+ "async-trait",
+ "futures 0.3.21",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "log",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-aura",
+ "sc-consensus-babe",
+ "sc-consensus-epochs",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-timestamp",
+ "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech//substrate?branch=polkadot-v0.9.18#fc3fd073d3a0acf9933c3994b660ebd7b5833f65"
@@ -12829,7 +12868,7 @@ checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
  "cfg-if 1.0.0",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.6.5",
  "static_assertions",
 ]
 

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4.8"
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.130", features = ["derive"] }
 hex-literal = "0.2.1"
+futures = "0.3.15"
 
 # Parachain dependencies
 interlay-runtime = { package = "interlay-runtime-parachain", path = "./runtime/interlay" }
@@ -42,6 +43,7 @@ module-refund-rpc-runtime-api = { path = "../crates/refund/rpc/runtime-api" }
 sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", features = ["wasmtime"] }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", features = ["wasmtime"] }
 sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }

--- a/parachain/src/cli.rs
+++ b/parachain/src/cli.rs
@@ -115,6 +115,12 @@ pub struct Cli {
     /// Relaychain arguments
     #[clap(raw = true)]
     pub relaychain_args: Vec<String>,
+
+    /// Instant block sealing
+    ///
+    /// Can only be used with `--dev`
+    #[clap(long = "instant-seal", requires = "dev")]
+    pub instant_seal: bool,
 }
 
 #[derive(Debug)]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -24,6 +24,7 @@ primitives = { package = "interbtc-primitives", path = "../primitives" }
 sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }

--- a/standalone/src/service.rs
+++ b/standalone/src/service.rs
@@ -206,6 +206,7 @@ pub fn new_full(mut config: Configuration) -> Result<(TaskManager, RpcHandlers),
                 client: client.clone(),
                 pool: pool.clone(),
                 deny_unsafe,
+                command_sink: None,
             };
 
             Ok(interbtc_rpc::create_full(deps))


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

This PR adds the `--instant-seal` option to the `interbtc-parachain` binary which automatically generates blocks when new transactions are added to the mempool or when calling the manual-seal RPC:

```
curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "engine_createBlock", "params": [true, true, null]}' http://localhost:9933/
```

Succeeds #363 