### PR TITLE
feat(vault): liquidation recovery

### DIFF
--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -128,6 +128,13 @@ pub(crate) mod vault_registry {
         <vault_registry::Pallet<T>>::decrease_to_be_replaced_tokens(vault_id, tokens)
     }
 
+    pub fn withdraw_replace_request<T: crate::Config>(
+        vault_id: &DefaultVaultId<T>,
+        amount: &Amount<T>,
+    ) -> Result<(Amount<T>, Amount<T>), DispatchError> {
+        <vault_registry::Pallet<T>>::withdraw_replace_request(vault_id, amount)
+    }
+
     pub fn try_deposit_collateral<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
         amount: &Amount<T>,

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -362,14 +362,7 @@ impl<T: Config> Pallet<T> {
         let amount = Amount::new(amount, vault_id.wrapped_currency());
         // decrease to-be-replaced tokens, so that the vault is free to use its issued tokens again.
         let (withdrawn_tokens, to_withdraw_collateral) =
-            ext::vault_registry::decrease_to_be_replaced_tokens::<T>(&vault_id, &amount)?;
-
-        // release the used collateral
-        ext::vault_registry::transfer_funds(
-            CurrencySource::AvailableReplaceCollateral(vault_id.clone()),
-            CurrencySource::FreeBalance(vault_id.account_id.clone()),
-            &to_withdraw_collateral,
-        )?;
+            ext::vault_registry::withdraw_replace_request::<T>(&vault_id, &amount)?;
 
         if withdrawn_tokens.is_zero() {
             return Err(Error::<T>::NoPendingRequest.into());

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -123,6 +123,14 @@ benchmarks! {
 
         Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::checked_from_rational(10, 1).unwrap()).unwrap();
     }: _(RawOrigin::Signed(origin), vault_id.clone())
+
+    recover_vault_id {
+        let vault_id = get_vault_id::<T>();
+        mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
+        register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
+        Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::checked_from_rational(10, 1).unwrap()).unwrap();
+        VaultRegistry::<T>::liquidate_vault_with_status(&vault_id, VaultStatus::CommittedTheft, None).unwrap();
+    }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone())
 }
 
 impl_benchmark_test_suite!(

--- a/crates/vault-registry/src/default_weights.rs
+++ b/crates/vault-registry/src/default_weights.rs
@@ -46,6 +46,7 @@ pub trait WeightInfo {
 	fn set_premium_redeem_threshold() -> Weight;
 	fn set_liquidation_collateral_threshold() -> Weight;
 	fn report_undercollateralized_vault() -> Weight;
+	fn recover_vault_id() -> Weight;
 }
 
 /// Weights for vault_registry using the Substrate node and recommended hardware.
@@ -180,6 +181,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(28 as Weight))
 			.saturating_add(T::DbWeight::get().writes(16 as Weight))
 	}
