### PR TITLE
fix: allow redeem execution after theft

### DIFF
--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -439,7 +439,7 @@ impl<AccountId: Ord, BlockNumber: Default, Balance: HasCompact + Default, Curren
     }
 
     pub fn is_liquidated(&self) -> bool {
-        matches!(self.status, VaultStatus::Liquidated)
+        matches!(self.status, VaultStatus::Liquidated | VaultStatus::CommittedTheft)
     }
 }
 

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -922,11 +922,17 @@ impl ParachainTwoVaultState {
 }
 
 pub fn liquidate_vault(vault_id: &VaultId) {
+    liquidate_vault_with_status(vault_id, VaultStatus::Liquidated);
+}
+
+pub fn liquidate_vault_with_status(vault_id: &VaultId, status: VaultStatus) {
     assert_ok!(OraclePallet::_set_exchange_rate(
         vault_id.currencies.collateral,
         FixedU128::checked_from_integer(10_000_000_000).unwrap()
     ));
-    assert_ok!(VaultRegistryPallet::liquidate_vault(&vault_id));
+    assert_ok!(VaultRegistryPallet::liquidate_vault_with_status(
+        &vault_id, status, None
+    ));
     assert_ok!(OraclePallet::_set_exchange_rate(
         vault_id.currencies.collateral,
         FixedU128::checked_from_integer(1).unwrap()


### PR DESCRIPTION
Not accounting for CommittedTheft caused `decrease_issued` to take the wrong code path, which led to the execute_redeem call failing on vaults that were liquidated due to theft.

We have tests for redeem execution after liquidation, but all of them were on vaults that were liquidated because of undercollateralization rather than theft..