### PR TITLE
feat: asset-registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,6 +3725,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
+ "xcm",
 ]
 
 [[package]]
@@ -3787,6 +3788,7 @@ dependencies = [
  "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
  "orml-vesting",
@@ -3920,6 +3922,7 @@ dependencies = [
  "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
  "orml-unknown-tokens",
@@ -4401,6 +4404,7 @@ dependencies = [
  "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
  "orml-unknown-tokens",
@@ -6158,6 +6162,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "orml-asset-registry"
+version = "0.4.1-dev"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=78f2d4521856e100d625336692befcc10819e856#78f2d4521856e100d625336692befcc10819e856"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "orml-traits",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
 ]
 
 [[package]]
@@ -12513,6 +12535,7 @@ dependencies = [
  "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
  "orml-unknown-tokens",
@@ -13017,9 +13040,9 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.6.5",
  "static_assertions",
 ]
 

--- a/crates/oracle/src/lib.rs
+++ b/crates/oracle/src/lib.rs
@@ -293,6 +293,7 @@ impl<T: Config> Pallet<T> {
 
     pub fn convert(amount: &Amount<T>, currency_id: T::CurrencyId) -> Result<Amount<T>, DispatchError> {
         let converted = match (amount.currency(), currency_id) {
+            (x, y) if x == y => amount.amount(),
             (x, _) if x == T::GetWrappedCurrencyId::get() => {
                 // convert interbtc to collateral
                 Self::wrapped_to_collateral(amount.amount(), currency_id)?

--- a/parachain/runtime/interlay/Cargo.toml
+++ b/parachain/runtime/interlay/Cargo.toml
@@ -114,6 +114,7 @@ orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-l
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'
@@ -226,6 +227,7 @@ std = [
   "orml-xtokens/std",
   "orml-xcm-support/std",
   "orml-unknown-tokens/std",
+  "orml-asset-registry/std",
 ]
 runtime-benchmarks = [
   "frame-benchmarking",

--- a/parachain/runtime/interlay/src/constants.rs
+++ b/parachain/runtime/interlay/src/constants.rs
@@ -2,14 +2,16 @@
 
 /// Money matters.
 pub mod currency {
+    use primitives::TokenSymbol;
     pub use primitives::{Balance, CurrencyId, CurrencyId::Token, DOT, IBTC, INTR};
 
-    pub const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
+    pub const NATIVE_TOKEN_ID: TokenSymbol = INTR;
+    pub const NATIVE_CURRENCY_ID: CurrencyId = Token(NATIVE_TOKEN_ID);
     pub const PARENT_CURRENCY_ID: CurrencyId = Token(DOT);
     pub const WRAPPED_CURRENCY_ID: CurrencyId = Token(IBTC);
 
     // https://github.com/paritytech/polkadot/blob/c4ee9d463adccfa3bf436433e3e26d0de5a4abbc/runtime/polkadot/src/constants.rs#L18
-    pub const UNITS: Balance = NATIVE_CURRENCY_ID.one();
+    pub const UNITS: Balance = NATIVE_TOKEN_ID.one();
     pub const DOLLARS: Balance = UNITS; // 10_000_000_000
     pub const CENTS: Balance = DOLLARS / 100; // 100_000_000
     pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -23,6 +23,7 @@ use frame_system::{
     limits::{BlockLength, BlockWeights},
     EnsureRoot, RawOrigin,
 };
+use orml_asset_registry::SequentialId;
 use orml_traits::parameter_type_with_key;
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
@@ -695,6 +696,16 @@ impl orml_tokens::Config for Runtime {
     type ReserveIdentifier = (); // we don't use named reserves
 }
 
+impl orml_asset_registry::Config for Runtime {
+    type Event = Event;
+    type Balance = Balance;
+    type CustomMetadata = primitives::CustomMetadata;
+    type AssetProcessor = SequentialId<Runtime>;
+    type AssetId = primitives::ForeignAssetId;
+    type AuthorityOrigin = EnsureRoot<AccountId>;
+    type WeightInfo = ();
+}
+
 parameter_types! {
     pub const InflationPeriod: BlockNumber = YEARS;
 }
@@ -1005,6 +1016,7 @@ construct_runtime! {
         Tokens: orml_tokens::{Pallet, Call, Storage, Config<T>, Event<T>} = 21,
         Supply: supply::{Pallet, Storage, Call, Event<T>, Config<T>} = 22,
         Vesting: orml_vesting::{Pallet, Storage, Call, Event<T>, Config<T>} = 23,
+        AssetRegistry: orml_asset_registry::{Pallet, Storage, Call, Event<T>, Config<T>} = 24,
 
         Escrow: escrow::{Pallet, Call, Storage, Event<T>} = 30,
         EscrowAnnuity: annuity::<Instance1>::{Pallet, Call, Storage, Event<T>} = 31,

--- a/parachain/runtime/kintsugi/Cargo.toml
+++ b/parachain/runtime/kintsugi/Cargo.toml
@@ -111,6 +111,7 @@ orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-l
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'
@@ -220,6 +221,7 @@ std = [
   "orml-tokens/std",
   "orml-traits/std",
   "orml-vesting/std",
+  "orml-asset-registry/std",
 
   "orml-xtokens/std",
   "orml-xcm-support/std",

--- a/parachain/runtime/kintsugi/src/constants.rs
+++ b/parachain/runtime/kintsugi/src/constants.rs
@@ -2,14 +2,16 @@
 
 /// Money matters.
 pub mod currency {
+    use primitives::TokenSymbol;
     pub use primitives::{Balance, CurrencyId, CurrencyId::Token, KBTC, KINT, KSM};
 
+    pub const NATIVE_TOKEN_ID: TokenSymbol = KINT;
     pub const NATIVE_CURRENCY_ID: CurrencyId = Token(KINT);
     pub const PARENT_CURRENCY_ID: CurrencyId = Token(KSM);
     pub const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
 
     // https://github.com/paritytech/polkadot/blob/c4ee9d463adccfa3bf436433e3e26d0de5a4abbc/runtime/kusama/src/constants.rs#L18
-    pub const UNITS: Balance = NATIVE_CURRENCY_ID.one();
+    pub const UNITS: Balance = NATIVE_TOKEN_ID.one();
     pub const CENTS: Balance = UNITS / 30_000;
     pub const GRAND: Balance = CENTS * 100_000;
     pub const MILLICENTS: Balance = CENTS / 1_000;

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -23,6 +23,7 @@ use frame_system::{
     limits::{BlockLength, BlockWeights},
     EnsureRoot, RawOrigin,
 };
+use orml_asset_registry::SequentialId;
 use orml_traits::parameter_type_with_key;
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
@@ -58,6 +59,7 @@ pub use sp_runtime::{Perbill, Permill};
 pub use btc_relay::{bitcoin, Call as RelayCall, TARGET_SPACING};
 pub use constants::{currency::*, time::*};
 pub use module_oracle_rpc_runtime_api::BalanceWrapper;
+pub use orml_asset_registry::AssetMetadata;
 pub use security::StatusCode;
 
 pub use primitives::{
@@ -658,6 +660,16 @@ impl orml_tokens::Config for Runtime {
     type ReserveIdentifier = (); // we don't use named reserves
 }
 
+impl orml_asset_registry::Config for Runtime {
+    type Event = Event;
+    type Balance = Balance;
+    type CustomMetadata = primitives::CustomMetadata;
+    type AssetProcessor = SequentialId<Runtime>;
+    type AssetId = primitives::ForeignAssetId;
+    type AuthorityOrigin = EnsureRoot<AccountId>;
+    type WeightInfo = ();
+}
+
 parameter_types! {
     pub const InflationPeriod: BlockNumber = YEARS;
 }
@@ -967,6 +979,7 @@ construct_runtime! {
         Tokens: orml_tokens::{Pallet, Call, Storage, Config<T>, Event<T>} = 8,
         Escrow: escrow::{Pallet, Call, Storage, Event<T>} = 9,
         Vesting: orml_vesting::{Pallet, Storage, Call, Event<T>, Config<T>} = 10,
+        AssetRegistry: orml_asset_registry::{Pallet, Storage, Call, Event<T>, Config<T>} = 44,
 
         EscrowAnnuity: annuity::<Instance1>::{Pallet, Call, Storage, Event<T>} = 11,
         EscrowRewards: reward::<Instance1>::{Pallet, Storage, Event<T>} = 12,

--- a/parachain/runtime/runtime-tests/src/setup.rs
+++ b/parachain/runtime/runtime-tests/src/setup.rs
@@ -15,7 +15,10 @@ pub use kintsugi_imports::*;
 mod kintsugi_imports {
     pub use frame_support::{parameter_types, weights::Weight};
     pub use kintsugi_runtime_parachain::{xcm_config::*, *};
-    pub use primitives::{CurrencyId::Token, KINT, KSM};
+    pub use primitives::{
+        CurrencyId::{ForeignAsset, Token},
+        CustomMetadata, KINT, KSM,
+    };
     pub use sp_runtime::{traits::AccountIdConversion, FixedPointNumber};
 }
 

--- a/parachain/runtime/testnet/Cargo.toml
+++ b/parachain/runtime/testnet/Cargo.toml
@@ -115,6 +115,7 @@ orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-l
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'
@@ -227,6 +228,7 @@ std = [
   "orml-tokens/std",
   "orml-traits/std",
   "orml-vesting/std",
+  "orml-asset-registry/std",
 
   "orml-xtokens/std",
   "orml-xcm-support/std",

--- a/parachain/runtime/testnet/src/constants.rs
+++ b/parachain/runtime/testnet/src/constants.rs
@@ -2,14 +2,16 @@
 
 /// Money matters.
 pub mod currency {
+    use primitives::TokenSymbol;
     pub use primitives::{Balance, CurrencyId, CurrencyId::Token, KBTC, KINT, KSM};
 
-    pub const NATIVE_CURRENCY_ID: CurrencyId = Token(KINT);
+    pub const NATIVE_TOKEN_ID: TokenSymbol = KINT;
+    pub const NATIVE_CURRENCY_ID: CurrencyId = Token(NATIVE_TOKEN_ID);
     pub const PARENT_CURRENCY_ID: CurrencyId = Token(KSM);
     pub const WRAPPED_CURRENCY_ID: CurrencyId = Token(KBTC);
 
     // https://github.com/paritytech/polkadot/blob/c4ee9d463adccfa3bf436433e3e26d0de5a4abbc/runtime/kusama/src/constants.rs#L18
-    pub const UNITS: Balance = NATIVE_CURRENCY_ID.one();
+    pub const UNITS: Balance = NATIVE_TOKEN_ID.one();
     pub const CENTS: Balance = UNITS / 30_000;
     pub const GRAND: Balance = CENTS * 100_000;
     pub const MILLICENTS: Balance = CENTS / 1_000;

--- a/parachain/runtime/testnet/src/lib.rs
+++ b/parachain/runtime/testnet/src/lib.rs
@@ -24,6 +24,7 @@ use frame_system::{
     limits::{BlockLength, BlockWeights},
     EnsureRoot, EnsureSigned,
 };
+use orml_asset_registry::SequentialId;
 use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key, MultiCurrency};
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
@@ -69,7 +70,7 @@ pub use primitives::{
 
 // XCM imports
 use pallet_xcm::{EnsureXcm, IsMajorityOfBody};
-use xcm::opaque::latest::BodyId;
+use xcm::{latest::MultiLocation, opaque::latest::BodyId};
 use xcm_config::ParentLocation;
 
 pub mod constants;
@@ -668,6 +669,16 @@ impl orml_tokens::Config for Runtime {
     type ReserveIdentifier = (); // we don't use named reserves
 }
 
+impl orml_asset_registry::Config for Runtime {
+    type Event = Event;
+    type Balance = Balance;
+    type CustomMetadata = primitives::CustomMetadata;
+    type AssetProcessor = SequentialId<Runtime>;
+    type AssetId = primitives::ForeignAssetId;
+    type AuthorityOrigin = EnsureRoot<AccountId>;
+    type WeightInfo = ();
+}
+
 parameter_types! {
     pub const InflationPeriod: BlockNumber = YEARS;
 }
@@ -979,6 +990,7 @@ construct_runtime! {
         Tokens: orml_tokens::{Pallet, Call, Storage, Config<T>, Event<T>} = 21,
         Supply: supply::{Pallet, Storage, Call, Event<T>, Config<T>} = 22,
         Vesting: orml_vesting::{Pallet, Storage, Call, Event<T>, Config<T>} = 23,
+        AssetRegistry: orml_asset_registry::{Pallet, Storage, Call, Event<T>, Config<T>} = 24,
 
         Escrow: escrow::{Pallet, Call, Storage, Event<T>} = 30,
         EscrowAnnuity: annuity::<Instance1>::{Pallet, Call, Storage, Event<T>} = 31,

--- a/parachain/runtime/testnet/src/xcm_config.rs
+++ b/parachain/runtime/testnet/src/xcm_config.rs
@@ -1,5 +1,7 @@
 use super::*;
 use cumulus_primitives_core::ParaId;
+use orml_asset_registry::{AssetRegistryTrader, FixedRateAssetRegistryTrader};
+use orml_traits::FixedConversionRateProvider;
 use orml_xcm_support::{DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
@@ -11,6 +13,7 @@ use xcm_builder::{
     SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue, TakeWeightCredit,
 };
 use xcm_executor::{Config, XcmExecutor};
+use CurrencyId::ForeignAsset;
 
 parameter_types! {
     pub const ParentLocation: MultiLocation = MultiLocation::parent();
@@ -137,8 +140,16 @@ pub type Trader = (
     FixedRateOfFungible<KbtcPerSecond, ToTreasury>,
     FixedRateOfFungible<CanonicalizedKintPerSecond, ToTreasury>,
     FixedRateOfFungible<CanonicalizedKbtcPerSecond, ToTreasury>,
-    FreeTestExection,
+    AssetRegistryTrader<FixedRateAssetRegistryTrader<MyFixedConversionRateProvider>, ToTreasury>,
 );
+
+pub struct MyFixedConversionRateProvider;
+impl FixedConversionRateProvider for MyFixedConversionRateProvider {
+    fn get_fee_per_second(location: &MultiLocation) -> Option<u128> {
+        let metadata = AssetRegistry::fetch_metadata_by_location(location)?;
+        Some(metadata.additional.fee_per_second)
+    }
+}
 
 // If all other trader items fail to apply, then execute for free. This is useful in in xcm
 // testing: it allows the sibling to place the assets in UnknownTokens so that it can send
@@ -258,6 +269,7 @@ mod currency_id_convert {
                 PARENT_CURRENCY_ID => Some(MultiLocation::parent()),
                 WRAPPED_CURRENCY_ID => Some(native_currency_location(id)),
                 NATIVE_CURRENCY_ID => Some(native_currency_location(id)),
+                ForeignAsset(id) => AssetRegistry::multilocation(&id).unwrap_or_default(),
                 _ => None,
             }
         }
@@ -279,7 +291,7 @@ mod currency_id_convert {
                 }
             }
 
-            match location {
+            match location.clone() {
                 x if x == MultiLocation::parent() => Some(PARENT_CURRENCY_ID),
                 MultiLocation {
                     parents: 1,
@@ -292,6 +304,7 @@ mod currency_id_convert {
                 } => decode_currency_id(key),
                 _ => None,
             }
+            .or_else(|| AssetRegistry::location_to_asset_id(&location).map(|id| CurrencyId::ForeignAsset(id)))
         }
     }
 
@@ -316,7 +329,7 @@ parameter_types! {
 
 parameter_type_with_key! {
     // Only used for transferring parachain tokens to other parachains using KSM as fee currency. Currently we do not support this, hence return MAX.
-    // See: https://github.com/open-web3-stack/open-runtime-module-library/blob/cadcc9fb10b8212f92668138fc8f83dc0c53acf5/xtokens/README.md#transfer-multiple-currencies
+    // See: https://github.com/interlay/open-runtime-module-library/blob/cadcc9fb10b8212f92668138fc8f83dc0c53acf5/xtokens/README.md#transfer-multiple-currencies
     pub ParachainMinFee: |location: MultiLocation| -> u128 {
         #[allow(clippy::match_ref_pats)] // false positive
         match (location.parents, location.first_interior()) {

--- a/parachain/src/chain_spec/interlay.rs
+++ b/parachain/src/chain_spec/interlay.rs
@@ -158,6 +158,7 @@ fn interlay_mainnet_genesis(
         security: interlay_runtime::SecurityConfig {
             initial_status: interlay_runtime::StatusCode::Shutdown,
         },
+        asset_registry: Default::default(),
         tokens: Default::default(),
         vesting: Default::default(),
         oracle: interlay_runtime::OracleConfig {

--- a/parachain/src/chain_spec/kintsugi.rs
+++ b/parachain/src/chain_spec/kintsugi.rs
@@ -124,6 +124,7 @@ fn kintsugi_mainnet_genesis(
         security: kintsugi_runtime::SecurityConfig {
             initial_status: kintsugi_runtime::StatusCode::Shutdown,
         },
+        asset_registry: Default::default(),
         tokens: Default::default(),
         vesting: Default::default(),
         oracle: kintsugi_runtime::OracleConfig {

--- a/parachain/src/chain_spec/testnet.rs
+++ b/parachain/src/chain_spec/testnet.rs
@@ -357,6 +357,7 @@ fn testnet_genesis(
             // Assign network admin rights.
             key: Some(root_key.clone()),
         },
+        asset_registry: Default::default(),
         tokens: testnet_runtime::TokensConfig {
             balances: endowed_accounts
                 .iter()

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -13,6 +13,7 @@ scale-info = { version = "2.0.0", default-features = false, features = ["derive"
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", default-features = false }
+xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.20", default-features = false }
 
 # Parachain dependencies
 bitcoin = { path = "../crates/bitcoin", default-features = false }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -491,12 +491,12 @@ create_currency_id! {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum CurrencyId {
     Token(TokenSymbol),
+    ForeignAsset(ForeignAssetId),
 }
 
-impl CurrencyId {
-    pub const fn one(&self) -> Balance {
-        match self {
-            CurrencyId::Token(token) => token.one(),
-        }
-    }
+pub type ForeignAssetId = u32;
+
+#[derive(scale_info::TypeInfo, Encode, Decode, Clone, Eq, PartialEq, Debug)]
+pub struct CustomMetadata {
+    pub fee_per_second: u128,
 }

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -91,6 +91,7 @@ module-refund-rpc-runtime-api = { path = "../../crates/refund/rpc/runtime-api", 
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "78f2d4521856e100d625336692befcc10819e856", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.2"
@@ -182,6 +183,7 @@ std = [
   "module-replace-rpc-runtime-api/std",
   "module-refund-rpc-runtime-api/std",
 
+  "orml-asset-registry/std",
   "orml-tokens/std",
   "orml-traits/std",
   "orml-vesting/std",

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -22,6 +22,7 @@ use frame_system::{
     limits::{BlockLength, BlockWeights},
     EnsureRoot, EnsureSigned,
 };
+use orml_asset_registry::SequentialId;
 use orml_traits::parameter_type_with_key;
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
@@ -33,6 +34,7 @@ use sp_runtime::{
     ApplyExtrinsicResult, FixedPointNumber, Perquintill,
 };
 use sp_std::{marker::PhantomData, prelude::*};
+
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
@@ -431,7 +433,7 @@ impl pallet_multisig::Config for Runtime {
 }
 
 // https://github.com/paritytech/polkadot/blob/ece7544b40d8b29897f5aa799f27840dcc32f24d/runtime/polkadot/src/constants.rs#L18
-pub const UNITS: Balance = NATIVE_CURRENCY_ID.one();
+pub const UNITS: Balance = NATIVE_TOKEN_ID.one();
 pub const DOLLARS: Balance = UNITS; // 10_000_000_000
 pub const CENTS: Balance = UNITS / 100; // 100_000_000
 pub const MILLICENTS: Balance = CENTS / 1_000; // 100_000
@@ -546,7 +548,8 @@ impl btc_relay::Config for Runtime {
     type ParachainBlocksPerBitcoinBlock = ParachainBlocksPerBitcoinBlock;
 }
 
-const NATIVE_CURRENCY_ID: CurrencyId = Token(INTR);
+const NATIVE_TOKEN_ID: TokenSymbol = INTR;
+const NATIVE_CURRENCY_ID: CurrencyId = Token(NATIVE_TOKEN_ID);
 const PARENT_CURRENCY_ID: CurrencyId = Token(DOT);
 const WRAPPED_CURRENCY_ID: CurrencyId = Token(IBTC);
 
@@ -928,6 +931,16 @@ impl nomination::Config for Runtime {
     type WeightInfo = ();
 }
 
+impl orml_asset_registry::Config for Runtime {
+    type Event = Event;
+    type Balance = Balance;
+    type CustomMetadata = primitives::CustomMetadata;
+    type AssetProcessor = SequentialId<Runtime>;
+    type AssetId = primitives::ForeignAssetId;
+    type AuthorityOrigin = EnsureRoot<AccountId>;
+    type WeightInfo = ();
+}
+
 construct_runtime! {
     pub enum Runtime where
         Block = Block,
@@ -948,6 +961,7 @@ construct_runtime! {
         Tokens: orml_tokens::{Pallet, Call, Storage, Config<T>, Event<T>} = 9,
         Escrow: escrow::{Pallet, Call, Storage, Event<T>} = 10,
         Vesting: orml_vesting::{Pallet, Storage, Call, Event<T>, Config<T>} = 11,
+        AssetRegistry: orml_asset_registry::{Pallet, Storage, Call, Event<T>, Config<T>} = 37,
 
         EscrowAnnuity: annuity::<Instance1>::{Pallet, Call, Storage, Event<T>} = 12,
         EscrowRewards: reward::<Instance1>::{Pallet, Storage, Event<T>} = 13,

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -22,7 +22,8 @@ pub use interbtc_runtime_standalone::{
 pub use mocktopus::mocking::*;
 pub use orml_tokens::CurrencyAdapter;
 pub use primitives::{
-    CurrencyId::Token, VaultCurrencyPair, VaultId as PrimitiveVaultId, DOT, IBTC, INTR, KBTC, KINT, KSM,
+    CurrencyId::{ForeignAsset, Token},
+    VaultCurrencyPair, VaultId as PrimitiveVaultId, DOT, IBTC, INTR, KBTC, KINT, KSM,
 };
 use redeem::RedeemRequestStatus;
 use staking::DefaultVaultCurrencyPair;
@@ -354,7 +355,7 @@ pub fn iter_currency_pairs() -> impl Iterator<Item = DefaultVaultCurrencyPair<Ru
 }
 
 pub fn iter_collateral_currencies() -> impl Iterator<Item = CurrencyId> {
-    vec![Token(DOT), Token(KSM)].into_iter()
+    vec![Token(DOT), Token(KSM), ForeignAsset(1)].into_iter()
 }
 
 pub fn iter_native_currencies() -> impl Iterator<Item = CurrencyId> {

--- a/standalone/runtime/tests/test_fee_pool.rs
+++ b/standalone/runtime/tests/test_fee_pool.rs
@@ -48,6 +48,7 @@ fn test_with<R>(execute: impl Fn(CurrencyId) -> R) {
     };
     test_with(Token(KSM));
     test_with(Token(DOT));
+    test_with(ForeignAsset(1));
 }
 
 fn withdraw_vault_global_pool_rewards(vault_id: &VaultId) -> i128 {

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -24,6 +24,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
     test_with(Token(DOT), Token(KBTC));
     test_with(Token(KSM), Token(IBTC));
     test_with(Token(DOT), Token(IBTC));
+    test_with(ForeignAsset(1), Token(IBTC));
 }
 
 fn test_with_initialized_vault<R>(execute: impl Fn(VaultId) -> R) {

--- a/standalone/runtime/tests/test_nomination.rs
+++ b/standalone/runtime/tests/test_nomination.rs
@@ -25,6 +25,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
     test_with(Token(DOT), Token(KBTC));
     test_with(Token(KSM), Token(IBTC));
     test_with(Token(DOT), Token(IBTC));
+    test_with(ForeignAsset(1), Token(IBTC));
 }
 
 fn test_with_nomination_enabled<R>(execute: impl Fn(VaultId) -> R) {

--- a/standalone/runtime/tests/test_redeem.rs
+++ b/standalone/runtime/tests/test_redeem.rs
@@ -37,6 +37,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
     test_with(Token(DOT), Token(IBTC), None);
     test_with(Token(DOT), Token(IBTC), Some(Token(KSM)));
     test_with(Token(KSM), Token(IBTC), None);
+    test_with(ForeignAsset(1), Token(IBTC), None);
 }
 
 /// to-be-replaced & replace_collateral are decreased in request_redeem

--- a/standalone/runtime/tests/test_refund.rs
+++ b/standalone/runtime/tests/test_refund.rs
@@ -22,6 +22,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
     test_with(Token(KSM), Token(IBTC));
     test_with(Token(DOT), Token(IBTC));
     test_with(Token(DOT), Token(KBTC));
+    test_with(ForeignAsset(1), Token(KBTC));
 }
 
 mod spec_based_tests {

--- a/standalone/runtime/tests/test_relayers.rs
+++ b/standalone/runtime/tests/test_relayers.rs
@@ -19,6 +19,7 @@ fn test_with<R>(execute: impl Fn(CurrencyId) -> R) {
     };
     test_with(Token(DOT));
     test_with(Token(KSM));
+    test_with(ForeignAsset(1));
 }
 
 fn setup_vault_for_potential_double_spend(

--- a/standalone/runtime/tests/test_replace.rs
+++ b/standalone/runtime/tests/test_replace.rs
@@ -56,6 +56,8 @@ fn test_with<R>(execute: impl Fn(VaultId, VaultId) -> R) {
     test_with(Token(DOT), Token(DOT), Token(IBTC), Some(Token(KSM)));
     test_with(Token(DOT), Token(KSM), Token(IBTC), None);
     test_with(Token(KSM), Token(DOT), Token(IBTC), None);
+    test_with(ForeignAsset(1), Token(DOT), Token(IBTC), None);
+    test_with(Token(KSM), ForeignAsset(1), Token(IBTC), None);
 }
 
 fn test_without_initialization<R>(execute: impl Fn(CurrencyId) -> R) {

--- a/standalone/runtime/tests/test_vault_registry.rs
+++ b/standalone/runtime/tests/test_vault_registry.rs
@@ -27,6 +27,7 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
     test_with(Token(DOT), Token(KBTC));
     test_with(Token(KSM), Token(IBTC));
     test_with(Token(DOT), Token(IBTC));
+    test_with(ForeignAsset(1), Token(IBTC));
 }
 
 mod deposit_collateral_test {

--- a/standalone/src/chain_spec.rs
+++ b/standalone/src/chain_spec.rs
@@ -371,5 +371,6 @@ fn testnet_genesis(
             start_height: YEARS * 4,
             inflation: FixedU128::checked_from_rational(2, 100).unwrap(), // 2%
         },
+        asset_registry: Default::default(),
     }
 }


### PR DESCRIPTION
Adds the new asset registry. Left for a future PR is to add benchmarks for asset registry functions (which are 0 by default).

The most significant change for downstream users is the change in the `CurrencyId`:

```rust
enum TokenSymbol { DOT, IBTC, INTR, KSM, KBTC, KINT }
enum CurrencyId {
    Token(TokenSymbol),
    ForeignAsset(u32), // <-- this is new
}
```

For example, USDC might be represented as `CurrencyId::ForeignAsset(1)`. 

I would recommend against hardcoding information about these currencies, because `CurrencyId::ForeignAsset(1)` might refer to a completely different currencies on the kintsugi and interlay networks. Instead, you can query the asset's metadata by readying `api.query.assetRegistry.metadata(1)`. This gives you the asset's name, symbol, and number of decimals. 