+
+	// Storage: VaultRegistry Vaults (r:2 w:1)
+	fn recover_vault_id() -> Weight {
+		(14_679_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
@@ -312,6 +320,13 @@ impl WeightInfo for () {
 		(363_346_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(28 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(16 as Weight))
+	}
+
+	// Storage: VaultRegistry Vaults (r:2 w:1)
+	fn recover_vault_id() -> Weight {
+		(14_679_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }
 

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -417,6 +417,26 @@ pub mod pallet {
             Self::_set_liquidation_collateral_threshold(currency_pair, threshold);
             Ok(())
         }
+
+        /// Recover vault ID from a liquidated status.
+        ///
+        /// # Arguments
+        /// * `currency_pair` - the currency pair to change
+        #[pallet::weight(<T as Config>::WeightInfo::recover_vault_id())]
+        #[transactional]
+        pub fn recover_vault_id(origin: OriginFor<T>, currency_pair: DefaultVaultCurrencyPair<T>) -> DispatchResult {
+            let account_id = ensure_signed(origin)?;
+            let vault_id = VaultId::new(account_id, currency_pair.collateral, currency_pair.wrapped);
+            ensure!(Self::is_vault_liquidated(&vault_id)?, Error::<T>::VaultNotRecoverable);
+
+            let mut vault = Self::get_rich_vault_from_id(&vault_id.clone())?;
+            ensure!(vault.to_be_redeemed_tokens().is_zero(), Error::<T>::VaultNotRecoverable);
+
+            // Vault accepts new issues by default
+            vault.set_accept_new_issues(true)?;
+
+            Ok(())
+        }
     }
 
     #[pallet::event]
@@ -560,6 +580,8 @@ pub mod pallet {
         VaultCommittedTheft,
         /// Vault is no longer usable as it was liquidated due to undercollateralization.
         VaultLiquidated,
+        /// Vault must be either liquidated or flagged for theft.
+        VaultNotRecoverable,
         /// No bitcoin public key is registered for the vault.
         NoBitcoinPublicKey,
         /// A bitcoin public key was already registered for this account.
@@ -1392,6 +1414,27 @@ impl<T: Config> Pallet<T> {
         new_vault.decrease_to_be_issued(tokens)?;
 
         Ok(())
+    }
+
+    /// Withdraws an `amount` of tokens that were requested for replacement by `vault_id`
+    ///
+    /// # Arguments
+    /// * `vault_id` - the id of the vault
+    /// * `amount` - the amount of tokens to be withdrawn from replace requests
+    pub fn withdraw_replace_request(
+        vault_id: &DefaultVaultId<T>,
+        amount: &Amount<T>,
+    ) -> Result<(Amount<T>, Amount<T>), DispatchError> {
+        let (withdrawn_tokens, to_withdraw_collateral) = Self::decrease_to_be_replaced_tokens(&vault_id, &amount)?;
+
+        // release the used collateral
+        Self::transfer_funds(
+            CurrencySource::AvailableReplaceCollateral(vault_id.clone()),
+            CurrencySource::FreeBalance(vault_id.account_id.clone()),
+            &to_withdraw_collateral,
+        )?;
+
+        Ok((withdrawn_tokens, to_withdraw_collateral))
     }
 
     fn undercollateralized_vaults() -> impl Iterator<Item = DefaultVaultId<T>> {

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -651,6 +651,9 @@ impl<T: Config> RichVault<T> {
                 .ok_or(Error::<T>::ThresholdNotSet)?,
         )?;
 
+        // Clear `to_be_replaced` tokens, since the vault will have no more `issued` or `to_be_issued` tokens.
+        let _ = Pallet::<T>::withdraw_replace_request(&self.data.id, &self.to_be_replaced_tokens())?;
+
         // amount of tokens being backed
         let collateral_tokens = self.backed_tokens()?;
 

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -252,6 +252,7 @@ pub fn default_vault_state(vault_id: &VaultId) -> CoreVaultData {
             .map(|x| (x, default_vault_free_balance(x)))
             .collect(),
         liquidated_collateral: Amount::new(0, vault_id.collateral_currency()),
+        status: VaultStatus::Active(true),
     }
 }
 
@@ -508,6 +509,7 @@ pub struct CoreVaultData {
     pub free_balance: BTreeMap<CurrencyId, Amount<Runtime>>,
     pub to_be_replaced: Amount<Runtime>,
     pub replace_collateral: Amount<Runtime>,
+    pub status: VaultStatus,
 }
 
 impl CoreVaultData {
@@ -522,6 +524,7 @@ impl CoreVaultData {
             backing_collateral: Amount::new(0, vault_id.collateral_currency()),
             free_balance: iter_all_currencies().map(|x| (x, Amount::new(0, x))).collect(),
             liquidated_collateral: Amount::new(0, vault_id.collateral_currency()),
+            status: VaultStatus::Active(true),
         }
     }
 }
@@ -558,6 +561,7 @@ impl CoreVaultData {
                 vault.replace_collateral,
                 <Runtime as vault_registry::Config>::GetGriefingCollateralCurrencyId::get(),
             ),
+            status: vault.status,
         }
     }
 

--- a/standalone/runtime/tests/test_relayers.rs
+++ b/standalone/runtime/tests/test_relayers.rs
@@ -120,6 +120,7 @@ fn integration_test_report_vault_theft() {
                 vault.issued -= issued_tokens;
                 vault.backing_collateral -= confiscated_collateral;
                 vault.backing_collateral -= theft_fee;
+                vault.status = VaultStatus::CommittedTheft;
 
                 liquidation_vault.issued += issued_tokens;
                 liquidation_vault.collateral += confiscated_collateral;

--- a/standalone/runtime/tests/test_replace.rs
+++ b/standalone/runtime/tests/test_replace.rs
@@ -206,6 +206,13 @@ mod accept_replace_tests {
             )
             .unwrap();
 
+            // Set `accept_new_issues` back to the default value so the parachain state check succeeds.
+            assert_ok!(Call::VaultRegistry(VaultRegistryCall::accept_new_issues {
+                currency_pair: new_vault_id.currencies.clone(),
+                accept_new_issues: true
+            })
+            .dispatch(origin_of(new_vault_id.account_id.clone())));
+
             assert_state_after_accept_replace_correct(&old_vault_id, &new_vault_id, &replace);
         });
     }

