### PR TITLE
fix: only award redeem premium upto the secure threshold

### DIFF
--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -79,6 +79,12 @@ pub(crate) mod vault_registry {
         <vault_registry::Pallet<T>>::get_vault_from_id(vault_id)
     }
 
+    pub fn vault_to_be_backed_tokens<T: crate::Config>(
+        vault_id: &DefaultVaultId<T>,
+    ) -> Result<Amount<T>, DispatchError> {
+        <vault_registry::Pallet<T>>::vault_to_be_backed_tokens(vault_id)
+    }
+
     pub fn try_increase_to_be_redeemed_tokens<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
         amount: &Amount<T>,
@@ -136,6 +142,12 @@ pub(crate) mod vault_registry {
         vault_id: &DefaultVaultId<T>,
     ) -> Result<bool, DispatchError> {
         <vault_registry::Pallet<T>>::is_vault_below_secure_threshold(vault_id)
+    }
+
+    pub fn vault_capacity_at_secure_threshold<T: crate::Config>(
+        vault_id: &DefaultVaultId<T>,
+    ) -> Result<Amount<T>, DispatchError> {
+        <vault_registry::Pallet<T>>::vault_capacity_at_secure_threshold(vault_id)
     }
 
     pub fn decrease_to_be_redeemed_tokens<T: crate::Config>(

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -378,22 +378,34 @@ impl<T: Config> Pallet<T> {
             Error::<T>::AmountBelowDustAmount
         );
 
+        let below_premium_redeem = ext::vault_registry::is_vault_below_premium_threshold::<T>(&vault_id)?;
+        let currency_id = vault_id.collateral_currency();
+
+        let premium_collateral = if below_premium_redeem {
+            // we only award a premium on the amount ok tokens required to bring
+            // `issued + to_be_issued - to_be_redeemed` back to the secure threshold
+
+            let capacity = ext::vault_registry::vault_capacity_at_secure_threshold(&vault_id)?;
+            let to_be_backed_tokens = ext::vault_registry::vault_to_be_backed_tokens(&vault_id)?;
+
+            // the amount of tokens that we can give a premium for
+            let max_premium_tokens = to_be_backed_tokens.saturating_sub(&capacity)?;
+            // the actual amount of tokens redeemed that we give a premium for
+            let actual_premium_tokens = max_premium_tokens.min(&user_to_be_received_btc)?;
+            // converted to collateral..
+            let premium_tokens_in_collateral = actual_premium_tokens.convert_to(currency_id)?;
+
+            ext::fee::get_premium_redeem_fee::<T>(&premium_tokens_in_collateral)?
+        } else {
+            Amount::zero(currency_id)
+        };
+
         // vault will get rid of the btc + btc_inclusion_fee
         ext::vault_registry::try_increase_to_be_redeemed_tokens::<T>(&vault_id, &vault_to_be_burned_tokens)?;
 
         // lock full amount (inc. fee)
         amount_wrapped.lock_on(&redeemer)?;
         let redeem_id = ext::security::get_secure_id::<T>(&redeemer);
-
-        let below_premium_redeem = ext::vault_registry::is_vault_below_premium_threshold::<T>(&vault_id)?;
-        let currency_id = vault_id.collateral_currency();
-
-        let premium_collateral = if below_premium_redeem {
-            let redeem_amount_wrapped_in_collateral = user_to_be_received_btc.convert_to(currency_id)?;
-            ext::fee::get_premium_redeem_fee::<T>(&redeem_amount_wrapped_in_collateral)?
-        } else {
-            Amount::zero(currency_id)
-        };
 
         // decrease to-be-replaced tokens - when the vault requests tokens to be replaced, it
         // want to get rid of tokens, and it does not matter whether this is through a redeem,

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -578,6 +578,18 @@ impl<T: Config> RichVault<T> {
         Ok(Amount::new(amount, self.wrapped_currency()))
     }
 
+    /// the number of issued tokens if all issues and redeems execute successfully
+    pub(crate) fn to_be_backed_tokens(&self) -> Result<Amount<T>, DispatchError> {
+        let amount = self
+            .data
+            .issued_tokens
+            .checked_add(&self.data.to_be_issued_tokens)
+            .ok_or(Error::<T>::ArithmeticOverflow)?
+            .checked_sub(&self.data.to_be_redeemed_tokens)
+            .ok_or(Error::<T>::ArithmeticUnderflow)?;
+        Ok(Amount::new(amount, self.wrapped_currency()))
+    }
+
     pub(crate) fn to_be_replaced_tokens(&self) -> Amount<T> {
         Amount::new(self.data.to_be_replaced_tokens, self.wrapped_currency())
     }

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -334,6 +334,16 @@ impl Wrapped for VaultId {
     }
 }
 
+pub trait Collateral {
+    fn collateral(&self, amount: Balance) -> Amount<Runtime>;
+}
+
+impl Collateral for VaultId {
+    fn collateral(&self, amount: Balance) -> Amount<Runtime> {
+        Amount::new(amount, self.collateral_currency())
+    }
+}
+
 pub fn iter_currency_pairs() -> impl Iterator<Item = DefaultVaultCurrencyPair<Runtime>> {
     iter_collateral_currencies().flat_map(|collateral_id| {
         iter_wrapped_currencies().map(move |wrapped_id| VaultCurrencyPair {


### PR DESCRIPTION
2 significant changes: 

- Only award a premium for the amount of tokens required to bring the vault back to the secure threshold. Otherwise the vault could end up paying the premium for _all_ of its tokens.
- Rather than only considering `issued_tokens` to determine whether or not a vault is below the premium redeem threshold, now use the "to_be_backed" tokens, i.e. the tokens if all open issues and redeems execute successfully (= issued + to_be_issued - to_be_redeemed). This is required because otherwise additional redeems would again be able to de a premium redeem. 

Since this significantly modifies audited code, I'd like to have 2 people approve this PR before we merge