### PR TITLE
Add Copy trait to VaultCurrencyPair

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -48,7 +48,7 @@ impl TruncateFixedPointToInt for UnsignedFixedPoint {
     }
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, std::hash::Hash))]
 pub struct VaultCurrencyPair<CurrencyId: Copy> {
     pub collateral: CurrencyId,


### PR DESCRIPTION
I have been trying to extend interbtc-clients to have an rpc call to "liquidation_redeem" (the burn function). Compile fails on the below code because async move requires VaultCurrencyPair to have Clone/Copy.
I managed to make a workaround by locally redefining a VaultCurrencyPairCLI type in interbtc-clients and then having the async move act on that one (See code below) but it would be probably be cleaner to add Copy to the traits in the interbtc repo.


~~~~
async fn liquidation_redeem(&self, collateral: CurrencyId, wrapped: CurrencyId, amount: u128, ) -> Result<(), Error> {
 
    // Problem when defining directly VaultCurrencyPair (defined in interbtc module?)
    // because it does not implement Clone that is needed in the async move below.
    // Managed to compile by defining a VaultCurrencyPailCLI that implements Clone.
    // then passing to an (inner) VaultCurrencyPair
    let currencies = VaultCurrencyPairCLI {
        collateral,
        wrapped
    };
    
    let _burn_event = self
    .with_unique_signer(|signer| async move {
        let mut currencies_inner = VaultCurrencyPair {
            collateral: Token(DOT),
            wrapped: Token(DOT)
        };
        currencies_inner.collateral = currencies.collateral;    
        currencies_inner.wrapped = currencies.wrapped;    
    
        self.api
            .tx()
            .redeem()
            .liquidation_redeem(currencies_inner, amount)
            .sign_and_submit_then_watch_default(&signer)
            .await
    })
    .await?
    .find_first::<LiquidationRedeemEvent>()?
    .ok_or(Error::RequestRedeemIDNotFound)?;
 
    Ok(())
 }
}
~~~~

Excerpt of the error generated by the lack of Copy trait on VaultCurrencyPair

~~~~
error[E0507]: cannot move out of `currencies`, a captured variable in an `Fn` closure
    --> runtime/src/rpc.rs:1235:45
     |
1229 |        let currencies = VaultCurrencyPair {
     |            ---------- captured outer variable
...
1235 |        .with_unique_signer(|signer| async move {
     |  __________________________-___________________^
     | | _________________________|
     | ||
1236 | ||         let mut currencies_inner = VaultCurrencyPair {
1237 | ||             collateral: Token(DOT),
1238 | ||             wrapped: Token(DOT)
...    ||
1246 | ||             .liquidation_redeem(currencies, amount)
     | ||                                 ----------
     | ||                                 |
     | ||                                 move occurs because `currencies` has type `interbtc_primitives::VaultCurrencyPair<interbtc_primitives::CurrencyId>`, which does not implement the `Copy` trait
     | ||                                 move occurs due to use in generator
1247 | ||             .sign_and_submit_then_watch_default(&signer)
1248 | ||             .await
1249 | ||     })
     | ||     ^
     | ||_____|
     | |______captured by this `Fn` closure
     |        move out of `currencies` occurs here