### PR TITLE
test: check that liquidation_redeem with 0 collateral works

### DIFF
--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -783,6 +783,7 @@ impl<T: Config> RichSystemVault<T> {
         Amount::new(self.data.to_be_redeemed_tokens, self.wrapped_currency())
     }
 
+    #[cfg_attr(feature = "integration-tests", visibility::make(pub))]
     pub(crate) fn collateral(&self) -> Amount<T> {
         Amount::new(self.data.collateral, self.data.currency_pair.collateral)
     }

--- a/parachain/runtime/runtime-tests/src/relaychain/kusama_cross_chain_transfer.rs
+++ b/parachain/runtime/runtime-tests/src/relaychain/kusama_cross_chain_transfer.rs
@@ -124,11 +124,12 @@ mod hrmp {
         init_open_channel::<Sibling>(SIBLING_PARA_ID, KINTSUGI_PARA_ID);
         accept_open_channel::<Kintsugi>(SIBLING_PARA_ID, KINTSUGI_PARA_ID);
 
-        // check that Bob received left-over funds (from both Kintsugi and Sibling):
+        // check that Bob received left-over funds (from both Kintsugi and Sibling).
+        // We expect slightly less than 4 * 0.41 KSM
         KusamaNet::execute_with(|| {
             assert_eq!(
                 kusama_runtime::Balances::free_balance(&AccountId::from(BOB)),
-                1_638_400_000_100
+                1_637_510_889_920
             );
         });
     }

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -756,7 +756,7 @@ impl SingleLiquidationVault {
 #[derive(Debug, PartialEq, Clone)]
 pub struct LiquidationVaultData {
     // note: we use BTreeMap such that the debug print output is sorted, for easier diffing
-    liquidation_vaults: BTreeMap<DefaultVaultCurrencyPair<Runtime>, SingleLiquidationVault>,
+    pub liquidation_vaults: BTreeMap<DefaultVaultCurrencyPair<Runtime>, SingleLiquidationVault>,
 }
 
 impl LiquidationVaultData {
@@ -813,6 +813,16 @@ impl LiquidationVaultData {
             liquidation_vault
                 .increase_to_be_redeemed(&(target.to_be_redeemed - current.to_be_redeemed))
                 .unwrap();
+
+            // reset collateral to 0
+            VaultRegistryPallet::transfer_funds(
+                CurrencySource::LiquidationVault(currency_pair.clone()),
+                CurrencySource::FreeBalance(account_of(FAUCET)),
+                &liquidation_vault.collateral(),
+            )
+            .unwrap();
+
+            // set to desired amount
             VaultRegistryPallet::transfer_funds(
                 CurrencySource::FreeBalance(account_of(FAUCET)),
                 CurrencySource::LiquidationVault(currency_pair.clone()),


### PR DESCRIPTION
The liquidation vault currently has 0 collateral, and with the upcoming migration it will have non-zero issued tokens but 0 to-be-redeemed. This checks that we allow kbtc to be burned without any collateral reward (i.e. there is no division by zero anywhere)