### PR TITLE
feat: pending vault theft status

### DIFF
--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -29,8 +29,8 @@ use mocktopus::macros::mockable;
 use primitives::VaultCurrencyPair;
 
 use crate::types::{
-    BalanceOf, BtcAddress, CurrencyId, DefaultSystemVault, RichSystemVault, RichVault, SignedInner, UnsignedFixedPoint,
-    UpdatableVault, Version,
+    BalanceOf, BtcAddress, CurrencyId, DefaultSystemVault, DefaultVaultStatus, RichSystemVault, RichVault, SignedInner,
+    UnsignedFixedPoint, UpdatableVault, Version,
 };
 
 use crate::types::DefaultVaultCurrencyPair;
@@ -521,7 +521,7 @@ pub mod pallet {
             to_be_redeemed_tokens: BalanceOf<T>,
             to_be_replaced_tokens: BalanceOf<T>,
             backing_collateral: BalanceOf<T>,
-            status: VaultStatus,
+            status: DefaultVaultStatus<T>,
             replace_collateral: BalanceOf<T>,
         },
         BanVault {
@@ -777,6 +777,7 @@ impl<T: Config> Pallet<T> {
             VaultStatus::Active(_) => Ok(vault),
             VaultStatus::Liquidated => Err(Error::<T>::VaultLiquidated.into()),
             VaultStatus::CommittedTheft => Err(Error::<T>::VaultCommittedTheft.into()),
+            VaultStatus::PendingTheft { .. } => Err(Error::<T>::VaultCommittedTheft.into()),
         }
     }
 
@@ -1419,7 +1420,7 @@ impl<T: Config> Pallet<T> {
     /// * `status` - status with which to liquidate the vault
     pub fn liquidate_vault_with_status(
         vault_id: &DefaultVaultId<T>,
-        status: VaultStatus,
+        status: DefaultVaultStatus<T>,
         reporter: Option<T::AccountId>,
     ) -> Result<Amount<T>, DispatchError> {
         let mut vault = Self::get_active_rich_vault_from_id(&vault_id)?;

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -27,7 +27,7 @@ pub use primitives::{
 };
 use redeem::RedeemRequestStatus;
 use staking::DefaultVaultCurrencyPair;
-use vault_registry::types::UpdatableVault;
+use vault_registry::types::{DefaultVaultStatus, UpdatableVault};
 
 pub use issue::{types::IssueRequestExt, IssueRequest, IssueRequestStatus};
 pub use oracle::OracleKey;
@@ -45,7 +45,7 @@ pub use sp_runtime::{
 pub use sp_std::convert::TryInto;
 use std::collections::BTreeMap;
 pub use std::convert::TryFrom;
-pub use vault_registry::{CurrencySource, DefaultVaultId, Vault, VaultStatus};
+pub use vault_registry::{CurrencySource, DefaultVaultId, Vault};
 
 use self::redeem_testing_utils::USER_BTC_ADDRESS;
 
@@ -59,6 +59,7 @@ pub use itertools::Itertools;
 pub use pretty_assertions::assert_eq;
 
 pub type VaultId = DefaultVaultId<Runtime>;
+pub type VaultStatus = DefaultVaultStatus<Runtime>;
 
 pub const ALICE: [u8; 32] = [0u8; 32];
 pub const BOB: [u8; 32] = [1u8; 32];


### PR DESCRIPTION
Adds `PendingTheft` to the `VaultStatus` enum. Part of the implementation for https://github.com/interlay/interbtc/issues/636.