### PR TITLE
fix: remove dev-kintsugi feature

### DIFF
--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -107,5 +107,4 @@ runtime-benchmarks = [
     "interlay-runtime/runtime-benchmarks",
     "polkadot-service/runtime-benchmarks",
 ]
-dev-kintsugi = ["testnet-runtime/dev-kintsugi"]
 dev-interlay = ["testnet-runtime/dev-interlay"]

--- a/parachain/runtime/testnet/Cargo.toml
+++ b/parachain/runtime/testnet/Cargo.toml
@@ -132,7 +132,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 # https://github.com/paritytech/substrate/issues/8161
 
 [features]
-default = ["std", "dev-kintsugi"]
+default = ["std"]
 std = [
   "serde",
   "codec/std",
@@ -251,5 +251,4 @@ runtime-benchmarks = [
   "fee/runtime-benchmarks",
 ]
 disable-runtime-api = []
-dev-kintsugi = []
 dev-interlay = []

--- a/parachain/runtime/testnet/src/constants.rs
+++ b/parachain/runtime/testnet/src/constants.rs
@@ -2,14 +2,13 @@
 
 /// Money matters.
 pub mod currency {
-    #[cfg(feature = "dev-kintsugi")]
+    #[cfg(not(feature = "dev-interlay"))]
     pub use dev_kintsugi::*;
 
-    #[cfg(feature = "dev-kintsugi")]
+    #[cfg(not(feature = "dev-interlay"))]
     pub mod dev_kintsugi {
         use primitives::TokenSymbol;
         pub use primitives::{Balance, CurrencyId, CurrencyId::Token, KBTC, KINT, KSM};
-
         pub const NATIVE_TOKEN_ID: TokenSymbol = KINT;
         pub const NATIVE_CURRENCY_ID: CurrencyId = Token(NATIVE_TOKEN_ID);
         pub const PARENT_TOKEN_ID: TokenSymbol = KSM;

--- a/parachain/runtime/testnet/src/xcm_config.rs
+++ b/parachain/runtime/testnet/src/xcm_config.rs
@@ -84,31 +84,31 @@ pub fn xcm_per_second() -> u128 {
 
 parameter_types! {
     pub KsmPerSecond: (AssetId, u128) = (MultiLocation::parent().into(), xcm_per_second());
-    pub KintPerSecond: (AssetId, u128) = ( // can be removed once we no longer need to support polkadot < 0.9.16
+    pub NativePerSecond: (AssetId, u128) = ( // can be removed once we no longer need to support polkadot < 0.9.16
         MultiLocation::new(
             1,
-            X2(Parachain(ParachainInfo::get().into()), GeneralKey(Token(KINT).encode())),
+            X2(Parachain(ParachainInfo::get().into()), GeneralKey(NATIVE_CURRENCY_ID.encode())),
         ).into(),
         (xcm_per_second() * 4) / 3
     );
-    pub KbtcPerSecond: (AssetId, u128) = ( // can be removed once we no longer need to support polkadot < 0.9.16
+    pub WrappedPerSecond: (AssetId, u128) = ( // can be removed once we no longer need to support polkadot < 0.9.16
         MultiLocation::new(
             1,
-            X2(Parachain(ParachainInfo::get().into()), GeneralKey(Token(KBTC).encode())),
+            X2(Parachain(ParachainInfo::get().into()), GeneralKey(WRAPPED_CURRENCY_ID.encode())),
         ).into(),
         xcm_per_second() / 1_500_000
     );
-    pub CanonicalizedKintPerSecond: (AssetId, u128) = (
+    pub CanonicalizedNativePerSecond: (AssetId, u128) = (
         MultiLocation::new(
             0,
-            X1(GeneralKey(Token(KINT).encode())),
+            X1(GeneralKey(NATIVE_CURRENCY_ID.encode())),
         ).into(),
         (xcm_per_second() * 4) / 3
     );
-    pub CanonicalizedKbtcPerSecond: (AssetId, u128) = (
+    pub CanonicalizedWrappedPerSecond: (AssetId, u128) = (
         MultiLocation::new(
             0,
-            X1(GeneralKey(Token(KBTC).encode())),
+            X1(GeneralKey(WRAPPED_CURRENCY_ID.encode())),
         ).into(),
         xcm_per_second() / 1_500_000
     );
@@ -133,10 +133,10 @@ impl TakeRevenue for ToTreasury {
 
 pub type Trader = (
     FixedRateOfFungible<KsmPerSecond, ToTreasury>,
-    FixedRateOfFungible<KintPerSecond, ToTreasury>,
-    FixedRateOfFungible<KbtcPerSecond, ToTreasury>,
-    FixedRateOfFungible<CanonicalizedKintPerSecond, ToTreasury>,
-    FixedRateOfFungible<CanonicalizedKbtcPerSecond, ToTreasury>,
+    FixedRateOfFungible<NativePerSecond, ToTreasury>,
+    FixedRateOfFungible<WrappedPerSecond, ToTreasury>,
+    FixedRateOfFungible<CanonicalizedNativePerSecond, ToTreasury>,
+    FixedRateOfFungible<CanonicalizedWrappedPerSecond, ToTreasury>,
     AssetRegistryTrader<FixedRateAssetRegistryTrader<MyFixedConversionRateProvider>, ToTreasury>,
 );
 


### PR DESCRIPTION
The `dev-kintsugi` feature was enabled by default, and there was no easy way to disable it. Enabling `dev-interlay` would compile, but only due to [a compiler bug](https://github.com/rust-lang/rust/issues/97584). I also changed the tokens used in the xcm config