### PR TITLE
feat!: Added oracle register/remove events to facilitate tracking through event indexers

### DIFF
--- a/crates/oracle/src/lib.rs
+++ b/crates/oracle/src/lib.rs
@@ -82,6 +82,13 @@ pub mod pallet {
             oracle_id: T::AccountId,
             values: Vec<(OracleKey, T::UnsignedFixedPoint)>,
         },
+        OracleAdded {
+            oracle_id: T::AccountId,
+            name: Vec<u8>,
+        },
+        OracleRemoved {
+            oracle_id: T::AccountId,
+        },
     }
 
     #[pallet::error]
@@ -217,7 +224,11 @@ pub mod pallet {
             name: Vec<u8>,
         ) -> DispatchResult {
             ensure_root(origin)?;
-            Self::insert_oracle(account_id, name);
+            Self::insert_oracle(account_id.clone(), name.clone());
+            Self::deposit_event(Event::OracleAdded {
+                oracle_id: account_id,
+                name,
+            });
             Ok(())
         }
 
@@ -229,7 +240,8 @@ pub mod pallet {
         #[transactional]
         pub fn remove_authorized_oracle(origin: OriginFor<T>, account_id: T::AccountId) -> DispatchResult {
             ensure_root(origin)?;
-            <AuthorizedOracles<T>>::remove(account_id);
+            <AuthorizedOracles<T>>::remove(account_id.clone());
+            Self::deposit_event(Event::OracleRemoved { oracle_id: account_id });
             Ok(())
         }
     }

--- a/crates/oracle/src/tests.rs
+++ b/crates/oracle/src/tests.rs
@@ -273,19 +273,20 @@ fn insert_authorized_oracle_succeeds() {
         let oracle = 1;
         let key = OracleKey::ExchangeRate(Token(DOT));
         let rate = FixedU128::checked_from_rational(1, 1).unwrap();
+        let name = Vec::<u8>::new();
         assert_err!(
             Oracle::feed_values(Origin::signed(oracle), vec![]),
             TestError::InvalidOracleSource
         );
         assert_err!(
-            Oracle::insert_authorized_oracle(Origin::signed(oracle), oracle, Vec::<u8>::new()),
+            Oracle::insert_authorized_oracle(Origin::signed(oracle), oracle, name.clone()),
             DispatchError::BadOrigin
         );
-        assert_ok!(Oracle::insert_authorized_oracle(
-            Origin::root(),
-            oracle,
-            Vec::<u8>::new()
-        ));
+        assert_ok!(Oracle::insert_authorized_oracle(Origin::root(), oracle, name.clone()));
+        assert_emitted!(Event::OracleAdded {
+            oracle_id: 1,
+            name: name
+        });
         assert_ok!(Oracle::feed_values(Origin::signed(oracle), vec![(key, rate)]));
     });
 }
@@ -300,6 +301,7 @@ fn remove_authorized_oracle_succeeds() {
             DispatchError::BadOrigin
         );
         assert_ok!(Oracle::remove_authorized_oracle(Origin::root(), oracle,));
+        assert_emitted!(Event::OracleRemoved { oracle_id: 1 });
     });
 }
 


### PR DESCRIPTION
This will help with getting the oracle list through Squid, removing the need for one more RPC call