### PR TITLE
Chore: use tini for pid 1 in docker

### DIFF
--- a/Dockerfile_release
+++ b/Dockerfile_release
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # install tools and dependencies
 RUN apt-get update && apt-get upgrade -y && \
-      apt-get install -y libssl1.1 ca-certificates curl && \
+      apt-get install -y libssl1.1 ca-certificates curl tini && \
       apt-get autoremove -y &&  apt-get clean && \
       find /var/lib/apt/lists/ -type f -not -name lock -delete
 
@@ -21,4 +21,4 @@ RUN chmod +x /usr/local/bin/interbtc-parachain && \
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]
 
-ENTRYPOINT ["/usr/local/bin/interbtc-parachain"]
+ENTRYPOINT ["tini", "--", "/usr/local/bin/interbtc-parachain"]


### PR DESCRIPTION
Tini allows us to avoid several Docker edge cases, see https://github.com/krallin/tini.