### PR TITLE
Vault Theft Recovery

### DIFF
--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -276,6 +276,9 @@ impl<T: Config> Pallet<T> {
             Error::<T>::WaitingForRelayerInitialization
         );
 
+        // Check that the vault is currently not banned or pending theft
+        ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
+
         let vault = ext::vault_registry::get_active_vault_from_id::<T>(&vault_id)?;
 
         // ensure that the vault is accepting new issues
@@ -283,9 +286,6 @@ impl<T: Config> Pallet<T> {
             vault.status == VaultStatus::Active(true),
             Error::<T>::VaultNotAcceptingNewIssues
         );
-
-        // Check that the vault is currently not banned
-        ext::vault_registry::ensure_not_banned::<T>(&vault_id)?;
 
         // calculate griefing collateral based on the total amount of tokens to be issued
         let amount_collateral = amount_requested.convert_to(T::GetGriefingCollateralCurrencyId::get())?;

--- a/crates/relay/src/ext.rs
+++ b/crates/relay/src/ext.rs
@@ -3,8 +3,7 @@ use mocktopus::macros::mockable;
 
 #[cfg_attr(test, mockable)]
 pub(crate) mod vault_registry {
-    use crate::DefaultVaultId;
-    use ::vault_registry::VaultStatus;
+    use crate::{BalanceOf, DefaultVaultId, DefaultVaultStatus};
     use frame_support::dispatch::{DispatchError, DispatchResult};
     use vault_registry::types::DefaultVault;
 
@@ -14,16 +13,26 @@ pub(crate) mod vault_registry {
         <vault_registry::Pallet<T>>::get_active_vault_from_id(vault_id)
     }
 
-    pub fn liquidate_theft_vault<T: crate::Config>(
+    pub fn get_vault_from_id<T: crate::Config>(vault_id: &DefaultVaultId<T>) -> Result<DefaultVault<T>, DispatchError> {
+        <vault_registry::Pallet<T>>::get_vault_from_id(vault_id)
+    }
+
+    pub fn report_vault_theft<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
-        reporter_id: T::AccountId,
+        reported_amount: BalanceOf<T>,
+        reporter_id: &T::AccountId,
     ) -> DispatchResult {
-        let _ = <vault_registry::Pallet<T>>::liquidate_vault_with_status(
+        <vault_registry::Pallet<T>>::report_vault_theft(vault_id, reported_amount, reporter_id)
+    }
+
+    pub fn recover_vault_theft<T: crate::Config>(
+        vault_id: &DefaultVaultId<T>,
+        recovered_amount: BalanceOf<T>,
+    ) -> Result<DefaultVaultStatus<T>, DispatchError> {
+        Ok(<vault_registry::Pallet<T>>::recover_vault_theft(
             vault_id,
-            VaultStatus::CommittedTheft,
-            Some(reporter_id),
-        )?;
-        Ok(())
+            recovered_amount,
+        )?)
     }
 }
 

--- a/crates/relay/src/tests.rs
+++ b/crates/relay/src/tests.rs
@@ -1,5 +1,5 @@
 extern crate hex;
