### PR TITLE
fix: exclude toBeRedeemed tokens from generating rewards

### DIFF
--- a/crates/annuity/src/lib.rs
+++ b/crates/annuity/src/lib.rs
@@ -165,7 +165,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 pub trait BlockRewardProvider<AccountId> {
     type Currency: ReservableCurrency<AccountId>;
-    #[cfg(feature = "runtime-benchmarks")]
+    #[cfg(any(feature = "runtime-benchmarks", test))]
     fn deposit_stake(from: &AccountId, amount: <Self::Currency as Currency<AccountId>>::Balance) -> DispatchResult;
     fn distribute_block_reward(
         from: &AccountId,

--- a/crates/annuity/src/mock.rs
+++ b/crates/annuity/src/mock.rs
@@ -95,7 +95,7 @@ pub struct MockBlockRewardProvider;
 
 impl BlockRewardProvider<AccountId> for MockBlockRewardProvider {
     type Currency = Balances;
-    #[cfg(feature = "runtime-benchmarks")]
+    #[cfg(any(feature = "runtime-benchmarks", test))]
     fn deposit_stake(_: &AccountId, _: Balance) -> DispatchResult {
         Ok(())
     }

--- a/crates/reward/src/lib.rs
+++ b/crates/reward/src/lib.rs
@@ -24,7 +24,7 @@ use sp_runtime::{
     traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, MaybeSerializeDeserialize, Saturating, Zero},
     ArithmeticError,
 };
-use sp_std::{convert::TryInto, fmt::Debug};
+use sp_std::{cmp::PartialOrd, convert::TryInto, fmt::Debug};
 
 pub(crate) type SignedFixedPoint<T, I = ()> = <T as Config<I>>::SignedFixedPoint;
 
@@ -309,17 +309,11 @@ pub trait Rewards<AccountId, Balance, CurrencyId> {
     /// Set the stake to `amount` for `account_id` regardless of its current stake.
     fn set_stake(account_id: &AccountId, amount: Balance) -> DispatchResult;
 
-    /// Deposit an `amount` of stake to the `account_id`.
-    fn deposit_stake(account_id: &AccountId, amount: Balance) -> DispatchResult;
-
     /// Distribute the `amount` to all participants OR error if zero total stake.
     fn distribute_reward(amount: Balance, currency_id: CurrencyId) -> DispatchResult;
 
     /// Compute the expected reward for the `account_id`.
     fn compute_reward(account_id: &AccountId, currency_id: CurrencyId) -> Result<Balance, DispatchError>;
-
-    /// Withdraw an `amount` of stake from the `account_id`.
-    fn withdraw_stake(account_id: &AccountId, amount: Balance) -> DispatchResult;
 
     /// Withdraw all rewards from the `account_id`.
     fn withdraw_reward(account_id: &AccountId, currency_id: CurrencyId) -> Result<Balance, DispatchError>;
@@ -329,7 +323,7 @@ impl<T, I, Balance> Rewards<T::RewardId, Balance, T::CurrencyId> for Pallet<T, I
 where
     T: Config<I>,
     I: 'static,
-    Balance: BalanceToFixedPoint<SignedFixedPoint<T, I>> + Saturating + sp_std::cmp::PartialOrd,
+    Balance: BalanceToFixedPoint<SignedFixedPoint<T, I>> + Saturating + PartialOrd,
     <T::SignedFixedPoint as FixedPointNumber>::Inner: TryInto<Balance>,
 {
     fn get_stake(reward_id: &T::RewardId) -> Result<Balance, DispatchError> {
@@ -344,17 +338,19 @@ where
         let current_stake = <Self as Rewards<T::RewardId, Balance, T::CurrencyId>>::get_stake(reward_id)?;
         if current_stake < amount {
             let additional_stake = amount.saturating_sub(current_stake);
-            <Self as Rewards<T::RewardId, Balance, T::CurrencyId>>::deposit_stake(reward_id, additional_stake)
+            Pallet::<T, I>::deposit_stake(
+                reward_id,
+                additional_stake.to_fixed().ok_or(Error::<T, I>::TryIntoIntError)?,
+            )
         } else if current_stake > amount {
             let surplus_stake = current_stake.saturating_sub(amount);
-            <Self as Rewards<T::RewardId, Balance, T::CurrencyId>>::withdraw_stake(reward_id, surplus_stake)
+            Pallet::<T, I>::withdraw_stake(
+                reward_id,
+                surplus_stake.to_fixed().ok_or(Error::<T, I>::TryIntoIntError)?,
+            )
         } else {
             Ok(())
         }
-    }
-
-    fn deposit_stake(reward_id: &T::RewardId, amount: Balance) -> DispatchResult {
-        Pallet::<T, I>::deposit_stake(reward_id, amount.to_fixed().ok_or(Error::<T, I>::TryIntoIntError)?)
     }
 
     fn distribute_reward(amount: Balance, currency_id: T::CurrencyId) -> DispatchResult {
@@ -365,10 +361,6 @@ where
         Pallet::<T, I>::compute_reward(currency_id, reward_id)?
             .try_into()
             .map_err(|_| Error::<T, I>::TryIntoIntError.into())
-    }
-
-    fn withdraw_stake(reward_id: &T::RewardId, amount: Balance) -> DispatchResult {
-        Pallet::<T, I>::withdraw_stake(reward_id, amount.to_fixed().ok_or(Error::<T, I>::TryIntoIntError)?)
     }
 
     fn withdraw_reward(reward_id: &T::RewardId, currency_id: T::CurrencyId) -> Result<Balance, DispatchError> {

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -68,17 +68,12 @@ pub(crate) mod reward {
     use frame_support::dispatch::DispatchError;
     use reward::Rewards;
 
-    pub fn deposit_stake<T: crate::Config>(
-        vault_id: &DefaultVaultId<T>,
-        amount: &Amount<T>,
-    ) -> Result<(), DispatchError> {
-        T::VaultRewards::deposit_stake(vault_id, amount.amount())
+    pub fn set_stake<T: crate::Config>(vault_id: &DefaultVaultId<T>, amount: &Amount<T>) -> Result<(), DispatchError> {
+        T::VaultRewards::set_stake(vault_id, amount.amount())
     }
 
-    pub fn withdraw_stake<T: crate::Config>(
-        vault_id: &DefaultVaultId<T>,
-        amount: &Amount<T>,
-    ) -> Result<(), DispatchError> {
-        T::VaultRewards::withdraw_stake(vault_id, amount.amount())
+    #[cfg(feature = "integration-tests")]
+    pub fn get_stake<T: crate::Config>(vault_id: &DefaultVaultId<T>) -> Result<crate::BalanceOf<T>, DispatchError> {
+        T::VaultRewards::get_stake(vault_id)
     }
 }

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -1,6 +1,8 @@
 use crate::{
-    ext, mock::*, types::BalanceOf, BtcPublicKey, CurrencySource, DefaultVaultId, DispatchError, Error, UpdatableVault,
-    Vault, VaultStatus,
+    ext,
+    mock::*,
+    types::{BalanceOf, UpdatableVault},
+    BtcPublicKey, CurrencySource, DefaultVaultId, DispatchError, Error, Vault, VaultStatus,
 };
 use codec::Decode;
 use currency::Amount;

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -665,9 +665,11 @@ impl<T: Config> RichVault<T> {
     pub(crate) fn request_issue_tokens(&mut self, tokens: &Amount<T>) -> DispatchResult {
         self.increase_to_be_issued(tokens)
     }
+
     pub(crate) fn cancel_issue_tokens(&mut self, tokens: &Amount<T>) -> DispatchResult {
         self.decrease_to_be_issued(tokens)
     }
+
     pub(crate) fn execute_issue_tokens(&mut self, tokens: &Amount<T>) -> DispatchResult {
         self.decrease_to_be_issued(tokens)?;
         self.increase_issued(tokens)?;
@@ -678,10 +680,12 @@ impl<T: Config> RichVault<T> {
         self.increase_to_be_redeemed(tokens)?;
         self.update_stake()
     }
+
     pub(crate) fn cancel_redeem_tokens(&mut self, tokens: &Amount<T>) -> DispatchResult {
         self.decrease_to_be_redeemed(tokens)?;
         self.update_stake()
     }
+
     pub(crate) fn execute_redeem_tokens(&mut self, tokens: &Amount<T>) -> DispatchResult {
         // no need to update stake since these two token changes counteract the other's effect
         self.decrease_to_be_redeemed(tokens)?;

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -792,7 +792,9 @@ impl annuity::BlockRewardProvider<AccountId> for EscrowBlockRewardProvider {
 
     #[cfg(feature = "runtime-benchmarks")]
     fn deposit_stake(from: &AccountId, amount: Balance) -> DispatchResult {
-        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::deposit_stake(from, amount)
+        let current_stake = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::get_stake(from)?;
+        let new_stake = current_stake.saturating_add(amount);
+        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::set_stake(from, new_stake)
     }
 
     fn distribute_block_reward(_from: &AccountId, amount: Balance) -> DispatchResult {

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -891,7 +891,9 @@ impl annuity::BlockRewardProvider<AccountId> for EscrowBlockRewardProvider {
 
     #[cfg(feature = "runtime-benchmarks")]
     fn deposit_stake(from: &AccountId, amount: Balance) -> DispatchResult {
-        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::deposit_stake(from, amount)
+        let current_stake = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::get_stake(from)?;
+        let new_stake = current_stake.saturating_add(amount);
+        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::set_stake(from, new_stake)
     }
 
     fn distribute_block_reward(_from: &AccountId, amount: Balance) -> DispatchResult {

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -764,7 +764,9 @@ impl annuity::BlockRewardProvider<AccountId> for EscrowBlockRewardProvider {
 
     #[cfg(feature = "runtime-benchmarks")]
     fn deposit_stake(from: &AccountId, amount: Balance) -> DispatchResult {
-        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::deposit_stake(from, amount)
+        let current_stake = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::get_stake(from)?;
+        let new_stake = current_stake.saturating_add(amount);
+        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::set_stake(from, new_stake)
     }
 
     fn distribute_block_reward(_from: &AccountId, amount: Balance) -> DispatchResult {

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -764,7 +764,9 @@ impl annuity::BlockRewardProvider<AccountId> for EscrowBlockRewardProvider {
 
     #[cfg(feature = "runtime-benchmarks")]
     fn deposit_stake(from: &AccountId, amount: Balance) -> DispatchResult {
-        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::deposit_stake(from, amount)
+        let current_stake = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::get_stake(from)?;
+        let new_stake = current_stake.saturating_add(amount);
+        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::set_stake(from, new_stake)
     }
 
     fn distribute_block_reward(_from: &AccountId, amount: Balance) -> DispatchResult {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -700,7 +700,9 @@ impl annuity::BlockRewardProvider<AccountId> for EscrowBlockRewardProvider {
 
     #[cfg(feature = "runtime-benchmarks")]
     fn deposit_stake(from: &AccountId, amount: Balance) -> DispatchResult {
-        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::deposit_stake(from, amount)
+        let current_stake = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::get_stake(from)?;
+        let new_stake = current_stake.saturating_add(amount);
+        <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::set_stake(from, new_stake)
     }
 
     fn distribute_block_reward(_from: &AccountId, amount: Balance) -> DispatchResult {

--- a/standalone/runtime/tests/mock/issue_testing_utils.rs
+++ b/standalone/runtime/tests/mock/issue_testing_utils.rs
@@ -114,14 +114,18 @@ impl ExecuteIssueBuilder {
     }
 
     pub fn execute_prepared(&self) -> DispatchResultWithPostInfo {
+        VaultRegistryPallet::collateral_integrity_check();
+
         if let Some((proof, raw_tx)) = &self.execution_tx {
             // alice executes the issuerequest by confirming the btc transaction
-            Call::Issue(IssueCall::execute_issue {
+            let ret = Call::Issue(IssueCall::execute_issue {
                 issue_id: self.issue_id,
                 merkle_proof: proof.to_vec(),
                 raw_tx: raw_tx.to_vec(),
             })
-            .dispatch(origin_of(self.submitter.clone()))
+            .dispatch(origin_of(self.submitter.clone()));
+            VaultRegistryPallet::collateral_integrity_check();
+            ret
         } else {
             panic!("Backing transaction was not prepared prior to execution!");
         }

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -604,41 +604,50 @@ impl CoreVaultData {
             &vault_id,
             &current.to_be_issued
         ));
+        VaultRegistryPallet::collateral_integrity_check();
         assert_ok!(VaultRegistryPallet::decrease_to_be_redeemed_tokens(
             &vault_id,
             &current.to_be_redeemed
         ));
+        VaultRegistryPallet::collateral_integrity_check();
         assert_ok!(VaultRegistryPallet::try_increase_to_be_redeemed_tokens(
             &vault_id,
             &current.issued
         ));
+        VaultRegistryPallet::collateral_integrity_check();
         assert_ok!(VaultRegistryPallet::decrease_tokens(
             &vault_id,
             &account_of(DUMMY),
             &current.issued,
         ));
+        VaultRegistryPallet::collateral_integrity_check();
         assert_ok!(VaultRegistryPallet::decrease_to_be_replaced_tokens(
             &vault_id,
             &current.to_be_replaced,
         ));
+        VaultRegistryPallet::collateral_integrity_check();
 
         // set to-be-issued
         assert_ok!(VaultRegistryPallet::try_increase_to_be_issued_tokens(
             &vault_id,
             &state.to_be_issued
         ));
+        VaultRegistryPallet::collateral_integrity_check();
         // set issued (2 steps)
         assert_ok!(VaultRegistryPallet::try_increase_to_be_issued_tokens(
             &vault_id,
             &state.issued
         ));
+        VaultRegistryPallet::collateral_integrity_check();
         assert_ok!(VaultRegistryPallet::issue_tokens(&vault_id, &state.issued));
         // set to-be-redeemed
+        VaultRegistryPallet::collateral_integrity_check();
         assert_ok!(VaultRegistryPallet::try_increase_to_be_redeemed_tokens(
             &vault_id,
             &state.to_be_redeemed
         ));
         // set to-be-replaced:
+        VaultRegistryPallet::collateral_integrity_check();
         assert_ok!(VaultRegistryPallet::try_increase_to_be_replaced_tokens(
             &vault_id,
             &state.to_be_replaced,
@@ -1011,6 +1020,7 @@ pub fn try_register_vault(collateral: Amount<Runtime>, vault_id: &VaultId) {
     if VaultRegistryPallet::get_vault_from_id(vault_id).is_err() {
         register_vault(&vault_id, collateral);
     };
+    VaultRegistryPallet::collateral_integrity_check();
 }
 
 pub fn force_issue_tokens(user: [u8; 32], vault: [u8; 32], collateral: Amount<Runtime>, tokens: Amount<Runtime>) {
@@ -1464,6 +1474,7 @@ impl ExtBuilder {
 
             let ret = execute();
             VaultRegistryPallet::total_user_vault_collateral_integrity_check();
+            VaultRegistryPallet::collateral_integrity_check();
             ret
         })
     }

--- a/standalone/runtime/tests/mock/redeem_testing_utils.rs
+++ b/standalone/runtime/tests/mock/redeem_testing_utils.rs
@@ -52,13 +52,17 @@ impl ExecuteRedeemBuilder {
 
         SecurityPallet::set_active_block_number(SecurityPallet::active_block_number() + CONFIRMATIONS);
 
+        VaultRegistryPallet::collateral_integrity_check();
+
         // alice executes the redeemrequest by confirming the btc transaction
-        Call::Redeem(RedeemCall::execute_redeem {
+        let ret = Call::Redeem(RedeemCall::execute_redeem {
             redeem_id: self.redeem_id,
             merkle_proof: proof,
             raw_tx: raw_tx,
         })
-        .dispatch(origin_of(self.submitter.clone()))
+        .dispatch(origin_of(self.submitter.clone()));
+        VaultRegistryPallet::collateral_integrity_check();
+        ret
     }
 
     pub fn assert_execute(&self) {
@@ -110,6 +114,8 @@ pub fn setup_redeem(issued_tokens: Amount<Runtime>, user: [u8; 32], vault: &Vaul
         vault_id: vault.clone()
     })
     .dispatch(origin_of(account_of(user))));
+
+    VaultRegistryPallet::collateral_integrity_check();
 
     // assert that request happened and extract the id
     assert_redeem_request_event()

--- a/standalone/runtime/tests/mock/replace_testing_utils.rs
+++ b/standalone/runtime/tests/mock/replace_testing_utils.rs
@@ -82,6 +82,8 @@ pub fn accept_replace(
     .dispatch(origin_of(new_vault_id.account_id.clone()))
     .map_err(|err| err.error)?;
 
+    VaultRegistryPallet::collateral_integrity_check();
+
     let replace_id = assert_accept_replace_event();
     let replace = ReplacePallet::get_open_replace_request(&replace_id).unwrap();
     Ok((replace_id, replace))

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -44,12 +44,6 @@ fn test_with_initialized_vault<R>(execute: impl Fn(VaultId) -> R) {
     })
 }
 
-macro_rules! signed_fixed_point {
-    ($amount:expr) => {
-        sp_arithmetic::FixedI128::checked_from_integer($amount).unwrap()
-    };
-}
-
 mod expiry_test {
     use super::{assert_eq, *};
 
@@ -864,7 +858,8 @@ mod execute_issue_tests {
             let post_request_state = ParachainState::get(&vault_id);
 
             // need stake for rewards to deposit
-            assert_ok!(VaultRewardsPallet::deposit_stake(&vault_id, signed_fixed_point!(1)));
+            let stake: u128 = VaultRewardsPallet::get_stake(&vault_id).unwrap();
+            assert!(stake > 0u128);
 
             ExecuteIssueBuilder::new(issue_id)
                 .with_amount(sent_btc)

--- a/standalone/runtime/tests/test_replace.rs
+++ b/standalone/runtime/tests/test_replace.rs
@@ -48,6 +48,8 @@ fn test_with<R>(execute: impl Fn(VaultId, VaultId) -> R) {
                 );
                 CoreVaultData::force_to(&other_new_vault_id, default_vault_state(&other_new_vault_id));
             }
+            VaultRegistryPallet::collateral_integrity_check();
+
             execute(old_vault_id, new_vault_id)
         })
     };
@@ -66,6 +68,8 @@ fn test_without_initialization<R>(execute: impl Fn(CurrencyId) -> R) {
 }
 
 pub fn withdraw_replace(old_vault_id: &VaultId, amount: Amount<Runtime>) -> DispatchResultWithPostInfo {
+    VaultRegistryPallet::collateral_integrity_check();
+
     Call::Replace(ReplaceCall::withdraw_replace {
         currency_pair: old_vault_id.currencies.clone(),
         amount: amount.amount(),


### PR DESCRIPTION
This turned out to be a little bit more complicated that I anticipated. Before, we used a hook to set the reward-stake in increase/decrease_issued_tokens. With this change, we also have to update tokens when the `to_be_redeemed` tokens change. However, there are multiple operations that change both the issued and the to_be_redeemed tokens. With an added hook we'd have two stake updates for these. In some cases, like in execute redeem, we actually want 0 updates, since the change in to_be_redeemed tokens gets compensated by the change in issued tokens. So I refactored a little bit: the `vault-registry/lib.rs` file no longer has access to the raw increase/decrease token functions. Instead, it only uses the new `(request|cancel|execute)_(issue|redeem)_tokens` functions, which only update the stake when required.  

For testing, I added integrity checks at various places in the integration tests.