### PR TITLE
fix: disallow bitcoin hash of zero

### DIFF
--- a/crates/bitcoin/src/address.rs
+++ b/crates/bitcoin/src/address.rs
@@ -101,6 +101,13 @@ impl Address {
     pub fn random() -> Self {
         Address::P2PKH(H160::random())
     }
+
+    pub fn is_zero(&self) -> bool {
+        match self {
+            Self::P2PKH(hash) | Self::P2SH(hash) | Self::P2WPKHv0(hash) => hash.is_zero(),
+            Self::P2WSHv0(hash) => hash.is_zero(),
+        }
+    }
 }
 
 impl Default for Address {

--- a/crates/issue/src/benchmarking.rs
+++ b/crates/issue/src/benchmarking.rs
@@ -13,7 +13,7 @@ use frame_support::assert_ok;
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
 use primitives::{CurrencyId, VaultId};
-use sp_core::{H160, H256, U256};
+use sp_core::{H256, U256};
 use sp_runtime::{
     traits::{One, Zero},
     FixedPointNumber,
@@ -84,7 +84,7 @@ fn mine_blocks<T: crate::Config>(end_height: u32) {
     let height = 0;
     let block = BlockBuilder::new()
         .with_version(4)
-        .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
+        .with_coinbase(&BtcAddress::random(), 50, 3)
         .with_timestamp(1588813835)
         .mine(U256::from(2).pow(254.into()))
         .unwrap();
@@ -118,7 +118,7 @@ fn mine_blocks<T: crate::Config>(end_height: u32) {
         let block = BlockBuilder::new()
             .with_previous_hash(prev_hash)
             .with_version(4)
-            .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
+            .with_coinbase(&BtcAddress::random(), 50, 3)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())
             .mine(U256::from(2).pow(254.into()))
@@ -153,7 +153,7 @@ benchmarks! {
         let height = 0;
         let block = BlockBuilder::new()
             .with_version(4)
-            .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
+            .with_coinbase(&BtcAddress::random(), 50, 3)
             .with_timestamp(1588813835)
             .mine(U256::from(2).pow(254.into())).unwrap();
         let block_hash = block.header.hash;
@@ -163,7 +163,7 @@ benchmarks! {
         Security::<T>::set_active_block_number(1u32.into());
         BtcRelay::<T>::initialize(relayer_id.clone(), block_header, height).unwrap();
 
-        let vault_btc_address = BtcAddress::P2SH(H160::zero());
+        let vault_btc_address = BtcAddress::random();
 
         let transaction = TransactionBuilder::new()
         .with_version(2)
@@ -210,7 +210,7 @@ benchmarks! {
         mint_collateral::<T>(&vault_id.account_id.clone(), (1u32 << 31).into());
         mint_collateral::<T>(&relayer_id, (1u32 << 31).into());
 
-        let vault_btc_address = BtcAddress::P2SH(H160::zero());
+        let vault_btc_address = BtcAddress::random();
         let value: Amount<T> = Amount::new(2u32.into(), get_wrapped_currency_id::<T>());
 
         let issue_id = H256::zero();
@@ -300,7 +300,7 @@ benchmarks! {
         mint_collateral::<T>(&origin, (1u32 << 31).into());
         mint_collateral::<T>(&vault_id.account_id.clone(), (1u32 << 31).into());
 
-        let vault_btc_address = BtcAddress::P2SH(H160::zero());
+        let vault_btc_address = BtcAddress::random();
         let value = Amount::new(2u32.into(), get_wrapped_currency_id::<T>());
 
         let issue_id = H256::zero();

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -13,7 +13,7 @@ use frame_support::assert_ok;
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
 use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultCurrencyPair, VaultId};
-use sp_core::{H160, H256, U256};
+use sp_core::{H256, U256};
 use sp_runtime::traits::One;
 use sp_std::prelude::*;
 use vault_registry::types::{Vault, Wallet};
@@ -96,7 +96,7 @@ fn mine_blocks<T: crate::Config>(end_height: u32) {
     let height = 0;
     let block = BlockBuilder::new()
         .with_version(4)
-        .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
+        .with_coinbase(&BtcAddress::random(), 50, 3)
         .with_timestamp(1588813835)
         .mine(U256::from(2).pow(254.into()))
         .unwrap();
@@ -130,7 +130,7 @@ fn mine_blocks<T: crate::Config>(end_height: u32) {
         let block = BlockBuilder::new()
             .with_previous_hash(prev_hash)
             .with_version(4)
-            .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
+            .with_coinbase(&BtcAddress::random(), 50, 3)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())
             .mine(U256::from(2).pow(254.into()))
@@ -173,7 +173,7 @@ benchmarks! {
         let origin: T::AccountId = account("Origin", 0, 0);
         let vault_id = get_vault_id::<T>();
         let amount = Redeem::<T>::redeem_btc_dust_value() + 1000u32.into();
-        let btc_address = BtcAddress::P2SH(H160::from([0; 20]));
+        let btc_address = BtcAddress::random();
 
         initialize_oracle::<T>();
 
@@ -236,7 +236,7 @@ benchmarks! {
 
         initialize_oracle::<T>();
 
-        let origin_btc_address = BtcAddress::P2PKH(H160::zero());
+        let origin_btc_address = BtcAddress::random();
 
         let redeem_id = H256::zero();
         let mut redeem_request = test_request::<T>(&vault_id);

--- a/crates/redeem/src/lib.rs
+++ b/crates/redeem/src/lib.rs
@@ -358,6 +358,10 @@ impl<T: Config> Pallet<T> {
             Error::<T>::AmountExceedsUserBalance
         );
 
+        // We saw a user lose bitcoin when he forgot to enter the address in the polkadotjs ui.
+        // Make sure this can't happen again.
+        ensure!(!btc_address.is_zero(), btc_relay::Error::<T>::InvalidBtcHash);
+
         // todo: currently allowed to redeem from one currency to the other for free - decide if this is desirable
         let fee_wrapped = if redeemer == vault_id.account_id {
             Amount::zero(vault_id.wrapped_currency())

--- a/crates/refund/src/benchmarking.rs
+++ b/crates/refund/src/benchmarking.rs
@@ -12,7 +12,7 @@ use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::assert_ok;
 use frame_system::RawOrigin;
 use primitives::VaultId;
-use sp_core::{H160, H256, U256};
+use sp_core::{H256, U256};
 use sp_runtime::traits::One;
 use sp_std::prelude::*;
 use vault_registry::types::Vault;
@@ -43,7 +43,7 @@ benchmarks! {
         );
         let relayer_id: T::AccountId = account("Relayer", 0, 0);
 
-        let origin_btc_address = BtcAddress::P2PKH(H160::zero());
+        let origin_btc_address = BtcAddress::random();
 
         let refund_id = H256::zero();
         let refund_request = RefundRequest {

--- a/crates/refund/src/tests.rs
+++ b/crates/refund/src/tests.rs
@@ -5,7 +5,7 @@ use currency::Amount;
 use frame_support::{assert_err, assert_ok};
 use mocktopus::mocking::*;
 use primitives::refund::RefundRequest;
-use sp_core::{H160, H256};
+use sp_core::H256;
 
 fn dummy_merkle_proof() -> MerkleProof {
     MerkleProof {
@@ -36,7 +36,7 @@ fn test_refund_succeeds() {
             &wrapped(1000),
             VAULT,
             USER,
-            BtcAddress::P2SH(H160::zero()),
+            BtcAddress::random(),
             issue_id
         ));
 

--- a/crates/relay/src/tests.rs
+++ b/crates/relay/src/tests.rs
@@ -478,7 +478,7 @@ fn should_report_double_payment() {
     run_test(|| {
         let public_key = dummy_public_key();
         let input_address = BtcAddress::P2PKH(public_key.to_hash());
-        let output_address = BtcAddress::P2PKH(H160::random());
+        let output_address = BtcAddress::random();
         let left_tx = build_dummy_transaction_from_input_with_output_and_op_return(
             H256Le::from_bytes_le(&vec![1u8; 32]),
             &public_key,
@@ -511,8 +511,8 @@ fn should_report_double_payment() {
 fn should_not_report_double_payment_with_vault_no_input() {
     run_test(|| {
         let public_key = dummy_public_key();
-        let input_address = BtcAddress::P2PKH(H160::random());
-        let output_address = BtcAddress::P2PKH(H160::random());
+        let input_address = BtcAddress::random();
+        let output_address = BtcAddress::random();
         let left_tx = build_dummy_transaction_from_input_with_output_and_op_return(
             H256Le::from_bytes_le(&vec![1u8; 32]),
             &public_key,

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -67,7 +67,7 @@ fn mine_blocks<T: crate::Config>(end_height: u32) {
     let height = 0;
     let block = BlockBuilder::new()
         .with_version(4)
-        .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
+        .with_coinbase(&BtcAddress::random(), 50, 3)
         .with_timestamp(1588813835)
         .mine(U256::from(2).pow(254.into()))
         .unwrap();
@@ -101,7 +101,7 @@ fn mine_blocks<T: crate::Config>(end_height: u32) {
         let block = BlockBuilder::new()
             .with_previous_hash(prev_hash)
             .with_version(4)
-            .with_coinbase(&BtcAddress::P2SH(H160::zero()), 50, 3)
+            .with_coinbase(&BtcAddress::random(), 50, 3)
             .with_timestamp(1588813835)
             .add_transaction(transaction.clone())
             .mine(U256::from(2).pow(254.into()))

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -40,7 +40,7 @@ fn test_request() -> ReplaceRequest<AccountId, BlockNumber, Balance, CurrencyId>
         accept_time: 1,
         amount: 10,
         griefing_collateral: 0,
-        btc_address: BtcAddress::default(),
+        btc_address: BtcAddress::random(),
         collateral: 20,
         btc_height: 0,
         status: ReplaceRequestStatus::Pending,
@@ -137,20 +137,15 @@ mod accept_replace_tests {
     fn test_accept_replace_succeeds() {
         run_test(|| {
             setup_mocks();
-            assert_ok!(Replace::_accept_replace(
-                OLD_VAULT,
-                NEW_VAULT,
-                5,
-                10,
-                BtcAddress::default()
-            ));
+            let btc_address = BtcAddress::random();
+            assert_ok!(Replace::_accept_replace(OLD_VAULT, NEW_VAULT, 5, 10, btc_address));
             assert_event_matches!(Event::AcceptReplace{
                 replace_id: _,
                 old_vault_id: OLD_VAULT,
                 new_vault_id: NEW_VAULT,
                 amount: 5,
                 collateral: 10,
-                btc_address: addr} if addr == BtcAddress::default());
+                btc_address: addr} if addr == btc_address);
         })
     }
 
@@ -162,20 +157,16 @@ mod accept_replace_tests {
             ext::vault_registry::decrease_to_be_replaced_tokens::<Test>
                 .mock_safe(|_, _| MockResult::Return(Ok((wrapped(4), griefing(8)))));
 
-            assert_ok!(Replace::_accept_replace(
-                OLD_VAULT,
-                NEW_VAULT,
-                5,
-                10,
-                BtcAddress::default()
-            ));
+            let btc_address = BtcAddress::random();
+
+            assert_ok!(Replace::_accept_replace(OLD_VAULT, NEW_VAULT, 5, 10, btc_address));
             assert_event_matches!(Event::AcceptReplace{
                 replace_id: _, 
                 old_vault_id: OLD_VAULT, 
                 new_vault_id: NEW_VAULT, 
                 amount: 4, 
                 collateral: 8,
-                btc_address: addr} if addr == BtcAddress::default());
+                btc_address: addr} if addr == btc_address);
         })
     }
 
@@ -186,7 +177,7 @@ mod accept_replace_tests {
             ext::vault_registry::decrease_to_be_replaced_tokens::<Test>
                 .mock_safe(|_, _| MockResult::Return(Ok((wrapped(1), griefing(10)))));
             assert_err!(
-                Replace::_accept_replace(OLD_VAULT, NEW_VAULT, 5, 10, BtcAddress::default()),
+                Replace::_accept_replace(OLD_VAULT, NEW_VAULT, 5, 10, BtcAddress::random()),
                 TestError::AmountBelowDustAmount
             );
         })

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -94,7 +94,7 @@ benchmarks! {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
         register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
-    }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone(), BtcAddress::default())
+    }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone(), BtcAddress::random())
 
     accept_new_issues {
         let vault_id = get_vault_id::<T>();

--- a/parachain/runtime/testnet/src/xcm_config.rs
+++ b/parachain/runtime/testnet/src/xcm_config.rs
@@ -5,6 +5,7 @@ use orml_traits::FixedConversionRateProvider;
 use orml_xcm_support::{DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset};
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
+use primitives::{Balance, CurrencyId, CurrencyId::ForeignAsset};
 use xcm::latest::prelude::*;
 use xcm_builder::{
     AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom,
@@ -13,7 +14,6 @@ use xcm_builder::{
     SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue, TakeWeightCredit,
 };
 use xcm_executor::{Config, XcmExecutor};
-use CurrencyId::ForeignAsset;
 
 parameter_types! {
     pub const ParentLocation: MultiLocation = MultiLocation::parent();

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -687,7 +687,7 @@ mod execute_issue_tests {
             SecurityPallet::set_active_block_number(SecurityPallet::active_block_number() + CONFIRMATIONS);
 
             // send to wrong address
-            let bogus_address = BtcAddress::P2WPKHv0(H160::zero());
+            let bogus_address = BtcAddress::P2WPKHv0(H160::random());
             transaction.outputs[0] = TransactionOutput::payment(1000, &bogus_address);
             assert_noop!(
                 Call::Issue(IssueCall::execute_issue {

--- a/standalone/runtime/tests/test_redeem.rs
+++ b/standalone/runtime/tests/test_redeem.rs
@@ -76,7 +76,7 @@ mod spec_based_tests {
             assert_noop!(
                 Call::Redeem(RedeemCall::request_redeem {
                     amount_wrapped: 1500,
-                    btc_address: BtcAddress::P2PKH(H160([0u8; 20])),
+                    btc_address: BtcAddress::random(),
                     vault_id: vault_id.clone(),
                 })
                 .dispatch(origin_of(account_of(ALICE))),
@@ -141,7 +141,7 @@ mod spec_based_tests {
             assert_noop!(
                 Call::Redeem(RedeemCall::request_redeem {
                     amount_wrapped: 1500,
-                    btc_address: BtcAddress::P2PKH(H160([0u8; 20])),
+                    btc_address: BtcAddress::random(),
                     vault_id: vault_id.clone(),
                 })
                 .dispatch(origin_of(account_of(ALICE))),
@@ -213,7 +213,7 @@ mod spec_based_tests {
                 let amount = calculate_vault_capacity(&vault_id);
                 assert_ok!(Call::Redeem(RedeemCall::request_redeem {
                     amount_wrapped: amount.amount(),
-                    btc_address: BtcAddress::default(),
+                    btc_address: BtcAddress::random(),
                     vault_id: vault_id.clone()
                 })
                 .dispatch(origin_of(account_of(USER))));
@@ -247,7 +247,7 @@ mod spec_based_tests {
                 assert_noop!(
                     Call::Redeem(RedeemCall::request_redeem {
                         amount_wrapped: amount,
-                        btc_address: BtcAddress::default(),
+                        btc_address: BtcAddress::random(),
                         vault_id: vault_id.clone()
                     })
                     .dispatch(origin_of(account_of(USER))),
@@ -264,7 +264,7 @@ mod spec_based_tests {
                 assert_noop!(
                     Call::Redeem(RedeemCall::request_redeem {
                         amount_wrapped: 1500,
-                        btc_address: BtcAddress::P2PKH(H160([0u8; 20])),
+                        btc_address: BtcAddress::random(),
                         vault_id: vault_id.clone(),
                     })
                     .dispatch(origin_of(account_of(ALICE))),
@@ -283,7 +283,7 @@ mod spec_based_tests {
                 UserData::force_to(ALICE, good_state);
                 assert_ok!(Call::Redeem(RedeemCall::request_redeem {
                     amount_wrapped: free_tokens_to_redeem.amount(),
-                    btc_address: BtcAddress::P2PKH(H160([0u8; 20])),
+                    btc_address: BtcAddress::random(),
                     vault_id: vault_id.clone(),
                 })
                 .dispatch(origin_of(account_of(ALICE))));
@@ -296,7 +296,7 @@ mod spec_based_tests {
                 assert_noop!(
                     Call::Redeem(RedeemCall::request_redeem {
                         amount_wrapped: free_tokens_to_redeem.amount(),
-                        btc_address: BtcAddress::P2PKH(H160([0u8; 20])),
+                        btc_address: BtcAddress::random(),
                         vault_id: vault_id.clone(),
                     })
                     .dispatch(origin_of(account_of(ALICE))),
@@ -384,7 +384,7 @@ mod spec_based_tests {
                 assert_noop!(
                     Call::Redeem(RedeemCall::request_redeem {
                         amount_wrapped: user_to_redeem.amount(),
-                        btc_address: BtcAddress::P2PKH(H160([0u8; 20])),
+                        btc_address: BtcAddress::random(),
                         vault_id: vault_id.clone(),
                     })
                     .dispatch(origin_of(account_of(ALICE))),
@@ -411,7 +411,7 @@ mod spec_based_tests {
                 assert_noop!(
                     Call::Redeem(RedeemCall::request_redeem {
                         amount_wrapped: to_redeem.amount() - 1,
-                        btc_address: BtcAddress::P2PKH(H160([0u8; 20])),
+                        btc_address: BtcAddress::random(),
                         vault_id: vault_id.clone(),
                     })
                     .dispatch(origin_of(account_of(ALICE))),
@@ -419,7 +419,7 @@ mod spec_based_tests {
                 );
                 assert_ok!(Call::Redeem(RedeemCall::request_redeem {
                     amount_wrapped: to_redeem.amount(),
-                    btc_address: BtcAddress::P2PKH(H160([0u8; 20])),
+                    btc_address: BtcAddress::random(),
                     vault_id: vault_id.clone(),
                 })
                 .dispatch(origin_of(account_of(ALICE))));
@@ -450,7 +450,7 @@ mod spec_based_tests {
                 liquidate_vault(&vault_id);
                 assert_ok!(Call::Redeem(RedeemCall::request_redeem {
                     amount_wrapped: amount_btc.amount(),
-                    btc_address: BtcAddress::P2PKH(H160([0u8; 20])),
+                    btc_address: BtcAddress::random(),
                     vault_id: different_collateral_vault_id.clone(),
                 })
                 .dispatch(origin_of(account_of(ALICE))));
@@ -636,7 +636,7 @@ mod spec_based_tests {
         fn request_redeem(vault_id: &VaultId) -> H256 {
             assert_ok!(Call::Redeem(RedeemCall::request_redeem {
                 amount_wrapped: 4_000,
-                btc_address: BtcAddress::default(),
+                btc_address: BtcAddress::random(),
                 vault_id: vault_id.clone()
             })
             .dispatch(origin_of(account_of(USER))));


### PR DESCRIPTION
We saw a user lose bitcoin when he forgot to enter the address in the polkadotjs ui. This PR makes sure this can't happen again.