-use crate::{ext, mock::*};
+use crate::{ext, mock::*, types::BalanceOf};
 use bitcoin::{
     formatter::Formattable,
     types::{
@@ -55,7 +55,7 @@ fn test_report_vault_passes_with_vault_transaction() {
             .mock_safe(move |_| MockResult::Return(Ok(init_zero_vault(vault.clone(), vec![btc_address]))));
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
-        ext::vault_registry::liquidate_theft_vault::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::report_vault_theft::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
 
         assert_ok!(Relay::report_vault_theft(
             Origin::signed(ALICE),
@@ -106,7 +106,7 @@ fn test_report_vault_succeeds_with_segwit_transaction() {
             .mock_safe(move |_| MockResult::Return(Ok(init_zero_vault(vault.clone(), vec![btc_address]))));
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
-        ext::vault_registry::liquidate_theft_vault::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::report_vault_theft::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
 
         assert_ok!(Relay::report_vault_theft(
             Origin::signed(ALICE),
@@ -130,7 +130,7 @@ fn test_report_vault_succeeds_with_p2sh_segwit_transaction() {
             .mock_safe(move |_| MockResult::Return(Ok(init_zero_vault(vault.clone(), vec![btc_address]))));
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
-        ext::vault_registry::liquidate_theft_vault::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::report_vault_theft::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
 
         assert_ok!(Relay::report_vault_theft(
             Origin::signed(ALICE),
@@ -148,7 +148,7 @@ fn test_report_vault_theft_succeeds() {
 
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
         Relay::_is_parsed_transaction_invalid.mock_safe(move |_, _| MockResult::Return(Ok(())));
-        ext::vault_registry::liquidate_theft_vault::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::report_vault_theft::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
 
         let raw_proof = hex::decode("00000020ecf348128755dbeea5deb8eddf64566d9d4e59bc65d485000000000000000000901f0d92a66ee7dcefd02fa282ca63ce85288bab628253da31ef259b24abe8a0470a385a45960018e8d672f8a90a00000d0bdabada1fb6e3cef7f5c6e234621e3230a2f54efc1cba0b16375d9980ecbc023cbef3ba8d8632ea220927ec8f95190b30769eb35d87618f210382c9445f192504074f56951b772efa43b89320d9c430b0d156b93b7a1ff316471e715151a0619a39392657f25289eb713168818bd5b37476f1bc59b166deaa736d8a58756f9d7ce2aef46d8004c5fe3293d883838f87b5f1da03839878895b71530e9ff89338bb6d4578b3c3135ff3e8671f9a64d43b22e14c2893e8271cecd420f11d2359307403bb1f3128885b3912336045269ef909d64576b93e816fa522c8c027fe408700dd4bdee0254c069ccb728d3516fe1e27578b31d70695e3e35483da448f3a951273e018de7f2a8f657064b013c6ede75c74bbd7f98fdae1c2ac6789ee7b21a791aa29d60e89fff2d1d2b1ada50aa9f59f403823c8c58bb092dc58dc09b28158ca15447da9c3bedb0b160f3fe1668d5a27716e27661bcb75ddbf3468f5c76b7bed1004c6b4df4da2ce80b831a7c260b515e6355e1c306373d2233e8de6fda3674ed95d17a01a1f64b27ba88c3676024fbf8d5dd962ffc4d5e9f3b1700763ab88047f7d0000").unwrap();
         let tx_bytes = hex::decode("0100000001c8cc2b56525e734ff63a13bc6ad06a9e5664df8c67632253a8e36017aee3ee40000000009000483045022100ad0851c69dd756b45190b5a8e97cb4ac3c2b0fa2f2aae23aed6ca97ab33bf88302200b248593abc1259512793e7dea61036c601775ebb23640a0120b0dba2c34b79001455141042f90074d7a5bf30c72cf3a8dfd1381bdbd30407010e878f3a11269d5f74a58788505cdca22ea6eab7cfb40dc0e07aba200424ab0d79122a653ad0c7ec9896bdf51aefeffffff0120f40e00000000001976a9141d30342095961d951d306845ef98ac08474b36a088aca7270400").unwrap();
@@ -472,14 +472,20 @@ fn should_report_double_payment() {
         let public_key = BtcPublicKey::dummy();
         let input_address = BtcAddress::P2PKH(public_key.to_hash());
         let output_address = BtcAddress::random();
-        let left_tx = build_dummy_transaction_from_input_with_output_and_op_return(
+        let tx_1 = build_dummy_transaction_from_input_with_output_and_op_return(
             H256Le::from_bytes_le(&vec![1u8; 32]),
             &public_key,
             output_address,
             &[1; 32],
         );
-        let right_tx = build_dummy_transaction_from_input_with_output_and_op_return(
+        let tx_2 = build_dummy_transaction_from_input_with_output_and_op_return(
             H256Le::from_bytes_le(&vec![2u8; 32]),
+            &public_key,
+            output_address,
+            &[1; 32],
+        );
+        let tx_3 = build_dummy_transaction_from_input_with_output_and_op_return(
+            H256Le::from_bytes_le(&vec![3u8; 32]),
             &public_key,
             output_address,
             &[1; 32],
@@ -489,13 +495,19 @@ fn should_report_double_payment() {
             .mock_safe(move |_| MockResult::Return(Ok(init_zero_vault(CAROL.clone(), vec![input_address]))));
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
-        ext::vault_registry::liquidate_theft_vault::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::report_vault_theft::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
 
         assert_ok!(Relay::report_vault_double_payment(
             Origin::signed(ALICE),
             CAROL,
             (vec![0u8; 32], vec![1u8; 32]),
-            (left_tx.format(), right_tx.format()),
+            (tx_1.format(), tx_2.format()),
+        ));
+        assert_ok!(Relay::report_vault_double_payment(
+            Origin::signed(ALICE),
+            CAROL,
+            (vec![0u8; 32], vec![1u8; 32]),
+            (tx_1.format(), tx_3.format()),
         ));
     })
 }
@@ -523,7 +535,7 @@ fn should_not_report_double_payment_with_vault_no_input() {
             .mock_safe(move |_| MockResult::Return(Ok(init_zero_vault(CAROL.clone(), vec![input_address]))));
         ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
         ext::btc_relay::verify_transaction_inclusion::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
-        ext::vault_registry::liquidate_theft_vault::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::report_vault_theft::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(())));
 
         assert_err!(
             Relay::report_vault_double_payment(
@@ -534,5 +546,44 @@ fn should_not_report_double_payment_with_vault_no_input() {
             ),
             TestError::VaultNoInputToTransaction
         );
+    })
+}
+
+#[test]
+fn test_get_total_output() {
+    run_test(|| {
+        let address1 = BtcAddress::P2PKH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
+        let address2 = BtcAddress::P2PKH(H160::from_str(&"5f69790b72c98041330644bbd50f2ebb5d073c36").unwrap());
+
+        let mut wallet = Wallet::new();
+        wallet.add_btc_address(address1);
+        let address1_output = 50;
+        let address2_output = 60;
+
+        // One output is sent to a wallet address.
+        let transaction1 = build_dummy2_transaction_with(
+            vec![(address1_output, address1), (address2_output, address2)],
+            H256::zero(),
+        );
+        let total_wallet_output1: BalanceOf<Test> =
+            Relay::get_total_output(&transaction1, Some(wallet.clone())).unwrap();
+        assert_eq!(i64::try_from(total_wallet_output1).unwrap(), address1_output);
+
+        // No output is sent to a wallet address.
+        let transaction2 = build_dummy2_transaction_with(
+            vec![(address2_output, address2), (address2_output, address2)],
+            H256::zero(),
+        );
+        let total_wallet_output2: BalanceOf<Test> =
+            Relay::get_total_output(&transaction2, Some(wallet.clone())).unwrap();
+        assert_eq!(i64::try_from(total_wallet_output2).unwrap(), 0);
+
+        // All outputs are sent to a wallet address.
+        let transaction3 = build_dummy2_transaction_with(
+            vec![(address2_output, address1), (address2_output, address1)],
+            H256::zero(),
+        );
+        let total_wallet_output3: BalanceOf<Test> = Relay::get_total_output(&transaction3, Some(wallet)).unwrap();
+        assert_eq!(i64::try_from(total_wallet_output3).unwrap(), address2_output * 2);
     })
 }

--- a/crates/relay/src/types.rs
+++ b/crates/relay/src/types.rs
@@ -1,6 +1,8 @@
 use primitives::VaultId;
-use vault_registry::types::CurrencyId;
+use vault_registry::types::{CurrencyId, VaultStatus};
 
 pub(crate) type BalanceOf<T> = <T as vault_registry::Config>::Balance;
 
 pub(crate) type DefaultVaultId<T> = VaultId<<T as frame_system::Config>::AccountId, CurrencyId<T>>;
+
+pub(crate) type DefaultVaultStatus<T> = VaultStatus<<T as frame_system::Config>::BlockNumber, BalanceOf<T>>;

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -128,6 +128,13 @@ pub(crate) mod vault_registry {
         <vault_registry::Pallet<T>>::decrease_to_be_replaced_tokens(vault_id, tokens)
     }
 
+    pub fn withdraw_replace_request<T: crate::Config>(
+        vault_id: &DefaultVaultId<T>,
+        amount: &Amount<T>,
+    ) -> Result<(Amount<T>, Amount<T>), DispatchError> {
+        <vault_registry::Pallet<T>>::withdraw_replace_request(vault_id, amount)
+    }
+
     pub fn try_deposit_collateral<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
         amount: &Amount<T>,

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -362,14 +362,7 @@ impl<T: Config> Pallet<T> {
         let amount = Amount::new(amount, vault_id.wrapped_currency());
         // decrease to-be-replaced tokens, so that the vault is free to use its issued tokens again.
         let (withdrawn_tokens, to_withdraw_collateral) =
-            ext::vault_registry::decrease_to_be_replaced_tokens::<T>(&vault_id, &amount)?;
-
-        // release the used collateral
-        ext::vault_registry::transfer_funds(
-            CurrencySource::AvailableReplaceCollateral(vault_id.clone()),
-            CurrencySource::FreeBalance(vault_id.account_id.clone()),
-            &to_withdraw_collateral,
-        )?;
+            ext::vault_registry::withdraw_replace_request::<T>(&vault_id, &amount)?;
 
         if withdrawn_tokens.is_zero() {
             return Err(Error::<T>::NoPendingRequest.into());

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -123,6 +123,14 @@ benchmarks! {
 
         Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::checked_from_rational(10, 1).unwrap()).unwrap();
     }: _(RawOrigin::Signed(origin), vault_id.clone())
+
+    recover_vault_id {
+        let vault_id = get_vault_id::<T>();
+        mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
+        register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
+        Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::checked_from_rational(10, 1).unwrap()).unwrap();
+        VaultRegistry::<T>::liquidate_vault_with_status(&vault_id, VaultStatus::CommittedTheft, None).unwrap();
+    }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone())
 }
 
 impl_benchmark_test_suite!(

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -129,7 +129,7 @@ benchmarks! {
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
         register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
         Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(), UnsignedFixedPoint::<T>::checked_from_rational(10, 1).unwrap()).unwrap();
-        VaultRegistry::<T>::liquidate_vault_with_status(&vault_id, VaultStatus::CommittedTheft, None).unwrap();
+        VaultRegistry::<T>::liquidate_vault_with_status(&vault_id, VaultStatus::CommittedTheft).unwrap();
     }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone())
 }
 

--- a/crates/vault-registry/src/default_weights.rs
+++ b/crates/vault-registry/src/default_weights.rs
@@ -46,6 +46,7 @@ pub trait WeightInfo {
 	fn set_premium_redeem_threshold() -> Weight;
 	fn set_liquidation_collateral_threshold() -> Weight;
 	fn report_undercollateralized_vault() -> Weight;
+	fn recover_vault_id() -> Weight;
 }
 
 /// Weights for vault_registry using the Substrate node and recommended hardware.
@@ -180,6 +181,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(28 as Weight))
 			.saturating_add(T::DbWeight::get().writes(16 as Weight))
 	}
+
+	// Storage: VaultRegistry Vaults (r:2 w:1)
+	fn recover_vault_id() -> Weight {
+		(14_679_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
@@ -312,6 +320,13 @@ impl WeightInfo for () {
 		(363_346_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(28 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(16 as Weight))
+	}
+
+	// Storage: VaultRegistry Vaults (r:2 w:1)
+	fn recover_vault_id() -> Weight {
+		(14_679_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }
 

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -417,6 +417,29 @@ pub mod pallet {
             Self::_set_liquidation_collateral_threshold(currency_pair, threshold);
             Ok(())
         }
+
+        /// Recover vault ID from a liquidated status.
+        ///
+        /// # Arguments
+        /// * `currency_pair` - the currency pair to change
+        #[pallet::weight(<T as Config>::WeightInfo::recover_vault_id())]
+        #[transactional]
+        pub fn recover_vault_id(origin: OriginFor<T>, currency_pair: DefaultVaultCurrencyPair<T>) -> DispatchResult {
+            let account_id = ensure_signed(origin)?;
+            let vault_id = VaultId::new(account_id, currency_pair.collateral, currency_pair.wrapped);
+            ensure!(Self::is_vault_liquidated(&vault_id)?, Error::<T>::VaultNotRecoverable);
+
+            let mut vault = Self::get_rich_vault_from_id(&vault_id.clone())?;
+            ensure!(
+                !vault.has_outstanding_wrapped_tokens()?,
+                Error::<T>::VaultNotRecoverable
+            );
+
+            // Vault accepts new issues by default
+            vault.set_accept_new_issues(true)?;
+
+            Ok(())
+        }
     }
 
     #[pallet::event]
@@ -560,6 +583,8 @@ pub mod pallet {
         VaultCommittedTheft,
         /// Vault is no longer usable as it was liquidated due to undercollateralization.
         VaultLiquidated,
+        /// Vault must be either liquidated or flagged for theft.
+        VaultNotRecoverable,
         /// No bitcoin public key is registered for the vault.
         NoBitcoinPublicKey,
         /// A bitcoin public key was already registered for this account.
@@ -1392,6 +1417,27 @@ impl<T: Config> Pallet<T> {
         new_vault.decrease_to_be_issued(tokens)?;
 
         Ok(())
+    }
+
+    /// Withdraws an `amount` of tokens that were requested for replacement by `vault_id`
+    ///
+    /// # Arguments
+    /// * `vault_id` - the id of the vault
+    /// * `amount` - the amount of tokens to be withdrawn from replace requests
+    pub fn withdraw_replace_request(
+        vault_id: &DefaultVaultId<T>,
+        amount: &Amount<T>,
+    ) -> Result<(Amount<T>, Amount<T>), DispatchError> {
+        let (withdrawn_tokens, to_withdraw_collateral) = Self::decrease_to_be_replaced_tokens(&vault_id, &amount)?;
+
+        // release the used collateral
+        Self::transfer_funds(
+            CurrencySource::AvailableReplaceCollateral(vault_id.clone()),
+            CurrencySource::FreeBalance(vault_id.account_id.clone()),
+            &to_withdraw_collateral,
+        )?;
+
+        Ok((withdrawn_tokens, to_withdraw_collateral))
     }
 
     fn undercollateralized_vaults() -> impl Iterator<Item = DefaultVaultId<T>> {

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -252,6 +252,7 @@ pub fn default_vault_state(vault_id: &VaultId) -> CoreVaultData {
             .map(|x| (x, default_vault_free_balance(x)))
             .collect(),
         liquidated_collateral: Amount::new(0, vault_id.collateral_currency()),
+        status: VaultStatus::Active(true),
     }
 }
 
@@ -508,6 +509,7 @@ pub struct CoreVaultData {
     pub free_balance: BTreeMap<CurrencyId, Amount<Runtime>>,
     pub to_be_replaced: Amount<Runtime>,
     pub replace_collateral: Amount<Runtime>,
+    pub status: VaultStatus,
 }
 
 impl CoreVaultData {
@@ -522,6 +524,7 @@ impl CoreVaultData {
             backing_collateral: Amount::new(0, vault_id.collateral_currency()),
             free_balance: iter_all_currencies().map(|x| (x, Amount::new(0, x))).collect(),
             liquidated_collateral: Amount::new(0, vault_id.collateral_currency()),
+            status: VaultStatus::Active(true),
         }
     }
 }
@@ -558,6 +561,7 @@ impl CoreVaultData {
                 vault.replace_collateral,
                 <Runtime as vault_registry::Config>::GetGriefingCollateralCurrencyId::get(),
             ),
+            status: vault.status,
         }
     }
 

--- a/standalone/runtime/tests/test_relayers.rs
+++ b/standalone/runtime/tests/test_relayers.rs
@@ -120,6 +120,7 @@ fn integration_test_report_vault_theft() {
                 vault.issued -= issued_tokens;
                 vault.backing_collateral -= confiscated_collateral;
                 vault.backing_collateral -= theft_fee;
+                vault.status = VaultStatus::CommittedTheft;
 
                 liquidation_vault.issued += issued_tokens;
                 liquidation_vault.collateral += confiscated_collateral;

--- a/standalone/runtime/tests/test_replace.rs
+++ b/standalone/runtime/tests/test_replace.rs
@@ -206,6 +206,13 @@ mod accept_replace_tests {
             )
             .unwrap();
 
+            // Set `accept_new_issues` back to the default value so the parachain state check succeeds.
+            assert_ok!(Call::VaultRegistry(VaultRegistryCall::accept_new_issues {
+                currency_pair: new_vault_id.currencies.clone(),
+                accept_new_issues: true
+            })
+            .dispatch(origin_of(new_vault_id.account_id.clone())));
+
             assert_state_after_accept_replace_correct(&old_vault_id, &new_vault_id, &replace);
         });
     }


### PR DESCRIPTION
Implements https://github.com/interlay/interbtc/issues/636
Depends on https://github.com/interlay/interbtc/pull/647

- New vault status: `PendingTheft(amount, recovery_deadline_block)`. It is equivalent to being banned indefinitely.
- The rewarding of theft reporting is now separated from vault liquidation. `relay::report_vault_theft(...)` and  `relay::report_vault_double_payment(...)` call `vault_registry::report_vault_theft(...)` which distributes the theft fee to the reporter and either moves a vault from status `Active(...)` to `PendingTheft(...)`, or from `PendingTheft(amount, deadline)` to `PendingTheft(amount + new_theft, deadline)`.
- `amount` in the `PendingTheft(...)` status is computed as the total output of the reported transaction. This overestimates the stolen amount, but is much simpler than having input transactions reported and adding up only amounts from the vault's wallet.
- New extrinsic: `recover_vault_theft(...)`. It reduces the amount in `PendingTheft(amount, deadline)` by the sum of outputs to the vault's wallet. No input must originate from the vault's wallet. If `amount` reaches zero, the vault becomes `Active(true)`.
- New extrinsic: `pending_liquidation_elapsed(...)`. Called by the offchain worker, moves a vault from `PendingTheft(...)` status to `CommittedTheft` and liquidates it.
- The `VaultTheft` event is updated to include the stolen amount. `VaultDoublePayment` is left as-is, since it steals the same amount as in the request.
- New event: `VaultTheftRecovery`