### PR TITLE
fix: don't save collateral for to_be_redeemed tokens in liquidation vault

### DIFF
--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -1291,7 +1291,7 @@ impl<T: Config> Pallet<T> {
         let to_transfer = Self::calculate_collateral(
             &source_liquidation_vault.current_balance(currency_id)?,
             amount_wrapped,
-            &liquidation_vault.backed_tokens()?,
+            &liquidation_vault.to_be_backed_tokens()?,
         )?;
 
         Self::transfer_funds(

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -918,8 +918,10 @@ impl<T: Config> RichSystemVault<T> {
         self.issued_tokens().checked_sub(&self.to_be_redeemed_tokens())
     }
 
-    pub(crate) fn backed_tokens(&self) -> Result<Amount<T>, DispatchError> {
-        self.issued_tokens().checked_add(&self.to_be_issued_tokens())
+    pub(crate) fn to_be_backed_tokens(&self) -> Result<Amount<T>, DispatchError> {
+        self.issued_tokens()
+            .checked_add(&self.to_be_issued_tokens())?
+            .checked_sub(&self.to_be_redeemed_tokens())
     }
 
     pub(crate) fn to_be_redeemed_tokens(&self) -> Amount<T> {


### PR DESCRIPTION
When vault is liquidated.. let `X` be `toBeRedeemed / (issued + toBeIssued)`. Then..

- X * vault.collateral stays in vault
- (1-X) * vault.collateral is moved to liquidationVault

Then when users do a `liquidationRedeem`, to burn `Y` tokens, they got an amount of collateral equal to `Y / (issued + toBeIssued) * liquidationVault`.

However, since collateral corresponding to the toBeRedeemed tokens stayed behind in the original vault, we should instead give `Y / (issued + toBeIssued - toBeRedeemed) * liquidationVault`

I added a test that doing cancel_redeem after liquidation does not change the exchange rate used by the liquidation vault.