### PR TITLE
fix: disallow merge transactions

### DIFF
--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -351,20 +351,6 @@ impl<T: Config> Pallet<T> {
         })
     }
 
-    /// Checks if the vault is doing a valid merge transaction to move funds between
-    /// addresses.
-    ///
-    /// # Arguments
-    ///
-    /// * `transaction` - the tx
-    /// * `wallet` - vault btc addresses
-    pub(crate) fn is_valid_merge_transaction(transaction: &Transaction, wallet: &Wallet) -> bool {
-        return transaction
-            .outputs
-            .iter()
-            .all(|output| matches!(output.extract_address(), Ok(addr) if wallet.has_btc_address(&addr)));
-    }
-
     /// Checks if the vault is sending a valid request transaction.
     ///
     /// # Arguments
@@ -420,11 +406,6 @@ impl<T: Config> Pallet<T> {
         // * recipient: the recipient of the redeem / replace
         // * op_return: the associated ID encoded in the OP_RETURN
         // * vault: any "spare change" the vault is transferring
-
-        ensure!(
-            !Self::is_valid_merge_transaction(&tx, &vault.wallet),
-            Error::<T>::ValidMergeTransaction
-        );
 
         if let Ok(payment_data) = OpReturnPaymentData::<T>::try_from(tx) {
             // redeem requests

--- a/standalone/runtime/tests/test_relayers.rs
+++ b/standalone/runtime/tests/test_relayers.rs
@@ -260,7 +260,8 @@ fn integration_test_redeem_utxo_to_foreign_address() {
 }
 
 #[test]
-fn integration_test_merge_tx() {
+/// we used to allow merge transactions, but not anymore. Specifically test that we disallow it
+fn integration_test_merge_tx_is_disallowed() {
     test_with(|_currency_id| {
         let vault = BOB;
         let transfer_amount_raw = 100;
@@ -310,17 +311,14 @@ fn integration_test_merge_tx() {
 
         SecurityPallet::set_active_block_number(1 + CONFIRMATIONS);
 
-        // Reporting as theft should fail, because the transaction merged
-        // UTXOs sent to registered vault addresses
-        assert_err!(
-            Call::Relay(RelayCall::report_vault_theft {
-                vault_id: default_vault_id_of(vault),
-                raw_merkle_proof: merkle_proof,
-                raw_tx: raw_tx
-            })
-            .dispatch(origin_of(account_of(USER))),
-            RelayError::ValidMergeTransaction
-        );
+        // Reporting as theft should succeed, because we no longer
+        // allow merge transactions
+        assert_ok!(Call::Relay(RelayCall::report_vault_theft {
+            vault_id: default_vault_id_of(vault),
+            raw_merkle_proof: merkle_proof,
+            raw_tx: raw_tx
+        })
+        .dispatch(origin_of(account_of(USER))));
     });
 }
 


### PR DESCRIPTION
Prevents vaults from transferring between registered addresses.