### PR TITLE
refactor: only refund issue if input address is valid

### DIFF
--- a/crates/bitcoin/src/parser.rs
+++ b/crates/bitcoin/src/parser.rs
@@ -457,6 +457,7 @@ pub(crate) fn extract_address_hash_witness<B: AsRef<[u8]>>(witness_script: B) ->
     // https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wsh
     let mut hasher = Sha256::default();
     hasher.input(witness_script);
+    // WARNING: this will decode P2TR inputs incorrectly
     Ok(Address::P2WSHv0(H256::from_slice(&hasher.result()[..])))
 }
 

--- a/crates/btc-relay/src/lib.rs
+++ b/crates/btc-relay/src/lib.rs
@@ -592,7 +592,7 @@ impl<T: Config> Pallet<T> {
         merkle_proof: MerkleProof,
         transaction: Transaction,
         recipient_btc_address: BtcAddress,
-    ) -> Result<(BtcAddress, V), DispatchError> {
+    ) -> Result<(Option<BtcAddress>, V), DispatchError> {
         // Verify that the transaction is indeed included in the main chain
         Self::_verify_transaction_inclusion(transaction.tx_id(), merkle_proof, None)?;
 
@@ -602,13 +602,14 @@ impl<T: Config> Pallet<T> {
     fn get_issue_payment<V: TryFrom<i64>>(
         transaction: Transaction,
         recipient_btc_address: BtcAddress,
-    ) -> Result<(BtcAddress, V), DispatchError> {
+    ) -> Result<(Option<BtcAddress>, V), DispatchError> {
+        // only return BTC address if we can decode it
         let input_address = transaction
             .inputs
             .get(0)
             .ok_or(Error::<T>::MalformedTransaction)?
             .extract_address()
-            .map_err(|_| Error::<T>::MalformedTransaction)?;
+            .ok();
 
         // using the on-chain key derivation scheme we only expect a simple
         // payment to the vault's new deposit address

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -12,7 +12,7 @@ pub(crate) mod btc_relay {
         merkle_proof: MerkleProof,
         transaction: Transaction,
         recipient_btc_address: BtcAddress,
-    ) -> Result<(BtcAddress, V), DispatchError> {
+    ) -> Result<(Option<BtcAddress>, V), DispatchError> {
         <btc_relay::Pallet<T>>::get_and_verify_issue_payment(merkle_proof, transaction, recipient_btc_address)
     }
 

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -152,7 +152,7 @@ fn test_execute_issue_succeeds() {
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
         ext::btc_relay::parse_transaction::<Test>.mock_safe(|_| MockResult::Return(Ok(Transaction::default())));
         ext::btc_relay::get_and_verify_issue_payment::<Test, Balance>
-            .mock_safe(|_, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 3))));
+            .mock_safe(|_, _, _| MockResult::Return(Ok((Some(BtcAddress::P2SH(H160::zero())), 3))));
 
         assert_ok!(execute_issue(USER, &issue_id));
 
@@ -182,7 +182,7 @@ fn test_execute_issue_overpayment_succeeds() {
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
         ext::btc_relay::parse_transaction::<Test>.mock_safe(|_| MockResult::Return(Ok(Transaction::default())));
         ext::btc_relay::get_and_verify_issue_payment::<Test, Balance>
-            .mock_safe(|_, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 5))));
+            .mock_safe(|_, _, _| MockResult::Return(Ok((Some(BtcAddress::P2SH(H160::zero())), 5))));
 
         ext::vault_registry::is_vault_liquidated::<Test>.mock_safe(|_| MockResult::Return(Ok(false)));
 
@@ -223,7 +223,7 @@ fn test_execute_issue_refund_succeeds() {
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
         ext::btc_relay::parse_transaction::<Test>.mock_safe(|_| MockResult::Return(Ok(Transaction::default())));
         ext::btc_relay::get_and_verify_issue_payment::<Test, Balance>
-            .mock_safe(|_, _, _| MockResult::Return(Ok((BtcAddress::P2SH(H160::zero()), 103))));
+            .mock_safe(|_, _, _| MockResult::Return(Ok((Some(BtcAddress::P2SH(H160::zero())), 103))));
 
         // return some arbitrary error
         ext::vault_registry::try_increase_to_be_issued_tokens::<Test>.mock_safe(|_, amount| {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Note: I tried writing a test for this (specifically using a P2TR input) but it was decoded as P2WSH.