### PR TITLE
fix: iterate over all reward currencies in slash_stake

### DIFF
--- a/crates/staking/src/tests.rs
+++ b/crates/staking/src/tests.rs
@@ -12,6 +12,94 @@ macro_rules! fixed {
 }
 
 #[test]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn reproduce_broken_state() {
+    run_test(|| {
+        use crate::pallet::*;
+        let account = VAULT.account_id;
+        let currency = Token(INTR);
+        let wrong_currency = Token(KBTC);
+        
+        let f = |x: i128| {
+            SignedFixedPoint::from_inner(x)
+        };
+
+        // state at block 0x5aaf4dc2ca1a1043e2c37ba85a1d1487a0e4cc79d3beb30e6e646d2190223851
+        RewardPerToken::<Test>::insert(currency, (0, VAULT), f(8328262397106661114));
+        RewardTally::<Test>::insert(currency, (0, VAULT, account), f(594980318984627591665452302579139));
+        SlashPerToken::<Test>::insert(0, VAULT,  f(10288025703175927));
+        SlashTally::<Test>::insert(0, (VAULT, account), f(734987987016863199590580128394));
+        Stake::<Test>::insert(0, (VAULT, account), f(71441111076342999999817587297983));
+        TotalCurrentStake::<Test>::insert(0, VAULT, f(71441111076343000000000000000000));
+        TotalRewards::<Test>::insert(currency, (0, VAULT), f(1135651379916000000000000000000));
+        TotalStake::<Test>::insert(0, VAULT, f(71441111076342999999817587297983));
+
+        assert_ok!(Staking::broken_slash_stake_do_not_use(wrong_currency, &VAULT, fixed!(109_808_965_219)));
+        assert_ok!(Staking::broken_slash_stake_do_not_use(wrong_currency, &VAULT, fixed!(109_808_965_219)));
+        assert_ok!(Staking::broken_slash_stake_do_not_use(wrong_currency, &VAULT, fixed!(1_479_196_975_788)));
+
+        // state at block 0xe56fd1e1c66ca658284cda6334865cb3ac413fdb6a9272f00f350b6f29787ba5
+        // Note: RewardPerToken is unchanged, incorrect!  
+        assert_eq!(RewardPerToken::<Test>::get(currency, (0, VAULT)), f(8328262397106661114));
+        assert_eq!(RewardTally::<Test>::get(currency, (0, VAULT, account)), f(594980318984627591665452302579139));
+        assert_eq!(SlashPerToken::<Test>::get(0, VAULT,), f(34067259825257565));
+        assert_eq!(SlashTally::<Test>::get(0, (VAULT, account)), f(734987987016863199590580128394));
+        assert_eq!(Stake::<Test>::get(0, (VAULT, account)), f(71441111076342999999817587297983));
+        assert_eq!(TotalCurrentStake::<Test>::get(0, VAULT), f(69742296170117000000000000000000));
+        assert_eq!(TotalRewards::<Test>::get(currency, (0, VAULT)), f(1135651379916000000000000000000));
+        assert_eq!(TotalStake::<Test>::get(0, VAULT), f(71441111076342999999817587297983));
+
+        // The bug that we observed
+        Staking::distribute_reward(currency, &VAULT, f(14234191584160000000000000000000)).unwrap();
+        assert_eq!(Staking::withdraw_reward(currency, &VAULT, &account).unwrap(), 86015280993);
+    })
+}
+
+#[test]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn slash_stake_does_not_break_state() {
+    run_test(|| {
+        use crate::pallet::*;
+        let account = VAULT.account_id;
+        let currency = Token(INTR);
+        
+        let f = |x: i128| {
+            SignedFixedPoint::from_inner(x)
+        };
+
+        // state at block 0x5aaf4dc2ca1a1043e2c37ba85a1d1487a0e4cc79d3beb30e6e646d2190223851
+        RewardPerToken::<Test>::insert(currency, (0, VAULT), f(8328262397106661114));
+        RewardTally::<Test>::insert(currency, (0, VAULT, account), f(594980318984627591665452302579139));
+        SlashPerToken::<Test>::insert(0, VAULT,  f(10288025703175927));
+        SlashTally::<Test>::insert(0, (VAULT, account), f(734987987016863199590580128394));
+        Stake::<Test>::insert(0, (VAULT, account), f(71441111076342999999817587297983));
+        TotalCurrentStake::<Test>::insert(0, VAULT, f(71441111076343000000000000000000));
+        TotalRewards::<Test>::insert(currency, (0, VAULT), f(1135651379916000000000000000000));
+        TotalStake::<Test>::insert(0, VAULT, f(71441111076342999999817587297983));
+
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(109_808_965_219)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(109_808_965_219)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(1_479_196_975_788)));
+
+        // state at block 0xe56fd1e1c66ca658284cda6334865cb3ac413fdb6a9272f00f350b6f29787ba5
+        // Note: RewardPerToken is updated correctly  
+        assert_eq!(RewardPerToken::<Test>::get(currency, (0, VAULT)), f(8531126040549884148));
+        assert_eq!(RewardTally::<Test>::get(currency, (0, VAULT, account)), f(594980318984627591665452302579139));
+        assert_eq!(SlashPerToken::<Test>::get(0, VAULT,), f(34067259825257565));
+        assert_eq!(SlashTally::<Test>::get(0, (VAULT, account)), f(734987987016863199590580128394));
+        assert_eq!(Stake::<Test>::get(0, (VAULT, account)), f(71441111076342999999817587297983));
+        assert_eq!(TotalCurrentStake::<Test>::get(0, VAULT), f(69742296170117000000000000000000));
+        assert_eq!(TotalRewards::<Test>::get(currency, (0, VAULT)), f(1135651379916000000000000000000));
+        assert_eq!(TotalStake::<Test>::get(0, VAULT), f(71441111076342999999817587297983));
+
+        // The bug that we observed
+        Staking::distribute_reward(currency, &VAULT, f(14234191584160000000000000000000)).unwrap();
+        // same as distributed amount except for rounding error
+        assert_eq!(Staking::withdraw_reward(currency, &VAULT, &account).unwrap(), 14234191584159);
+    })
+}
+
+#[test]
 fn should_stake_and_earn_rewards() {
     run_test(|| {
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(50)));
@@ -19,7 +107,7 @@ fn should_stake_and_earn_rewards() {
         assert_ok!(Staking::distribute_reward(Token(IBTC), &VAULT, fixed!(100)));
         assert_ok!(Staking::compute_reward(Token(IBTC), &VAULT, &ALICE.account_id), 50);
         assert_ok!(Staking::compute_reward(Token(IBTC), &VAULT, &BOB.account_id), 50);
-        assert_ok!(Staking::slash_stake(Token(IBTC), &VAULT, fixed!(20)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(20)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 40);
         assert_ok!(Staking::compute_stake(&VAULT, &BOB.account_id), 40);
         assert_ok!(Staking::compute_reward(Token(IBTC), &VAULT, &ALICE.account_id), 50);
@@ -39,7 +127,7 @@ fn continues_functioning_after_slash() {
         assert_ok!(Staking::compute_reward(Token(IBTC), &VAULT, &ALICE.account_id), 10000);
 
         // step 2: slash
-        assert_ok!(Staking::slash_stake(Token(IBTC), &VAULT, fixed!(30)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(30)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 20);
 
         // step 3: withdraw rewards
@@ -65,8 +153,8 @@ fn should_stake_and_distribute_and_withdraw() {
         assert_ok!(Staking::compute_reward(Token(IBTC), &VAULT, &ALICE.account_id), 500);
         assert_ok!(Staking::compute_reward(Token(IBTC), &VAULT, &BOB.account_id), 500);
 
-        assert_ok!(Staking::slash_stake(Token(IBTC), &VAULT, fixed!(50)));
-        assert_ok!(Staking::slash_stake(Token(IBTC), &VAULT, fixed!(50)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(50)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(50)));
 
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(1000)));
         assert_ok!(Staking::distribute_reward(Token(IBTC), &VAULT, fixed!(1000)));
@@ -84,7 +172,7 @@ fn should_stake_and_distribute_and_withdraw() {
         assert_ok!(Staking::compute_stake(&VAULT, &BOB.account_id), 19950);
 
         assert_ok!(Staking::distribute_reward(Token(IBTC), &VAULT, fixed!(1000)));
-        assert_ok!(Staking::slash_stake(Token(IBTC), &VAULT, fixed!(10000)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(10000)));
 
         assert_ok!(Staking::compute_stake(&VAULT, &BOB.account_id), 9949);
 
@@ -121,7 +209,7 @@ fn should_not_withdraw_stake_if_balance_insufficient_after_slashing() {
     run_test(|| {
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(100)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 100);
-        assert_ok!(Staking::slash_stake(Token(IBTC), &VAULT, fixed!(100)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(100)));
         assert_ok!(Staking::compute_stake(&VAULT, &ALICE.account_id), 0);
         assert_err!(
             Staking::withdraw_stake(&VAULT, &ALICE.account_id, fixed!(100), None),
@@ -136,7 +224,7 @@ fn should_force_refund() {
         let mut nonce = Staking::nonce(&VAULT);
         assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(100)));
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(100)));
-        assert_ok!(Staking::slash_stake(Token(IBTC), &VAULT, fixed!(100)));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(100)));
         assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(100)));
         assert_ok!(Staking::deposit_stake(&VAULT, &ALICE.account_id, fixed!(10)));
         assert_ok!(Staking::distribute_reward(Token(IBTC), &VAULT, fixed!(100)));
@@ -200,11 +288,7 @@ fn should_compute_stake_after_adjustments() {
             &VAULT.account_id,
             fixed!(1152923504604516976)
         ));
