### PR TITLE
refactor: liquidate at most liquidation threshold on theft

### DIFF
--- a/crates/relay/src/benchmarking.rs
+++ b/crates/relay/src/benchmarking.rs
@@ -134,7 +134,7 @@ benchmarks! {
             vault
         );
 
-        VaultRegistry::<T>::_set_secure_collateral_threshold(vault_id.currencies.clone(), UnsignedFixedPoint::<T>::one());
+        VaultRegistry::<T>::_set_liquidation_collateral_threshold(vault_id.currencies.clone(), UnsignedFixedPoint::<T>::one());
         VaultRegistry::<T>::_set_system_collateral_ceiling(vault_id.currencies.clone(), 1_000_000_000u32.into());
 
         mint_collateral::<T>(&vault_id.account_id, 1000u32.into());

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -725,6 +725,16 @@ fn liquidate_at_most_liquidation_threshold() {
             FixedU128::checked_from_rational(150, 100).unwrap(), // 150%
         );
 
+        VaultRegistry::_set_premium_redeem_threshold(
+            DEFAULT_CURRENCY_PAIR,
+            FixedU128::checked_from_rational(175, 100).unwrap(), // 175%
+        );
+
+        VaultRegistry::_set_secure_collateral_threshold(
+            DEFAULT_CURRENCY_PAIR,
+            FixedU128::checked_from_rational(200, 100).unwrap(), // 200%
+        );
+
         let collateral_before = ext::currency::get_reserved_balance::<Test>(Token(DOT), &vault_id.account_id);
         assert_eq!(collateral_before, amount(backing_collateral)); // sanity check
 

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -705,7 +705,7 @@ fn cancel_replace_tokens_succeeds() {
 }
 
 #[test]
-fn liquidate_at_most_secure_threshold() {
+fn liquidate_at_most_liquidation_threshold() {
     run_test(|| {
         let vault_id = DEFAULT_ID;
 
@@ -720,7 +720,7 @@ fn liquidate_at_most_secure_threshold() {
         create_vault_with_collateral(&vault_id, backing_collateral);
         let liquidation_vault_before = VaultRegistry::get_rich_liquidation_vault(&DEFAULT_CURRENCY_PAIR);
 
-        VaultRegistry::_set_secure_collateral_threshold(
+        VaultRegistry::_set_liquidation_collateral_threshold(
             DEFAULT_CURRENCY_PAIR,
             FixedU128::checked_from_rational(150, 100).unwrap(), // 150%
         );

--- a/standalone/runtime/tests/test_relayers.rs
+++ b/standalone/runtime/tests/test_relayers.rs
@@ -108,7 +108,7 @@ fn integration_test_report_vault_theft() {
         })
         .dispatch(origin_of(account_of(user))));
 
-        let confiscated_collateral = Amount::new(150, currency_id);
+        let confiscated_collateral = Amount::new(110, currency_id);
         assert_eq!(
             ParachainState::get(&vault_id),
             pre_liquidation_state.with_changes(|user, vault, liquidation_vault, _fee_pool| {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Fairly trivial change to liquidate at most 110% (or whatever the liquidation threshold is) on theft.
Note that because all holdings are liquidated on undercollateralization most existing tests do not break.