### PR TITLE
fix!: add coingecko id to asset metadata

### DIFF
--- a/crates/annuity/src/mock.rs
+++ b/crates/annuity/src/mock.rs
@@ -95,6 +95,7 @@ pub struct MockBlockRewardProvider;
 
 impl BlockRewardProvider<AccountId> for MockBlockRewardProvider {
     type Currency = Balances;
+    #[cfg(feature = "runtime-benchmarks")]
     fn deposit_stake(_: &AccountId, _: Balance) -> DispatchResult {
         Ok(())
     }

--- a/crates/bitcoin/src/address.rs
+++ b/crates/bitcoin/src/address.rs
@@ -102,7 +102,7 @@ impl Address {
         Address::P2PKH(H160::random())
     }
 
-    #[cfg(feature = "runtime-benchmarks")]
+    #[cfg(any(feature = "runtime-benchmarks", feature = "std"))]
     pub const fn dummy() -> Self {
         Address::P2PKH(H160([
             149, 83, 39, 14, 55, 21, 215, 67, 152, 46, 157, 24, 82, 192, 192, 150, 62, 190, 160, 90,
@@ -284,7 +284,7 @@ impl PublicKey {
         script
     }
 
-    #[cfg(feature = "runtime-benchmarks")]
+    #[cfg(any(feature = "runtime-benchmarks", feature = "std"))]
     pub const fn dummy() -> Self {
         PublicKey([
             2, 205, 114, 218, 156, 16, 235, 172, 106, 37, 18, 153, 202, 140, 176, 91, 207, 51, 187, 55, 18, 45, 222,

--- a/parachain/runtime/runtime-tests/src/relaychain/kusama_cross_chain_transfer.rs
+++ b/parachain/runtime/runtime-tests/src/relaychain/kusama_cross_chain_transfer.rs
@@ -622,6 +622,7 @@ fn register_kint_as_foreign_asset() {
         location: Some(MultiLocation::new(1, X2(Parachain(KINTSUGI_PARA_ID), GeneralKey(Token(KINT).encode()))).into()),
         additional: CustomMetadata {
             fee_per_second: 1_000_000_000_000,
+            coingecko_id: "kint-sugi".as_bytes().to_vec(),
         },
     };
     AssetRegistry::register_asset(Origin::root(), metadata, None).unwrap();

--- a/parachain/runtime/runtime-tests/src/relaychain/polkadot_cross_chain_transfer.rs
+++ b/parachain/runtime/runtime-tests/src/relaychain/polkadot_cross_chain_transfer.rs
@@ -696,6 +696,7 @@ fn register_intr_as_foreign_asset() {
         location: Some(MultiLocation::new(1, X2(Parachain(INTERLAY_PARA_ID), GeneralKey(Token(INTR).encode()))).into()),
         additional: CustomMetadata {
             fee_per_second: 1_000_000_000_000,
+            coingecko_id: "interlay".as_bytes().to_vec(),
         },
     };
     AssetRegistry::register_asset(Origin::root(), metadata, None).unwrap();

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -499,4 +499,5 @@ pub type ForeignAssetId = u32;
 #[derive(scale_info::TypeInfo, Encode, Decode, Clone, Eq, PartialEq, Debug)]
 pub struct CustomMetadata {
     pub fee_per_second: u128,
+    pub coingecko_id: Vec<u8>,
 }


### PR DESCRIPTION
I didn't add a migration on the assumption that there are no assets registered just yet.