--- a/standalone/runtime/tests/test_vault_registry.rs
+++ b/standalone/runtime/tests/test_vault_registry.rs
@@ -3,6 +3,11 @@ mod mock;
 use currency::Amount;
 use mock::{assert_eq, *};
 
+use crate::mock::{
+    issue_testing_utils::{execute_issue, request_issue},
+    redeem_testing_utils::{cancel_redeem, setup_redeem, ExecuteRedeemBuilder},
+};
+
 pub const USER: [u8; 32] = ALICE;
 pub const VAULT: [u8; 32] = BOB;
 
@@ -28,6 +33,18 @@ fn test_with<R>(execute: impl Fn(VaultId) -> R) {
     test_with(Token(KSM), Token(IBTC));
     test_with(Token(DOT), Token(IBTC));
     test_with(ForeignAsset(1), Token(IBTC));
+}
+
+fn deposit_collateral_and_issue(vault_id: VaultId) {
+    let new_collateral = 10_000;
+    assert_ok!(Call::VaultRegistry(VaultRegistryCall::deposit_collateral {
+        currency_pair: vault_id.currencies.clone(),
+        amount: new_collateral,
+    })
+    .dispatch(origin_of(account_of(VAULT))));
+
+    let (issue_id, _) = request_issue(&vault_id, vault_id.wrapped(4_000));
+    execute_issue(issue_id);
 }
 
 mod deposit_collateral_test {
@@ -288,6 +305,7 @@ fn integration_test_vault_registry_with_parachain_shutdown_fails() {
 fn integration_test_vault_registry_undercollateralization_liquidation() {
     test_with(|vault_id| {
         let currency_id = vault_id.collateral_currency();
+        let vault_data = default_vault_state(&vault_id);
         liquidate_vault(&vault_id);
 
         assert_eq!(
@@ -310,6 +328,11 @@ fn integration_test_vault_registry_undercollateralization_liquidation() {
                 vault.backing_collateral = Amount::new(0, currency_id);
                 vault.liquidated_collateral =
                     default_vault_backing_collateral(currency_id) - liquidation_vault.collateral;
+                vault.status = VaultStatus::Liquidated;
+                *vault
+                    .free_balance
+                    .get_mut(&vault_data.replace_collateral.currency())
+                    .unwrap() += vault_data.replace_collateral;
             })
         );
     });
@@ -341,5 +364,188 @@ fn integration_test_vault_registry_register_respects_fund_limit() {
         );
 
         assert_ok!(get_register_vault_result(&user_vault_id, remaining));
+    });
+}
+
+#[test]
+fn integration_test_vault_registry_cannot_recover_active_vault() {
+    test_with(|vault_id| {
+        assert_noop!(
+            Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+                currency_pair: vault_id.currencies.clone(),
+            })
+            .dispatch(origin_of(account_of(VAULT))),
+            VaultRegistryError::VaultNotRecoverable
+        );
+    });
+}
+
+#[test]
+fn integration_test_vault_registry_nonexistent_vault_cannot_be_recovered() {
+    test_with(|vault_id| {
+        assert_noop!(
+            Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+                currency_pair: vault_id.currencies.clone(),
+            })
+            .dispatch(origin_of(account_of(USER))),
+            VaultRegistryError::VaultNotFound
+        );
+    });
+}
+
+#[test]
+fn integration_test_vault_registry_undercollateralization_recovery_fails() {
+    test_with(|vault_id| {
+        liquidate_vault_with_status(&vault_id, VaultStatus::Liquidated);
+        // `to_be_redeemeded` tokens are non-zero
+        assert_err!(
+            Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+                currency_pair: vault_id.currencies.clone(),
+            })
+            .dispatch(origin_of(account_of(VAULT))),
+            VaultRegistryError::VaultNotRecoverable
+        );
+    });
+}
+
+fn default_liquidation_recovery_vault(vault_id: &VaultId) -> CoreVaultData {
+    let mut vault_data = default_vault_state(&vault_id);
+    vault_data.to_be_redeemed = vault_id.wrapped(0);
+    vault_data.to_be_replaced = vault_id.wrapped(0);
+    vault_data
+}
+
+#[test]
+fn integration_test_vault_registry_undercollateralization_recovery_works() {
+    test_with(|vault_id| {
+        let vault_data = default_liquidation_recovery_vault(&vault_id);
+        CoreVaultData::force_to(&vault_id, vault_data.clone());
+        liquidate_vault_with_status(&vault_id, VaultStatus::Liquidated);
+
+        let pre_recovery_state = ParachainState::get(&vault_id);
+        assert_ok!(Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+            currency_pair: vault_id.currencies.clone(),
+        })
+        .dispatch(origin_of(account_of(VAULT))));
+
+        assert_eq!(
+            ParachainState::get(&vault_id),
+            pre_recovery_state.with_changes(|_, vault, _, _| {
+                vault.status = VaultStatus::Active(true);
+            })
+        );
+        deposit_collateral_and_issue(vault_id);
+    });
+}
+
+#[test]
+fn integration_test_vault_registry_theft_recovery_fails() {
+    test_with(|vault_id| {
+        liquidate_vault_with_status(&vault_id, VaultStatus::CommittedTheft);
+        // `to_be_redeemeded` tokens are non-zero
+        assert_err!(
+            Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+                currency_pair: vault_id.currencies.clone(),
+            })
+            .dispatch(origin_of(account_of(VAULT))),
+            VaultRegistryError::VaultNotRecoverable
+        );
+    });
+}
+
+#[test]
+fn integration_test_vault_registry_theft_recovery_works() {
+    test_with(|vault_id| {
+        let vault_data = default_liquidation_recovery_vault(&vault_id);
+        CoreVaultData::force_to(
+            &vault_id,
+            CoreVaultData {
+                backing_collateral: vault_data.backing_collateral * 2,
+                ..vault_data.clone()
+            },
+        );
+
+        assert_ok!(VaultRegistryPallet::liquidate_vault_with_status(
+            &vault_id,
+            VaultStatus::CommittedTheft,
+            None
+        ));
+
+        let pre_recovery_state = ParachainState::get(&vault_id);
+        assert_ok!(Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+            currency_pair: vault_id.currencies.clone(),
+        })
+        .dispatch(origin_of(account_of(VAULT))));
+
+        assert_eq!(
+            ParachainState::get(&vault_id),
+            pre_recovery_state.with_changes(|_, vault, _, _| {
+                vault.status = VaultStatus::Active(true);
+            })
+        );
+        deposit_collateral_and_issue(vault_id);
+    });
+}
+
+#[test]
+fn integration_test_vault_registry_theft_recovery_with_executed_redeem_works() {
+    test_with(|vault_id| {
+        let vault_data = default_liquidation_recovery_vault(&vault_id);
+        CoreVaultData::force_to(&vault_id, vault_data.clone());
+        // create an open redeem
+        let redeem_id = setup_redeem(vault_id.wrapped(10_000), USER, &vault_id);
+
+        assert_ok!(VaultRegistryPallet::liquidate_vault_with_status(
+            &vault_id,
+            VaultStatus::CommittedTheft,
+            None
+        ));
+        assert_err!(
+            Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+                currency_pair: vault_id.currencies.clone(),
+            })
+            .dispatch(origin_of(account_of(VAULT))),
+            VaultRegistryError::VaultNotRecoverable
+        );
+        let redeem = RedeemPallet::get_open_redeem_request_from_id(&redeem_id).unwrap();
+        ExecuteRedeemBuilder::new(redeem_id)
+            .with_amount(redeem.amount_btc())
+            .assert_execute();
+
+        assert_ok!(Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+            currency_pair: vault_id.currencies.clone(),
+        })
+        .dispatch(origin_of(account_of(VAULT))));
+    });
+}
+
+#[test]
+fn integration_test_vault_registry_theft_recovery_with_cancelled_redeem_works() {
+    test_with(|vault_id| {
+        let vault_data = default_liquidation_recovery_vault(&vault_id);
+        CoreVaultData::force_to(&vault_id, vault_data.clone());
+        // create an open redeem
+        let redeem_id = setup_redeem(vault_id.wrapped(10_000), USER, &vault_id);
+
+        assert_ok!(VaultRegistryPallet::liquidate_vault_with_status(
+            &vault_id,
+            VaultStatus::CommittedTheft,
+            None
+        ));
+        assert_err!(
+            Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+                currency_pair: vault_id.currencies.clone(),
+            })
+            .dispatch(origin_of(account_of(VAULT))),
+            VaultRegistryError::VaultNotRecoverable
+        );
+        mine_blocks(12);
+        SecurityPallet::set_active_block_number(1100);
+        cancel_redeem(redeem_id, USER, true);
+
+        assert_ok!(Call::VaultRegistry(VaultRegistryCall::recover_vault_id {
+            currency_pair: vault_id.currencies.clone(),
+        })
+        .dispatch(origin_of(account_of(VAULT))));
     });
 }


### PR DESCRIPTION
Implements https://github.com/interlay/interbtc/issues/637 without allowing recovery with outstanding wrapped tokens, to avoid [this](https://github.com/interlay/interbtc/issues/637#issuecomment-1155453172) edge case.