-        assert_ok!(Staking::slash_stake(
-            Token(IBTC),
-            &VAULT,
-            fixed!(1152923504604516976 + 100)
-        ));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(1152923504604516976 + 100)));
 
         assert_ok!(Staking::deposit_stake(&VAULT, &VAULT.account_id, fixed!(1_000_000)));
 
@@ -213,11 +297,7 @@ fn should_compute_stake_after_adjustments() {
             &VAULT.account_id,
             fixed!(1152924504603286976)
         ));
-        assert_ok!(Staking::slash_stake(
-            Token(IBTC),
-            &VAULT,
-            fixed!(1152924504603286976 + 1_000_000)
-        ));
+        assert_ok!(Staking::slash_stake(&VAULT, fixed!(1152924504603286976 + 1_000_000)));
 
         assert_ok!(Staking::compute_stake(&VAULT, &VAULT.account_id), 0);
 

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -24,10 +24,7 @@ pub(crate) mod security {
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod staking {
-    use crate::{
-        types::{BalanceOf, CurrencyId},
-        DefaultVaultId,
-    };
+    use crate::{types::BalanceOf, DefaultVaultId};
     use currency::Amount;
     use frame_support::dispatch::{DispatchError, DispatchResult};
     use staking::Staking;
@@ -48,12 +45,8 @@ pub(crate) mod staking {
         T::VaultStaking::withdraw_stake(vault_id, nominator_id, amount.amount(), None)
     }
 
-    pub fn slash_stake<T: crate::Config>(
-        currency_id: CurrencyId<T>,
-        vault_id: &DefaultVaultId<T>,
-        amount: &Amount<T>,
-    ) -> DispatchResult {
-        T::VaultStaking::slash_stake(vault_id, amount.amount(), currency_id)
+    pub fn slash_stake<T: crate::Config>(vault_id: &DefaultVaultId<T>, amount: &Amount<T>) -> DispatchResult {
+        T::VaultStaking::slash_stake(vault_id, amount.amount())
     }
 
     pub fn compute_stake<T: crate::Config>(

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -883,7 +883,7 @@ impl<T: Config> Pallet<T> {
     fn slash_backing_collateral(vault_id: &DefaultVaultId<T>, amount: &Amount<T>) -> DispatchResult {
         amount.unlock_on(&vault_id.account_id)?;
         Self::decrease_total_backing_collateral(&vault_id.currencies, amount)?;
-        ext::staking::slash_stake::<T>(vault_id.wrapped_currency(), vault_id, amount)?;
+        ext::staking::slash_stake::<T>(vault_id, amount)?;
         Ok(())
     }
 

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -606,7 +606,7 @@ impl<T: Config> RichVault<T> {
         ext::staking::withdraw_stake::<T>(&vault_id, &vault_id.account_id, &to_withdraw)?;
         // take remainder from nominators
         if let Some(to_slash) = to_slash {
-            ext::staking::slash_stake::<T>(self.wrapped_currency(), &vault_id, &to_slash)?;
+            ext::staking::slash_stake::<T>(&vault_id, &to_slash)?;
         }
 
         Pallet::<T>::transfer_funds(


### PR DESCRIPTION
In slash_stake, we reduce the vault's stake. That shouldn't cause them to lose rewards though, so we increase the rewards per token to compensate. However, the code contained a bug that caused the RewardsPerTokens to be only updated for KBTC, not for KINT. The fix is to iterate over both of these currencies