### PR TITLE
fix: correct rewards after slashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12088,6 +12088,8 @@ dependencies = [
  "frame-system",
  "interbtc-primitives",
  "mocktopus",
+ "orml-tokens",
+ "orml-traits",
  "pallet-timestamp",
  "parity-scale-codec",
  "rand 0.8.5",

--- a/crates/staking/Cargo.toml
+++ b/crates/staking/Cargo.toml
@@ -24,6 +24,10 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18", default-features = false, optional = true }
 
+# note: can be remove after removal of migration
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "2b5d4ce1d08fb54c0007c2055653892d2c93a92e", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "2b5d4ce1d08fb54c0007c2055653892d2c93a92e", default-features = false }
+
 [dev-dependencies]
 mocktopus = "0.7.0"
 rand = "0.8.3"

--- a/crates/staking/src/lib.rs
+++ b/crates/staking/src/lib.rs
@@ -606,6 +606,8 @@ impl<T: Config> Pallet<T> {
         vault_id: &DefaultVaultId<T>,
         nominator_id: &T::AccountId,
     ) -> Result<<SignedFixedPoint<T> as FixedPointNumber>::Inner, DispatchError> {
+        Self::apply_slash(vault_id, nominator_id)?;
+
         let reward = Self::compute_reward_at_index(nonce, currency_id, vault_id, nominator_id)?;
         let reward_as_fixed = SignedFixedPoint::<T>::checked_from_integer(reward).ok_or(Error::<T>::TryIntoIntError)?;
         checked_sub_mut!(TotalRewards<T>, currency_id, (nonce, vault_id), &reward_as_fixed);

--- a/crates/staking/src/mock.rs
+++ b/crates/staking/src/mock.rs
@@ -1,6 +1,7 @@
 use crate as staking;
 use crate::{Config, Error};
 use frame_support::{parameter_types, traits::Everything};
+use orml_traits::parameter_type_with_key;
 pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*};
 use primitives::{VaultCurrencyPair, VaultId};
 use sp_arithmetic::FixedI128;
@@ -22,6 +23,7 @@ frame_support::construct_runtime!(
     {
         System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
         Staking: staking::{Pallet, Call, Storage, Event<T>},
+        Tokens: orml_tokens::{Pallet, Call, Storage, Event<T>},
     }
 );
 
@@ -73,6 +75,28 @@ impl Config for Test {
     type SignedFixedPoint = SignedFixedPoint;
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
+}
+
+pub type Balance = u128;
+pub type RawAmount = i128;
+parameter_types! {
+    pub const MaxLocks: u32 = 50;
+}
+parameter_type_with_key! {
+    pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
+        0
+    };
+}
+impl orml_tokens::Config for Test {
+    type Event = TestEvent;
+    type Balance = Balance;
+    type Amount = RawAmount;
+    type CurrencyId = CurrencyId;
+    type WeightInfo = ();
+    type ExistentialDeposits = ExistentialDeposits;
+    type OnDust = ();
+    type MaxLocks = MaxLocks;
+    type DustRemovalWhitelist = Everything;
 }
 
 pub type TestEvent = Event;

--- a/crates/staking/src/tests.rs
+++ b/crates/staking/src/tests.rs
@@ -4,6 +4,7 @@ use frame_support::{assert_err, assert_ok};
 
 // type Event = crate::Event<Test>;
 
+#[macro_export]
 macro_rules! fixed {
     ($amount:expr) => {
         sp_arithmetic::FixedI128::from($amount)

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -414,6 +414,12 @@ impl frame_support::traits::OnRuntimeUpgrade for LiquidationVaultFixMigration {
         use orml_traits::MultiReservableCurrency;
         use sp_runtime::AccountId32;
         if let Ok(weight) = vault_registry::types::liquidation_vault_fix::fix_liquidation_vault::<Runtime>() {
+            // piggy back on vault migration do do some other migrations:
+
+            // try to do the staking migration. Technically we should add weight here
+            // but I think we'll be ok without
+            let _ = staking::migration::fix_broken_state::<Runtime, _>(Fee::fee_pool_account_id());
+
             // a3b3EwCtmURY7K3d6aoWzouHriGfTsvCP2axuMVGpRpkPoxg8
             let account_raw = hex_literal::hex!("24ac7fb5407f270d807425ecc6352305c0a21b9e7a1ba9812a1785a2af9b955a");
             let account_id = AccountId32::from(account_raw);


### PR DESCRIPTION
We had reports about people not receiving the rewards that they were expecting. The root cause for this was that vaults got slashed due to premium redeems, and there was a slashing-related bug in the staking code that caused vaults to receive too few rewards.