### PR TITLE
refactor!: remove all Bitcoin parsing and use concrete types

### DIFF
--- a/crates/bitcoin/src/formatter.rs
+++ b/crates/bitcoin/src/formatter.rs
@@ -392,16 +392,15 @@ mod tests {
     #[test]
     fn test_format_block_header() {
         let hex_header = parser::tests::sample_block_header();
-        let raw_header = RawBlockHeader::from_hex(&hex_header).unwrap();
-        let parsed_header = parser::parse_block_header(&raw_header).unwrap();
-        assert_eq!(parsed_header.try_format().unwrap(), raw_header.as_bytes());
+        let parsed_header = BlockHeader::from_hex(&hex_header).unwrap();
+        assert_eq!(hex::encode(parsed_header.try_format().unwrap()), hex_header);
     }
 
     #[test]
     fn test_format_block_header_testnet() {
         let hex_header = "00000020b0b3d77b97015b519553423c96642b33ca534c50ecefd133640000000000000029a0a725684aeca24af83e3ba0a3e3ee56adfdf032d19e5acba6d0a262e1580ca354915fd4c8001ac42a7b3a".to_string();
-        let raw_header = RawBlockHeader::from_hex(&hex_header).unwrap();
-        let parsed_header = parser::parse_block_header(&raw_header).unwrap();
+        let raw_header = hex::decode(&hex_header).unwrap();
+        let parsed_header = BlockHeader::from_bytes(&raw_header).unwrap();
 
         assert_eq!(
             parsed_header,
@@ -410,7 +409,7 @@ mod tests {
                 target: U256::from_dec_str("1260618571951953247774709397757627131971305851995253681160192").unwrap(),
                 timestamp: 1603359907,
                 version: 536870912,
-                hash: raw_header.hash(),
+                hash: sha256d_le(&raw_header),
                 hash_prev_block: H256Le::from_hex_be(
                     "000000000000006433d1efec504c53ca332b64963c425395515b01977bd7b3b0"
                 ),
@@ -418,7 +417,7 @@ mod tests {
             }
         );
 
-        assert_eq!(parsed_header.try_format().unwrap(), raw_header.as_bytes());
+        assert_eq!(hex::encode(parsed_header.try_format().unwrap()), hex_header);
     }
 
     // taken from https://bitcoin.org/en/developer-reference#block-headers

--- a/crates/bitcoin/src/merkle.rs
+++ b/crates/bitcoin/src/merkle.rs
@@ -10,6 +10,8 @@ use crate::{
     utils::hash256_merkle_step,
     Error,
 };
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use sp_std::prelude::*;
 
 // Values taken from https://github.com/bitcoin/bitcoin/blob/78dae8caccd82cfbfd76557f1fb7d7557c7b5edb/src/consensus/consensus.h
@@ -24,7 +26,7 @@ const MAX_TRANSACTIONS_IN_PROOF: u32 = MAX_BLOCK_WEIGHT / MIN_TRANSACTION_WEIGHT
 pub struct MerkleTree;
 
 /// Stores the content of a merkle proof
-#[derive(Clone)]
+#[derive(Encode, Decode, TypeInfo, PartialEq, Default, Clone)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct MerkleProof {
     pub block_header: BlockHeader,

--- a/crates/bitcoin/src/script.rs
+++ b/crates/bitcoin/src/script.rs
@@ -1,11 +1,13 @@
 use crate::{formatter::Formattable, parser::extract_op_return_data, types::*, Error};
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use sp_std::{prelude::*, vec};
 
 #[cfg(feature = "std")]
 use codec::alloc::string::String;
 
 /// Bitcoin script
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Encode, Decode, TypeInfo, PartialEq, Debug, Clone)]
 pub struct Script {
     pub(crate) bytes: Vec<u8>,
 }

--- a/crates/bitcoin/src/types.rs
+++ b/crates/bitcoin/src/types.rs
@@ -7,14 +7,14 @@ pub use crate::merkle::MerkleProof;
 use crate::{
     formatter::{Formattable, TryFormattable},
     merkle::MerkleTree,
-    parser::{extract_address_hash_scriptsig, extract_address_hash_witness},
+    parser::{extract_address_hash_scriptsig, extract_address_hash_witness, parse_block_header},
     utils::{log2, reverse_endianness, sha256d_le},
     Address, Error, PublicKey, Script,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 pub use sp_core::{H160, H256, U256};
-use sp_std::{convert::TryFrom, prelude::*, vec};
+use sp_std::{prelude::*, vec};
 
 #[cfg(feature = "std")]
 use codec::alloc::string::String;
@@ -161,76 +161,6 @@ pub enum OpCode {
 
 /// Custom Types
 
-/// Bitcoin raw block header (80 bytes)
-#[derive(Encode, Decode, Copy, Clone, TypeInfo, MaxEncodedLen)]
-pub struct RawBlockHeader([u8; 80]);
-
-impl Default for RawBlockHeader {
-    fn default() -> Self {
-        Self([0; 80])
-    }
-}
-
-impl TryFrom<Vec<u8>> for RawBlockHeader {
-    type Error = Error;
-
-    fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
-        RawBlockHeader::from_bytes(v)
-    }
-}
-
-impl RawBlockHeader {
-    /// Returns a raw block header from a bytes slice
-    ///
-    /// # Arguments
-    ///
-    /// * `bytes` - A slice containing the header
-    pub fn from_bytes<B: AsRef<[u8]>>(bytes: B) -> Result<RawBlockHeader, Error> {
-        let slice = bytes.as_ref();
-        if slice.len() != 80 {
-            return Err(Error::InvalidHeaderSize);
-        }
-        let mut result = [0u8; 80];
-        result.copy_from_slice(slice);
-        Ok(RawBlockHeader(result))
-    }
-
-    /// Returns a raw block header from a bytes slice
-    ///
-    /// # Arguments
-    ///
-    /// * `bytes` - A slice containing the header
-    #[cfg(feature = "std")]
-    pub fn from_hex<T: AsRef<[u8]>>(hex_string: T) -> Result<RawBlockHeader, Error> {
-        let bytes = hex::decode(hex_string).map_err(|_e| Error::MalformedHeader)?;
-        Self::from_bytes(&bytes)
-    }
-
-    /// Returns the hash of the block header using Bitcoin's double sha256
-    pub fn hash(&self) -> H256Le {
-        sha256d_le(self.as_bytes())
-    }
-
-    /// Returns the block header as a slice
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl PartialEq for RawBlockHeader {
-    fn eq(&self, other: &Self) -> bool {
-        let self_bytes = &self.0[..];
-        let other_bytes = &other.0[..];
-        self_bytes == other_bytes
-    }
-}
-
-impl sp_std::fmt::Debug for RawBlockHeader {
-    fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
-        f.debug_list().entries(self.0.iter()).finish()
-    }
-}
-
 // Constants
 pub const P2PKH_SCRIPT_SIZE: u32 = 25;
 pub const P2SH_SCRIPT_SIZE: u32 = 23;
@@ -250,17 +180,62 @@ pub struct BlockHeader {
     pub target: U256,
     pub timestamp: u32,
     pub version: i32,
+    // TODO: remove hash
     pub hash: H256Le,
     pub hash_prev_block: H256Le,
     pub nonce: u32,
 }
 
 impl BlockHeader {
+    /// Returns the hash of the block header using Bitcoin's double sha256
+    pub fn hash(&self) -> Result<H256Le, Error> {
+        Ok(sha256d_le(&self.try_format()?))
+    }
+
+    pub fn ensure_version(&self) -> Result<(), Error> {
+        if self.version < 4 {
+            // as per bip65, we reject block versions less than 4. Note that the reason
+            // we can hardcode this, is that bitcoin switched to version 4 in december
+            // 2015, and the genesis of the bridge will never be set to a genesis from
+            // before that date.
+            // see https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki#spv-clients
+            Err(Error::InvalidBlockVersion)
+        } else {
+            Ok(())
+        }
+    }
+
     pub fn update_hash(&mut self) -> Result<H256Le, Error> {
-        let new_hash = sha256d_le(&self.try_format()?);
+        let new_hash = self.hash()?;
 
         self.hash = new_hash;
         Ok(self.hash)
+    }
+
+    /// Returns a block header from a bytes slice
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - A slice containing the header
+    pub fn from_bytes<B: AsRef<[u8]>>(bytes: B) -> Result<BlockHeader, Error> {
+        let slice = bytes.as_ref();
+        if slice.len() != 80 {
+            return Err(Error::InvalidHeaderSize);
+        }
+        let mut result = [0u8; 80];
+        result.copy_from_slice(slice);
+        parse_block_header(&result)
+    }
+
+    /// Returns a block header from a hex string
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - A string containing the header
+    #[cfg(feature = "std")]
+    pub fn from_hex<T: AsRef<[u8]>>(data: T) -> Result<BlockHeader, Error> {
+        let bytes = hex::decode(data).map_err(|_e| Error::MalformedHeader)?;
+        Self::from_bytes(&bytes)
     }
 }
 

--- a/crates/bitcoin/src/types.rs
+++ b/crates/bitcoin/src/types.rs
@@ -264,7 +264,7 @@ impl BlockHeader {
     }
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Encode, Decode, TypeInfo, PartialEq, Clone, Debug)]
 pub enum TransactionInputSource {
     /// Spending from transaction with the given hash, from output with the given index
     FromOutput(H256Le, u32),
@@ -273,7 +273,7 @@ pub enum TransactionInputSource {
 }
 
 /// Bitcoin transaction input
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Encode, Decode, TypeInfo, PartialEq, Clone, Debug)]
 pub struct TransactionInput {
     pub source: TransactionInputSource,
     pub script: Vec<u8>,
@@ -302,7 +302,7 @@ impl TransactionInput {
 pub type Value = i64;
 
 /// Bitcoin transaction output
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Encode, Decode, TypeInfo, PartialEq, Debug, Clone)]
 pub struct TransactionOutput {
     pub value: Value,
     pub script: Script,
@@ -330,7 +330,7 @@ impl TransactionOutput {
 
 /// Bitcoin transaction
 // Note: the `default` implementation is used only for testing code
-#[derive(PartialEq, Debug, Clone, Default)]
+#[derive(Encode, Decode, TypeInfo, Default, PartialEq, Debug, Clone)]
 pub struct Transaction {
     pub version: i32,
     pub inputs: Vec<TransactionInput>,
@@ -350,7 +350,7 @@ impl Transaction {
 }
 
 // https://en.bitcoin.it/wiki/NLockTime
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Encode, Decode, TypeInfo, PartialEq, Debug, Clone)]
 pub enum LockTime {
     /// time as unix timestamp
     Time(u32),

--- a/crates/btc-relay/src/tests.rs
+++ b/crates/btc-relay/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{ext, mock::*, types::*, BtcAddress, Error, DIFFICULTY_ADJUSTMENT_INT
 type Event = crate::Event<Test>;
 
 use crate::{Chains, ChainsIndex};
-use bitcoin::{formatter::TryFormattable, merkle::*, parser::*, types::*};
+use bitcoin::{merkle::*, parser::*, types::*};
 use frame_support::{assert_err, assert_ok};
 use mocktopus::mocking::*;
 use sp_std::{
@@ -865,7 +865,7 @@ fn test_verify_block_header_correct_retarget_decrease_succeeds() {
         // Compute new target returns target of submitted header (i.e., correct)
         BTCRelay::compute_new_target.mock_safe(move |_, _| MockResult::Return(Ok(curr_block_header.target)));
 
-        let block_header = BTCRelay::parse_raw_block_header(&retarget_headers[2]).unwrap();
+        let block_header = parse_block_header(&retarget_headers[2]).unwrap();
         assert_ok!(BTCRelay::verify_block_header(
             &block_header,
             prev_block_header_rich.block_height + 1,
@@ -983,18 +983,17 @@ fn test_verify_block_header_low_diff_fails() {
 #[test]
 fn test_validate_transaction_succeeds_with_payment() {
     run_test(|| {
-        let raw_tx = hex::decode(sample_accepted_transaction()).unwrap();
         let minimum_btc: i64 = 2500200000;
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
 
         let outputs = vec![sample_valid_payment_output()];
 
-        BTCRelay::parse_transaction.mock_safe(move |_| MockResult::Return(Ok(sample_transaction_parsed(&outputs))));
+        let transaction = sample_transaction_parsed(&outputs);
 
         assert_ok!(BTCRelay::validate_transaction(
             RuntimeOrigin::signed(3),
-            raw_tx,
+            transaction,
             minimum_btc,
             recipient_btc_address,
             None,
@@ -1005,7 +1004,6 @@ fn test_validate_transaction_succeeds_with_payment() {
 #[test]
 fn test_validate_transaction_succeeds_with_payment_and_op_return() {
     run_test(|| {
-        let raw_tx = hex::decode(sample_accepted_transaction()).unwrap();
         let minimum_btc: i64 = 2500200000;
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
@@ -1014,11 +1012,11 @@ fn test_validate_transaction_succeeds_with_payment_and_op_return() {
 
         let outputs = vec![sample_valid_payment_output(), sample_valid_data_output()];
 
-        BTCRelay::parse_transaction.mock_safe(move |_| MockResult::Return(Ok(sample_transaction_parsed(&outputs))));
+        let transaction = sample_transaction_parsed(&outputs);
 
         assert_ok!(BTCRelay::validate_transaction(
             RuntimeOrigin::signed(3),
-            raw_tx,
+            transaction,
             minimum_btc,
             recipient_btc_address,
             Some(H256::from_slice(&op_return_id))
@@ -1029,7 +1027,6 @@ fn test_validate_transaction_succeeds_with_payment_and_op_return() {
 #[test]
 fn test_validate_transaction_succeeds_with_op_return_and_payment() {
     run_test(|| {
-        let raw_tx = hex::decode(sample_accepted_transaction()).unwrap();
         let minimum_btc: i64 = 2500200000;
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
@@ -1038,11 +1035,11 @@ fn test_validate_transaction_succeeds_with_op_return_and_payment() {
 
         let outputs = vec![sample_valid_data_output(), sample_valid_payment_output()];
 
-        BTCRelay::parse_transaction.mock_safe(move |_| MockResult::Return(Ok(sample_transaction_parsed(&outputs))));
+        let transaction = sample_transaction_parsed(&outputs);
 
         assert_ok!(BTCRelay::validate_transaction(
             RuntimeOrigin::signed(3),
-            raw_tx,
+            transaction,
             minimum_btc,
             recipient_btc_address,
             Some(H256::from_slice(&op_return_id))
@@ -1053,7 +1050,6 @@ fn test_validate_transaction_succeeds_with_op_return_and_payment() {
 #[test]
 fn test_validate_transaction_succeeds_with_payment_and_refund_and_op_return() {
     run_test(|| {
-        let raw_tx = hex::decode(sample_accepted_transaction()).unwrap();
         let minimum_btc: i64 = 2500200000;
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
@@ -1066,11 +1062,11 @@ fn test_validate_transaction_succeeds_with_payment_and_refund_and_op_return() {
             sample_valid_data_output(),
         ];
 
-        BTCRelay::parse_transaction.mock_safe(move |_| MockResult::Return(Ok(sample_transaction_parsed(&outputs))));
+        let transaction = sample_transaction_parsed(&outputs);
 
         assert_ok!(BTCRelay::validate_transaction(
             RuntimeOrigin::signed(3),
-            raw_tx,
+            transaction,
             minimum_btc,
             recipient_btc_address,
             Some(H256::from_slice(&op_return_id))
@@ -1081,9 +1077,6 @@ fn test_validate_transaction_succeeds_with_payment_and_refund_and_op_return() {
 #[test]
 fn test_validate_transaction_invalid_no_outputs_fails() {
     run_test(|| {
-        // Simulate input (we mock the parsed transaction)
-        let raw_tx = hex::decode(sample_accepted_transaction()).unwrap();
-
         let minimum_btc: i64 = 2500200000;
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
@@ -1092,12 +1085,12 @@ fn test_validate_transaction_invalid_no_outputs_fails() {
         // missing required data output
         let outputs = vec![sample_valid_payment_output()];
 
-        BTCRelay::parse_transaction.mock_safe(move |_| MockResult::Return(Ok(sample_transaction_parsed(&outputs))));
+        let transaction = sample_transaction_parsed(&outputs);
 
         assert_err!(
             BTCRelay::validate_transaction(
                 RuntimeOrigin::signed(3),
-                raw_tx,
+                transaction,
                 minimum_btc,
                 recipient_btc_address,
                 Some(H256::from_slice(&op_return_id))
@@ -1110,9 +1103,6 @@ fn test_validate_transaction_invalid_no_outputs_fails() {
 #[test]
 fn test_validate_transaction_insufficient_payment_value_fails() {
     run_test(|| {
-        // Simulate input (we mock the parsed transaction)
-        let raw_tx = vec![0u8; 342];
-
         let minimum_btc: i64 = 2500200000;
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
@@ -1121,12 +1111,12 @@ fn test_validate_transaction_insufficient_payment_value_fails() {
 
         let outputs = vec![sample_insufficient_value_payment_output(), sample_valid_data_output()];
 
-        BTCRelay::parse_transaction.mock_safe(move |_| MockResult::Return(Ok(sample_transaction_parsed(&outputs))));
+        let transaction = sample_transaction_parsed(&outputs);
 
         assert_err!(
             BTCRelay::validate_transaction(
                 RuntimeOrigin::signed(3),
-                raw_tx,
+                transaction,
                 minimum_btc,
                 recipient_btc_address,
                 Some(H256::from_slice(&op_return_id))
@@ -1139,9 +1129,6 @@ fn test_validate_transaction_insufficient_payment_value_fails() {
 #[test]
 fn test_validate_transaction_wrong_recipient_fails() {
     run_test(|| {
-        // Simulate input (we mock the parsed transaction)
-        let raw_tx = vec![0u8; 342];
-
         let minimum_btc: i64 = 2500200000;
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
@@ -1154,12 +1141,12 @@ fn test_validate_transaction_wrong_recipient_fails() {
             sample_valid_data_output(),
         ];
 
-        BTCRelay::parse_transaction.mock_safe(move |_| MockResult::Return(Ok(sample_transaction_parsed(&outputs))));
+        let transaction = sample_transaction_parsed(&outputs);
 
         assert_err!(
             BTCRelay::validate_transaction(
                 RuntimeOrigin::signed(3),
-                raw_tx,
+                transaction,
                 minimum_btc,
                 recipient_btc_address,
                 Some(H256::from_slice(&op_return_id))
@@ -1172,9 +1159,6 @@ fn test_validate_transaction_wrong_recipient_fails() {
 #[test]
 fn test_validate_transaction_incorrect_opreturn_fails() {
     run_test(|| {
-        // Simulate input (we mock the parsed transaction)
-        let raw_tx = vec![0u8; 342];
-
         let minimum_btc: i64 = 2500200000;
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
@@ -1183,12 +1167,12 @@ fn test_validate_transaction_incorrect_opreturn_fails() {
 
         let outputs = vec![sample_valid_payment_output(), sample_incorrect_data_output()];
 
-        BTCRelay::parse_transaction.mock_safe(move |_| MockResult::Return(Ok(sample_transaction_parsed(&outputs))));
+        let transaction = sample_transaction_parsed(&outputs);
 
         assert_err!(
             BTCRelay::validate_transaction(
                 RuntimeOrigin::signed(3),
-                raw_tx,
+                transaction,
                 minimum_btc,
                 recipient_btc_address,
                 Some(H256::from_slice(&op_return_id))
@@ -1215,22 +1199,21 @@ fn test_verify_and_validate_transaction_succeeds() {
 
         // rest are example values -- not checked in this test.
         // let block_height = 0;
-        let raw_merkle_proof = vec![0u8; 100];
+        let merkle_proof = sample_merkle_proof();
         let confirmations = None;
         let minimum_btc: i64 = 0;
         let recipient_btc_address =
             BtcAddress::P2SH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
         let op_return_id =
             hex::decode("e5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb4675".to_owned()).unwrap();
-        BTCRelay::parse_merkle_proof.mock_safe(|_| MockResult::Return(Ok(sample_merkle_proof())));
         BTCRelay::_validate_transaction.mock_safe(move |_, _, _, _| MockResult::Return(Ok(())));
         BTCRelay::_verify_transaction_inclusion.mock_safe(move |_, _, _| MockResult::Return(Ok(())));
 
         assert_ok!(BTCRelay::verify_and_validate_transaction(
             RuntimeOrigin::signed(3),
-            raw_merkle_proof,
+            merkle_proof,
             confirmations,
-            raw_tx,
+            transaction,
             minimum_btc,
             recipient_btc_address,
             Some(H256::from_slice(&op_return_id))
@@ -1246,12 +1229,10 @@ fn test_verify_transaction_inclusion_succeeds() {
         let start = 10;
         let main_chain_height = 300;
         let fork_chain_height = 280;
-        // Random init since we mock this
-        let raw_merkle_proof = vec![0u8; 100];
         let confirmations = None;
         let rich_block_header = sample_rich_tx_block_header(chain_id, main_chain_height);
 
-        let proof = sample_merkle_proof();
+        let merkle_proof = sample_merkle_proof();
         let proof_result = sample_valid_proof_result();
 
         let main = get_empty_block_chain_from_chain_id_and_height(chain_id, start, main_chain_height);
@@ -1269,7 +1250,6 @@ fn test_verify_transaction_inclusion_succeeds() {
 
         BTCRelay::get_best_block_height.mock_safe(move || MockResult::Return(main_chain_height));
 
-        BTCRelay::parse_merkle_proof.mock_safe(move |_| MockResult::Return(Ok(proof.clone())));
         BTCRelay::verify_merkle_proof.mock_safe(move |_| MockResult::Return(Ok(proof_result)));
 
         BTCRelay::get_block_header_from_hash.mock_safe(move |_| MockResult::Return(Ok(rich_block_header)));
@@ -1281,7 +1261,7 @@ fn test_verify_transaction_inclusion_succeeds() {
         assert_ok!(BTCRelay::verify_transaction_inclusion(
             RuntimeOrigin::signed(3),
             proof_result.transaction_hash,
-            raw_merkle_proof,
+            merkle_proof,
             confirmations
         ));
     });
@@ -1293,12 +1273,10 @@ fn test_verify_transaction_inclusion_empty_fork_succeeds() {
         let chain_id = 0;
         let start = 10;
         let main_chain_height = 300;
-        // Random init since we mock this
-        let raw_merkle_proof = vec![0u8; 100];
         let confirmations = None;
         let rich_block_header = sample_rich_tx_block_header(chain_id, main_chain_height);
 
-        let proof = sample_merkle_proof();
+        let merkle_proof = sample_merkle_proof();
         let proof_result = sample_valid_proof_result();
 
         let main = get_empty_block_chain_from_chain_id_and_height(chain_id, start, main_chain_height);
@@ -1313,7 +1291,6 @@ fn test_verify_transaction_inclusion_empty_fork_succeeds() {
 
         BTCRelay::get_best_block_height.mock_safe(move || MockResult::Return(main_chain_height));
 
-        BTCRelay::parse_merkle_proof.mock_safe(move |_| MockResult::Return(Ok(proof.clone())));
         BTCRelay::verify_merkle_proof.mock_safe(move |_| MockResult::Return(Ok(proof_result)));
 
         BTCRelay::get_block_header_from_hash.mock_safe(move |_| MockResult::Return(Ok(rich_block_header)));
@@ -1325,7 +1302,7 @@ fn test_verify_transaction_inclusion_empty_fork_succeeds() {
         assert_ok!(BTCRelay::verify_transaction_inclusion(
             RuntimeOrigin::signed(3),
             proof_result.transaction_hash,
-            raw_merkle_proof,
+            merkle_proof,
             confirmations,
         ));
     });
@@ -1339,8 +1316,6 @@ fn test_verify_transaction_inclusion_invalid_tx_id_fails() {
         let start = 10;
         let main_chain_height = 300;
         let fork_chain_height = 280;
-        // Random init since we mock this
-        let raw_merkle_proof = vec![0u8; 100];
         let confirmations = None;
         let rich_block_header = sample_rich_tx_block_header(chain_id, main_chain_height);
 
@@ -1349,7 +1324,7 @@ fn test_verify_transaction_inclusion_invalid_tx_id_fails() {
             &hex::decode("0000000000000000000000000000000000000000000000000000000000000000".to_owned()).unwrap(),
         );
 
-        let proof = sample_merkle_proof();
+        let merkle_proof = sample_merkle_proof();
         let proof_result = sample_valid_proof_result();
 
         let main = get_empty_block_chain_from_chain_id_and_height(chain_id, start, main_chain_height);
@@ -1367,7 +1342,6 @@ fn test_verify_transaction_inclusion_invalid_tx_id_fails() {
 
         BTCRelay::get_best_block_height.mock_safe(move || MockResult::Return(main_chain_height));
 
-        BTCRelay::parse_merkle_proof.mock_safe(move |_| MockResult::Return(Ok(proof.clone())));
         BTCRelay::verify_merkle_proof.mock_safe(move |_| MockResult::Return(Ok(proof_result)));
 
         BTCRelay::get_block_header_from_hash.mock_safe(move |_| MockResult::Return(Ok(rich_block_header)));
@@ -1380,7 +1354,7 @@ fn test_verify_transaction_inclusion_invalid_tx_id_fails() {
             BTCRelay::verify_transaction_inclusion(
                 RuntimeOrigin::signed(3),
                 invalid_tx_id,
-                raw_merkle_proof,
+                merkle_proof,
                 confirmations,
             ),
             TestError::InvalidTxid
@@ -1396,8 +1370,6 @@ fn test_verify_transaction_inclusion_invalid_merkle_root_fails() {
         let start = 10;
         let main_chain_height = 300;
         let fork_chain_height = 280;
-        // Random init since we mock this
-        let raw_merkle_proof = vec![0u8; 100];
         let confirmations = None;
         let mut rich_block_header = sample_rich_tx_block_header(chain_id, main_chain_height);
 
@@ -1407,7 +1379,7 @@ fn test_verify_transaction_inclusion_invalid_merkle_root_fails() {
         );
         rich_block_header.block_header.merkle_root = invalid_merkle_root;
 
-        let proof = sample_merkle_proof();
+        let merkle_proof = sample_merkle_proof();
         let proof_result = sample_valid_proof_result();
 
         let main = get_empty_block_chain_from_chain_id_and_height(chain_id, start, main_chain_height);
@@ -1425,8 +1397,6 @@ fn test_verify_transaction_inclusion_invalid_merkle_root_fails() {
 
         BTCRelay::get_best_block_height.mock_safe(move || MockResult::Return(main_chain_height));
 
-        BTCRelay::parse_merkle_proof.mock_safe(move |_| MockResult::Return(Ok(proof.clone())));
-
         BTCRelay::get_block_header_from_hash.mock_safe(move |_| MockResult::Return(Ok(rich_block_header)));
 
         BTCRelay::check_bitcoin_confirmations.mock_safe(|_, _, _| MockResult::Return(Ok(())));
@@ -1437,7 +1407,7 @@ fn test_verify_transaction_inclusion_invalid_merkle_root_fails() {
             BTCRelay::verify_transaction_inclusion(
                 RuntimeOrigin::signed(3),
                 proof_result.transaction_hash,
-                raw_merkle_proof,
+                merkle_proof,
                 confirmations,
             ),
             TestError::InvalidMerkleProof
@@ -1450,15 +1420,14 @@ fn test_verify_transaction_inclusion_fails_with_ongoing_fork() {
     run_test(|| {
         BTCRelay::get_chain_id_from_position.mock_safe(|_| MockResult::Return(Ok(1)));
         BTCRelay::get_block_chain_from_id.mock_safe(|_| MockResult::Return(Ok(BlockChain::default())));
-        BTCRelay::parse_merkle_proof.mock_safe(|_| MockResult::Return(Ok(sample_merkle_proof())));
         BTCRelay::verify_merkle_proof.mock_safe(|_| MockResult::Return(Ok(sample_valid_proof_result())));
 
         let tx_id = sample_valid_proof_result().transaction_hash;
-        let raw_merkle_proof = vec![0u8; 100];
+        let merkle_proof = sample_merkle_proof();
         let confirmations = None;
 
         assert_err!(
-            BTCRelay::verify_transaction_inclusion(RuntimeOrigin::signed(3), tx_id, raw_merkle_proof, confirmations,),
+            BTCRelay::verify_transaction_inclusion(RuntimeOrigin::signed(3), tx_id, merkle_proof, confirmations,),
             TestError::OngoingFork
         );
     });
@@ -1469,11 +1438,11 @@ fn test_get_and_verify_issue_payment_with_tx_containing_taproot() {
     run_test(|| {
         let raw_tx = "010000000001013413e41f47eecad702082578c35a2925217056fd0a837b22f1a205fe178a010d0500000000ffffffff19771000000000000017a91415f691c1905082c300362d48540846c30855162d877a1000000000000022512038234fa3e3ca718dfadfb540c320180e68798e67e0a9d4f10d98ea33d37caf047a100000000000001976a914d73838271ee26471aa3640915ed7274b49435b6688acee2000000000000016001470eab26ae0074a58802acc7c38cd9941619c408d14250000000000001976a91479ef95650e8284c3be439d888cf2ee2d1d8ef63088ac3129000000000000160014a558dd2db8167e069f580da2482a9b73dc4f5960217f0000000000001976a91409f3607112083fb1ffe3718214a8e5d5eb0da46188ac04a50000000000001600149215c14609d581aacaa54f629e823cc8abd17ee6c7cd00000000000017a9146da59c9a54a5465402884712bbbe140bc68a4f218728f700000000000017a914ed99cbd06b43b4e3741d1457f7af7b24c2e8d12487ae380100000000001976a91448296f6f29c497f59193ab4e7def5f2e03ef2f9988ac654901000000000017a914ba997376b5daaa3707aefdf30cc09745b579df2187a6a301000000000017a914ffed3c6e71adc2b73939d6951f4655ed1432909b87ec9202000000000017a9147759a1bffe2acca168afdb5b106250b02a703b2887d63603000000000016001439fef3095e8a3bce11ce471aa602bf3e3609d8ddae3703000000000017a914ea0d18bbd804d17a1f2f07ed9aa1670721777d2287cd370300000000001976a914bcc6bcffe584761176d8f510896e882f838208d988ac1d3803000000000016001470eb59ad925fdec71ca0ec50cf7c6b9bbe8dc7592f380300000000001976a91447eb6c94d7b2ac0c11eb3957c0844d333e21d02e88ac724803000000000016001470eb59ad925fdec71ca0ec50cf7c6b9bbe8dc759692e050000000000160014ae26178c1a9b4adb6f24f047fa119e034205900c381b10000000000017a914c9e20b0d7e46d07a878585955ca377db833d181587d32b20000000000017a914bbfcd0b601046e1656ba9b74a98ee8d362d5b63687402f200000000000160014ca146a720a30ca404e979df59d3ddca039e8fd58f22fea0000000000220020935f3eb059cd94bd307e6378bd590724f361f0316fd0964eb5952f274dfb7b4f0400483045022100c9fc44a423e31fc792f5d255ae09ffdc0b224cb70fcebacd52183ce2813ba11d022046c8530230f644be4a05f25bd6a2264b99afc7e3e38531d4bde12d477d03f18001473044022027f50b14154123b173286db76e189a32973a13b0b4ca425329533229cf7f8d9a02202cea81a657ee654c63ab4a01a741931378abae036435a1d695622216596d9e27016952210257bf4070df9735de32305f3bc25320d331edb10c662423e06cd1e50bc58d8fa7210246454540c4e36ba6a481347d0194ffe476640289aecfd2d3f3db1328415b9a5c210248e0a3385d6f744ae81779e10f8ccafbbed7d44debf08a2b0d5250e2f0a0e84853aef0210b00";
         let tx_bytes = hex::decode(&raw_tx).unwrap();
-        let transaction = BTCRelay::parse_transaction(&tx_bytes).unwrap();
+        let transaction = parse_transaction(&tx_bytes).unwrap();
 
         let raw_proof = "0000402007abe6919ca547e5a9ffe0a11936feef61cb59e7b1f703000000000000000000a53fd3336aa8a18ea00d4127ddb4f4c8d602eee44e271191ee957c257d6b28fc104c4362c0400a17783168d59f0a00000d20a74fa5c909996400a1eaf8ccb08a1fe93f125d260bdbe85f6c46a8ceb0135825c9767aea6bd8d7534a4dcb550332a174a3532aca52665e621c23504d020547dbaa46c7c8fd72b89d3b7dbe1f4f7ca977f3227ad9ce47fc725eb166324662ffdf6b1c856c7a4ec042017fd6c4b10b7b7405d35d2334389b1ea7455f3d94153b3ecfcbaea201e40fdfde250f6a810857bf3ce25af03521a417f44f038e48d7443c46d8574331f1e393ac0c47700544235de90786fca8b6f6d6ce4dce28eabfe82afdf11f4b31ae5209384e56cfc2e103a28f62cd5a269323966a3e29210276fd3fad24c0a2a832ba276dd036b0f50d1d24b12ad239812ffd64cc318f6c28a1a98295da3e28cc22959235808a432225dc101b3c5d545067c8c6553ea89675c7652d914146f9851d78c52802e5dffcbb77ae2f90478f507811c2cece1c2e7b08e5978b8384e6bdf73573b0033a6c2da1494abb5e0b760a00583c106cfdb9b658cecd0d11f35385dbbeb5546bda1144978c674a589e1991e8610aa5ef7480abff3e82bd5bcb91174fd1e896bab2746c9f5fed3faad55d043c1822e7a98f8b8862a104d7ae0500";
         let proof_bytes = hex::decode(&raw_proof).unwrap();
-        let merkle_proof = BTCRelay::parse_merkle_proof(&proof_bytes).unwrap();
+        let merkle_proof = MerkleProof::parse(&proof_bytes).unwrap();
 
         // check the last output address
         let raw_address = "935f3eb059cd94bd307e6378bd590724f361f0316fd0964eb5952f274dfb7b4f";
@@ -1622,21 +1591,17 @@ fn get_chain_from_id_ok() {
 fn store_generated_block_headers() {
     let target = U256::from(2).pow(254.into());
     let miner = BtcAddress::P2PKH(H160::from_str(&"66c7060feb882664ae62ffad0051fe843e318e85").unwrap());
-    let get_header = |block: &Block| RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();
 
     run_test(|| {
         let mut last_block = BlockBuilder::new().with_coinbase(&miner, 50, 0).mine(target).unwrap();
-        let last_block_header = BTCRelay::parse_raw_block_header(&get_header(&last_block)).unwrap();
-        assert_ok!(BTCRelay::_initialize(3, last_block_header, 0));
+        assert_ok!(BTCRelay::_initialize(3, last_block.header, 0));
         for i in 1..20 {
             last_block = BlockBuilder::new()
                 .with_coinbase(&miner, 50, i)
                 .with_previous_hash(last_block.header.hash)
                 .mine(target)
                 .unwrap();
-            let raw_header = get_header(&last_block);
-            let block_header = parse_block_header(&raw_header).unwrap();
-            assert_ok!(BTCRelay::_store_block_header(&3, block_header));
+            assert_ok!(BTCRelay::_store_block_header(&3, last_block.header));
         }
         let main_chain: BlockChain = BTCRelay::get_block_chain_from_id(crate::MAIN_CHAIN_ID).unwrap();
         assert_eq!(main_chain.start_height, 0);
@@ -2143,10 +2108,6 @@ fn sample_retarget_interval_decrease() -> [RawBlockHeader; 3] {
     let curr_header = RawBlockHeader::from_hex("00000020".to_owned() + "6b05bd2c4a06b3d8503a033c2593396a25a79e1dcadb140000000000000000001b08df3d42cd9a38d8b66adf9dc5eb464f503633bd861085ffff723634531596a1a24e5c35683017bf67b72a").unwrap();
 
     [last_retarget_header, prev_block_header, curr_header]
-}
-
-fn sample_accepted_transaction() -> String {
-    "020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0502cb000101ffffffff02400606950000000017a91466c7060feb882664ae62ffad0051fe843e318e85870000000000000000266a24aa21a9ede5c17d15b8b1fa2811b7e6da66ffa5e1aaa05922c69068bf90cd585b95bb46750120000000000000000000000000000000000000000000000000000000000000000000000000".to_owned()
 }
 
 fn sample_rich_tx_block_header(chain_id: u32, block_height: u32) -> RichBlockHeader<BlockNumber> {

--- a/crates/issue/src/ext.rs
+++ b/crates/issue/src/ext.rs
@@ -24,14 +24,6 @@ pub(crate) mod btc_relay {
         <btc_relay::Pallet<T>>::is_fully_initialized()
     }
 
-    pub fn parse_transaction<T: btc_relay::Config>(raw_tx: &[u8]) -> Result<Transaction, DispatchError> {
-        <btc_relay::Pallet<T>>::parse_transaction(raw_tx)
-    }
-
-    pub fn parse_merkle_proof<T: btc_relay::Config>(raw_merkle_proof: &[u8]) -> Result<MerkleProof, DispatchError> {
-        <btc_relay::Pallet<T>>::parse_merkle_proof(raw_merkle_proof)
-    }
-
     pub fn has_request_expired<T: crate::Config>(
         opentime: T::BlockNumber,
         btc_open_height: u32,

--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -30,6 +30,7 @@ pub mod types;
 pub use crate::types::{DefaultIssueRequest, IssueRequest, IssueRequestStatus};
 
 use crate::types::{BalanceOf, DefaultVaultId, Version};
+use bitcoin::types::{MerkleProof, Transaction};
 use btc_relay::{BtcAddress, BtcPublicKey};
 use currency::Amount;
 use frame_support::{dispatch::DispatchError, ensure, traits::Get, transactional, PalletId};
@@ -225,11 +226,11 @@ pub mod pallet {
         pub fn execute_issue(
             origin: OriginFor<T>,
             issue_id: H256,
-            merkle_proof: Vec<u8>,
-            raw_tx: Vec<u8>,
+            merkle_proof: MerkleProof,
+            transaction: Transaction,
         ) -> DispatchResultWithPostInfo {
             let executor = ensure_signed(origin)?;
-            Self::_execute_issue(executor, issue_id, merkle_proof, raw_tx)?;
+            Self::_execute_issue(executor, issue_id, merkle_proof, transaction)?;
             Ok(().into())
         }
 
@@ -355,15 +356,13 @@ impl<T: Config> Pallet<T> {
     fn _execute_issue(
         executor: T::AccountId,
         issue_id: H256,
-        raw_merkle_proof: Vec<u8>,
-        raw_tx: Vec<u8>,
+        merkle_proof: MerkleProof,
+        transaction: Transaction,
     ) -> Result<(), DispatchError> {
         let mut issue = Self::get_issue_request_from_id(&issue_id)?;
         // allow anyone to complete issue request
         let requester = issue.requester.clone();
 
-        let transaction = ext::btc_relay::parse_transaction::<T>(&raw_tx)?;
-        let merkle_proof = ext::btc_relay::parse_merkle_proof::<T>(&raw_merkle_proof)?;
         let amount_transferred = ext::btc_relay::get_and_verify_issue_payment::<T, BalanceOf<T>>(
             merkle_proof,
             transaction,

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -1,6 +1,5 @@
 use crate::{ext, mock::*, Event, IssueRequest};
 
-use bitcoin::types::{MerkleProof, Transaction};
 use btc_relay::{BtcAddress, BtcPublicKey};
 use currency::Amount;
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
@@ -11,15 +10,6 @@ use sp_arithmetic::FixedU128;
 use sp_core::H256;
 use sp_runtime::traits::One;
 use vault_registry::{DefaultVault, DefaultVaultId, Vault, VaultStatus};
-
-fn dummy_merkle_proof() -> MerkleProof {
-    MerkleProof {
-        block_header: Default::default(),
-        transactions_count: 0,
-        flag_bits: vec![],
-        hashes: vec![],
-    }
-}
 
 fn griefing(amount: u128) -> Amount<Test> {
     Amount::new(amount, DEFAULT_NATIVE_CURRENCY)
@@ -64,7 +54,7 @@ fn request_issue_ok_with_address(
 }
 
 fn execute_issue(origin: AccountId, issue_id: &H256) -> Result<(), DispatchError> {
-    Issue::_execute_issue(origin, *issue_id, vec![0u8; 100], vec![0u8; 100])
+    Issue::_execute_issue(origin, *issue_id, Default::default(), Default::default())
 }
 
 fn cancel_issue(origin: AccountId, issue_id: &H256) -> Result<(), DispatchError> {
@@ -166,8 +156,6 @@ fn setup_execute(
     let issue_id = request_issue_ok(USER, issue_amount, VAULT);
     <security::Pallet<Test>>::set_active_block_number(5);
 
-    ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
-    ext::btc_relay::parse_transaction::<Test>.mock_safe(|_| MockResult::Return(Ok(Transaction::default())));
     ext::btc_relay::get_and_verify_issue_payment::<Test, Balance>
         .mock_safe(move |_, _, _| MockResult::Return(Ok(btc_transferred)));
 

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -1,10 +1,6 @@
 use super::*;
-use bitcoin::{
-    formatter::{Formattable, TryFormattable},
-    types::{
-        BlockBuilder, RawBlockHeader, TransactionBuilder, TransactionInputBuilder, TransactionInputSource,
-        TransactionOutput,
-    },
+use bitcoin::types::{
+    BlockBuilder, TransactionBuilder, TransactionInputBuilder, TransactionInputSource, TransactionOutput,
 };
 use btc_relay::{BtcAddress, BtcPublicKey};
 use currency::getters::{get_relay_chain_currency_id as get_collateral_currency_id, *};
@@ -94,11 +90,8 @@ fn mine_blocks<T: crate::Config>(end_height: u32) {
         .mine(U256::from(2).pow(254.into()))
         .unwrap();
 
-    let raw_block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();
-    let block_header = BtcRelay::<T>::parse_raw_block_header(&raw_block_header).unwrap();
-
     Security::<T>::set_active_block_number(1u32.into());
-    BtcRelay::<T>::_initialize(relayer_id.clone(), block_header, height).unwrap();
+    BtcRelay::<T>::_initialize(relayer_id.clone(), block.header, height).unwrap();
 
     let transaction = TransactionBuilder::new()
         .with_version(2)
@@ -130,10 +123,7 @@ fn mine_blocks<T: crate::Config>(end_height: u32) {
             .unwrap();
         prev_hash = block.header.hash;
 
-        let raw_block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();
-        let block_header = BtcRelay::<T>::parse_raw_block_header(&raw_block_header).unwrap();
-
-        BtcRelay::<T>::_store_block_header(&relayer_id, block_header).unwrap();
+        BtcRelay::<T>::_store_block_header(&relayer_id, block.header).unwrap();
     }
 }
 
@@ -255,11 +245,9 @@ benchmarks! {
             .mine(U256::from(2).pow(254.into())).unwrap();
 
         let block_hash = block.header.hash;
-        let raw_block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();
-        let block_header = BtcRelay::<T>::parse_raw_block_header(&raw_block_header).unwrap();
 
         Security::<T>::set_active_block_number(1u32.into());
-        BtcRelay::<T>::_initialize(relayer_id.clone(), block_header, height).unwrap();
+        BtcRelay::<T>::_initialize(relayer_id.clone(), block.header, height).unwrap();
 
         let value = 0;
         let transaction = TransactionBuilder::new()
@@ -293,20 +281,19 @@ benchmarks! {
             .mine(U256::from(2).pow(254.into())).unwrap();
 
         let tx_id = transaction.tx_id();
-        let proof = block.merkle_proof(&[tx_id]).unwrap().try_format().unwrap();
-        let raw_tx = transaction.format_with(true);
+        let merkle_proof = block.merkle_proof(&[tx_id]).unwrap();
 
-        let raw_block_header = RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).unwrap();
-        let block_header = BtcRelay::<T>::parse_raw_block_header(&raw_block_header).unwrap();
-
-        BtcRelay::<T>::_store_block_header(&relayer_id, block_header).unwrap();
-        Security::<T>::set_active_block_number(Security::<T>::active_block_number() +
-BtcRelay::<T>::parachain_confirmations() + 1u32.into());
+        BtcRelay::<T>::_store_block_header(&relayer_id, block.header).unwrap();
+        Security::<T>::set_active_block_number(
+            Security::<T>::active_block_number() +
+            BtcRelay::<T>::parachain_confirmations() +
+            1u32.into()
+        );
 
         assert_ok!(Oracle::<T>::_set_exchange_rate(get_collateral_currency_id::<T>(),
             UnsignedFixedPoint::<T>::one()
         ));
-    }: _(RawOrigin::Signed(vault_id.account_id.clone()), redeem_id, proof, raw_tx)
+    }: _(RawOrigin::Signed(vault_id.account_id.clone()), redeem_id, merkle_proof, transaction)
 
     cancel_redeem_reimburse {
         let origin: T::AccountId = account("Origin", 0, 0);

--- a/crates/redeem/src/ext.rs
+++ b/crates/redeem/src/ext.rs
@@ -29,14 +29,6 @@ pub(crate) mod btc_relay {
         <btc_relay::Pallet<T>>::get_best_block_height()
     }
 
-    pub fn parse_transaction<T: btc_relay::Config>(raw_tx: &[u8]) -> Result<Transaction, DispatchError> {
-        <btc_relay::Pallet<T>>::parse_transaction(raw_tx)
-    }
-
-    pub fn parse_merkle_proof<T: btc_relay::Config>(raw_merkle_proof: &[u8]) -> Result<MerkleProof, DispatchError> {
-        <btc_relay::Pallet<T>>::parse_merkle_proof(raw_merkle_proof)
-    }
-
     pub fn has_request_expired<T: crate::Config>(
         opentime: T::BlockNumber,
         btc_open_height: u32,

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -1,7 +1,6 @@
 use crate::{ext, mock::*};
 
 use crate::types::{RedeemRequest, RedeemRequestStatus};
-use bitcoin::types::{MerkleProof, Transaction};
 use btc_relay::BtcAddress;
 use currency::Amount;
 use frame_support::{assert_err, assert_noop, assert_ok, dispatch::DispatchError};
@@ -34,15 +33,6 @@ macro_rules! assert_emitted {
             $times
         );
     };
-}
-
-fn dummy_merkle_proof() -> MerkleProof {
-    MerkleProof {
-        block_header: Default::default(),
-        transactions_count: 0,
-        flag_bits: vec![],
-        hashes: vec![],
-    }
 }
 
 fn inject_redeem_request(key: H256, value: RedeemRequest<AccountId, BlockNumber, Balance, CurrencyId>) {
@@ -376,8 +366,8 @@ fn test_execute_redeem_fails_with_redeem_id_not_found() {
             Redeem::execute_redeem(
                 RuntimeOrigin::signed(VAULT.account_id),
                 H256([0u8; 32]),
-                Vec::default(),
-                Vec::default()
+                Default::default(),
+                Default::default()
             ),
             TestError::RedeemIdNotFound
         );
@@ -405,8 +395,6 @@ fn test_execute_redeem_succeeds_with_another_account() {
                 liquidated_collateral: 0,
             },
         );
-        ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
-        ext::btc_relay::parse_transaction::<Test>.mock_safe(|_| MockResult::Return(Ok(Transaction::default())));
         ext::btc_relay::verify_and_validate_op_return_transaction::<Test, Balance>
             .mock_safe(|_, _, _, _, _| MockResult::Return(Ok(())));
 
@@ -447,8 +435,8 @@ fn test_execute_redeem_succeeds_with_another_account() {
         assert_ok!(Redeem::execute_redeem(
             RuntimeOrigin::signed(USER),
             H256([0u8; 32]),
-            Vec::default(),
-            Vec::default()
+            Default::default(),
+            Default::default()
         ));
         assert_emitted!(Event::ExecuteRedeem {
             redeem_id: H256([0; 32]),
@@ -486,8 +474,6 @@ fn test_execute_redeem_succeeds() {
                 liquidated_collateral: 0,
             },
         );
-        ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
-        ext::btc_relay::parse_transaction::<Test>.mock_safe(|_| MockResult::Return(Ok(Transaction::default())));
         ext::btc_relay::verify_and_validate_op_return_transaction::<Test, Balance>
             .mock_safe(|_, _, _, _, _| MockResult::Return(Ok(())));
 
@@ -528,8 +514,8 @@ fn test_execute_redeem_succeeds() {
         assert_ok!(Redeem::execute_redeem(
             RuntimeOrigin::signed(VAULT.account_id),
             H256([0u8; 32]),
-            Vec::default(),
-            Vec::default()
+            Default::default(),
+            Default::default()
         ));
         assert_emitted!(Event::ExecuteRedeem {
             redeem_id: H256([0; 32]),
@@ -847,8 +833,6 @@ mod spec_based_tests {
                     ..default_vault()
                 },
             );
-            ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
-            ext::btc_relay::parse_transaction::<Test>.mock_safe(|_| MockResult::Return(Ok(Transaction::default())));
             ext::btc_relay::verify_and_validate_op_return_transaction::<Test, Balance>
                 .mock_safe(|_, _, _, _, _| MockResult::Return(Ok(())));
 
@@ -885,8 +869,8 @@ mod spec_based_tests {
             assert_ok!(Redeem::execute_redeem(
                 RuntimeOrigin::signed(USER),
                 H256([0u8; 32]),
-                Vec::default(),
-                Vec::default()
+                Default::default(),
+                Default::default()
             ));
             assert_emitted!(Event::ExecuteRedeem {
                 redeem_id: H256([0; 32]),

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -29,14 +29,6 @@ pub(crate) mod btc_relay {
         <btc_relay::Pallet<T>>::get_best_block_height()
     }
 
-    pub fn parse_transaction<T: btc_relay::Config>(raw_tx: &[u8]) -> Result<Transaction, DispatchError> {
-        <btc_relay::Pallet<T>>::parse_transaction(raw_tx)
-    }
-
-    pub fn parse_merkle_proof<T: btc_relay::Config>(raw_merkle_proof: &[u8]) -> Result<MerkleProof, DispatchError> {
-        <btc_relay::Pallet<T>>::parse_merkle_proof(raw_merkle_proof)
-    }
-
     pub fn has_request_expired<T: crate::Config>(
         opentime: T::BlockNumber,
         btc_open_height: u32,

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -3,7 +3,6 @@ use crate::{
     *,
 };
 
-use bitcoin::types::{MerkleProof, Transaction};
 use btc_relay::BtcAddress;
 use currency::Amount;
 use frame_support::{assert_err, assert_ok};
@@ -11,15 +10,6 @@ use mocktopus::mocking::*;
 use sp_core::H256;
 
 type Event = crate::Event<Test>;
-
-fn dummy_merkle_proof() -> MerkleProof {
-    MerkleProof {
-        block_header: Default::default(),
-        transactions_count: 0,
-        flag_bits: vec![],
-        hashes: vec![],
-    }
-}
 
 macro_rules! assert_event_matches {
     ($( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
@@ -198,8 +188,6 @@ mod execute_replace_test {
 
         Replace::replace_period.mock_safe(|| MockResult::Return(20));
         ext::btc_relay::has_request_expired::<Test>.mock_safe(|_, _, _| MockResult::Return(Ok(false)));
-        ext::btc_relay::parse_merkle_proof::<Test>.mock_safe(|_| MockResult::Return(Ok(dummy_merkle_proof())));
-        ext::btc_relay::parse_transaction::<Test>.mock_safe(|_| MockResult::Return(Ok(Transaction::default())));
         ext::btc_relay::verify_and_validate_op_return_transaction::<Test, Balance>
             .mock_safe(|_, _, _, _, _| MockResult::Return(Ok(())));
         ext::vault_registry::replace_tokens::<Test>.mock_safe(|_, _, _, _| MockResult::Return(Ok(())));
@@ -214,7 +202,11 @@ mod execute_replace_test {
     fn test_execute_replace_succeeds() {
         run_test(|| {
             setup_mocks();
-            assert_ok!(Replace::_execute_replace(H256::zero(), Vec::new(), Vec::new()));
+            assert_ok!(Replace::_execute_replace(
+                H256::zero(),
+                Default::default(),
+                Default::default()
+            ));
             assert_event_matches!(Event::ExecuteReplace {
                 replace_id: _,
                 old_vault_id: OLD_VAULT,
@@ -236,7 +228,11 @@ mod execute_replace_test {
                 replace
             });
 
-            assert_ok!(Replace::_execute_replace(H256::zero(), Vec::new(), Vec::new()));
+            assert_ok!(Replace::_execute_replace(
+                H256::zero(),
+                Default::default(),
+                Default::default()
+            ));
             assert_event_matches!(Event::ExecuteReplace {
                 replace_id: _,
                 old_vault_id: OLD_VAULT,

--- a/standalone/runtime/tests/bitcoin_data.rs
+++ b/standalone/runtime/tests/bitcoin_data.rs
@@ -1,7 +1,4 @@
-use bitcoin::{
-    parser::parse_block_header_lenient,
-    types::{BlockHeader, H256Le, MerkleProof, RawBlockHeader},
-};
+use bitcoin::types::{BlockHeader, H256Le, MerkleProof};
 use flate2::read::GzDecoder;
 use serde::Deserialize;
 use std::{
@@ -39,8 +36,7 @@ impl Block {
     }
 
     pub fn get_block_header(&self) -> BlockHeader {
-        parse_block_header_lenient(&RawBlockHeader::from_hex(&self.raw_header).expect(ERR_INVALID_HEADER))
-            .expect(ERR_INVALID_HEADER)
+        BlockHeader::from_hex(&self.raw_header).expect(ERR_INVALID_HEADER)
     }
 }
 
@@ -91,12 +87,12 @@ pub fn get_bitcoin_testdata() -> Vec<Block> {
     test_data
 }
 
-pub fn get_fork_testdata() -> Vec<RawBlockHeader> {
+pub fn get_fork_testdata() -> Vec<BlockHeader> {
     let data = read_data(PATH_TESTNET_FORKS);
 
-    let test_data: Vec<RawBlockHeader> = data
+    let test_data: Vec<BlockHeader> = data
         .lines()
-        .filter_map(|s| RawBlockHeader::from_hex(s.strip_prefix(FORK_PREFIX).unwrap_or(s)).ok())
+        .filter_map(|s| BlockHeader::from_hex(s.strip_prefix(FORK_PREFIX).unwrap_or(s)).ok())
         .collect();
 
     assert!(test_data.len() == NUM_FORK_HEADERS as usize);

--- a/standalone/runtime/tests/bitcoin_data.rs
+++ b/standalone/runtime/tests/bitcoin_data.rs
@@ -1,4 +1,7 @@
-use bitcoin::types::{H256Le, RawBlockHeader};
+use bitcoin::{
+    parser::parse_block_header_lenient,
+    types::{BlockHeader, H256Le, MerkleProof, RawBlockHeader},
+};
 use flate2::read::GzDecoder;
 use serde::Deserialize;
 use std::{
@@ -35,8 +38,9 @@ impl Block {
         H256Le::from_hex_be(&self.hash)
     }
 
-    pub fn get_raw_header(&self) -> RawBlockHeader {
-        RawBlockHeader::from_hex(&self.raw_header).expect(ERR_INVALID_HEADER)
+    pub fn get_block_header(&self) -> BlockHeader {
+        parse_block_header_lenient(&RawBlockHeader::from_hex(&self.raw_header).expect(ERR_INVALID_HEADER))
+            .expect(ERR_INVALID_HEADER)
     }
 }
 
@@ -51,8 +55,8 @@ impl Transaction {
         H256Le::from_hex_be(&self.txid)
     }
 
-    pub fn get_raw_merkle_proof(&self) -> Vec<u8> {
-        hex::decode(&self.raw_merkle_proof).expect(ERR_INVALID_PROOF)
+    pub fn get_merkle_proof(&self) -> MerkleProof {
+        MerkleProof::parse(&hex::decode(&self.raw_merkle_proof).expect(ERR_INVALID_PROOF)).expect(ERR_INVALID_PROOF)
     }
 }
 

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -1235,7 +1235,7 @@ impl TransactionGenerator {
         self.relayer = relayer;
         self
     }
-    pub fn mine(&self) -> (H256Le, u32, Vec<u8>, Vec<u8>, Transaction) {
+    pub fn mine(&self) -> (H256Le, u32, MerkleProof, Transaction) {
         let mut height = BTCRelayPallet::get_best_block_height() + 1;
         let extra_confirmations = self.confirmations - 1;
 
@@ -1251,11 +1251,7 @@ impl TransactionGenerator {
                 .mine(U256::from(2).pow(254.into()))
                 .unwrap();
 
-            let raw_init_block_header = RawBlockHeader::from_bytes(&init_block.header.try_format().unwrap())
-                .expect("could not serialize block header");
-            let init_block_header = BTCRelayPallet::parse_raw_block_header(&raw_init_block_header).unwrap();
-
-            match BTCRelayPallet::_initialize(account_of(ALICE), init_block_header, height) {
+            match BTCRelayPallet::_initialize(account_of(ALICE), init_block.header, height) {
                 Ok(_) => {}
                 Err(e) if e == BTCRelayError::AlreadyInitialized.into() => {}
                 _ => panic!("Failed to initialize btc relay"),
@@ -1313,16 +1309,11 @@ impl TransactionGenerator {
             .mine(U256::from(2).pow(254.into()))
             .unwrap();
 
-        let raw_block_header =
-            RawBlockHeader::from_bytes(&block.header.try_format().unwrap()).expect("could not serialize block header");
-
         let tx_id = transaction.tx_id();
         let tx_block_height = height;
-        let proof = block.merkle_proof(&[tx_id]).unwrap();
-        let bytes_proof = proof.try_format().unwrap();
-        let raw_tx = transaction.format_with(true);
+        let merkle_proof = block.merkle_proof(&[tx_id]).unwrap();
 
-        self.relay(height, &block, raw_block_header);
+        self.relay(height, &block, block.header);
 
         // Mine six new blocks to get over required confirmations
         let mut prev_block_hash = block.header.hash;
@@ -1338,26 +1329,22 @@ impl TransactionGenerator {
                 .mine(U256::from(2).pow(254.into()))
                 .unwrap();
 
-            let raw_conf_block_header = RawBlockHeader::from_bytes(&conf_block.header.try_format().unwrap())
-                .expect("could not serialize block header");
-            self.relay(height, &conf_block, raw_conf_block_header);
+            self.relay(height, &conf_block, conf_block.header);
 
             prev_block_hash = conf_block.header.hash;
         }
 
-        (tx_id, tx_block_height, bytes_proof, raw_tx, transaction)
+        (tx_id, tx_block_height, merkle_proof, transaction)
     }
 
-    fn relay(&self, height: u32, block: &Block, raw_block_header: RawBlockHeader) {
+    fn relay(&self, height: u32, block: &Block, block_header: BlockHeader) {
         if let Some(relayer) = self.relayer {
             assert_ok!(RuntimeCall::BTCRelay(BTCRelayCall::store_block_header {
-                raw_block_header: raw_block_header
+                block_header: block_header
             })
             .dispatch(origin_of(account_of(relayer))));
-            assert_store_main_chain_header_event(height, raw_block_header.hash(), account_of(relayer));
+            assert_store_main_chain_header_event(height, block_header.hash, account_of(relayer));
         } else {
-            // bypass staked relayer module
-            let block_header = BTCRelayPallet::parse_raw_block_header(&raw_block_header).unwrap();
             assert_ok!(BTCRelayPallet::_store_block_header(&account_of(ALICE), block_header));
             assert_store_main_chain_header_event(height, block.header.hash, account_of(ALICE));
         }
@@ -1369,14 +1356,13 @@ pub fn generate_transaction_and_mine(
     inputs: Vec<(Transaction, u32, Option<BtcPublicKey>)>,
     outputs: Vec<(BtcAddress, Amount<Runtime>)>,
     return_data: Vec<H256>,
-) -> (H256Le, u32, Vec<u8>, Vec<u8>, Transaction) {
-    let (tx_id, height, proof, raw_tx, tx) = TransactionGenerator::new()
+) -> (H256Le, u32, MerkleProof, Transaction) {
+    TransactionGenerator::new()
         .with_script(signer.to_p2pkh_script_sig(vec![1; 32]).as_bytes())
         .with_inputs(inputs)
         .with_outputs(outputs)
         .with_op_return(return_data)
-        .mine();
-    (tx_id, height, proof, raw_tx, tx)
+        .mine()
 }
 
 pub struct ExtBuilder {

--- a/standalone/runtime/tests/test_btc_relay.rs
+++ b/standalone/runtime/tests/test_btc_relay.rs
@@ -32,20 +32,19 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
             .iter()
             .position(|d| d.height % DIFFICULTY_ADJUSTMENT_INTERVAL == 0)
             .unwrap();
-        let parachain_genesis_header = test_data[skip_blocks].get_raw_header();
+        let parachain_genesis_header = test_data[skip_blocks].get_block_header();
         let parachain_genesis_height = test_data[skip_blocks].height;
         assert_eq!(parachain_genesis_height % DIFFICULTY_ADJUSTMENT_INTERVAL, 0);
 
         assert_ok!(RuntimeCall::BTCRelay(BTCRelayCall::initialize {
-            raw_block_header: parachain_genesis_header,
+            block_header: parachain_genesis_header,
             block_height: parachain_genesis_height
         })
         .dispatch(origin_of(account_of(ALICE))));
 
         for block in test_data.iter().skip(skip_blocks + 1).take(BLOCKS_TO_TEST) {
-            let raw_header = block.get_raw_header();
-            let parsed_block = bitcoin::parser::parse_block_header_lenient(&raw_header).unwrap();
-            let prev_header_hash = parsed_block.hash_prev_block;
+            let block_header = block.get_block_header();
+            let prev_header_hash = block_header.hash_prev_block;
 
             // check that the previously submitted header and the current header are matching
             let best_block_hash = BTCRelayPallet::get_best_block();
@@ -56,7 +55,7 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
 
             // submit block hashes
             assert_ok!(RuntimeCall::BTCRelay(BTCRelayCall::store_block_header {
-                raw_block_header: block.get_raw_header()
+                block_header: block.get_block_header()
             })
             .dispatch(origin_of(account_of(ALICE))));
 
@@ -69,11 +68,11 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
         for block in test_data.iter().skip(skip_blocks).take(BLOCKS_TO_TEST) {
             for tx in &block.test_txs {
                 let txid = tx.get_txid();
-                let raw_merkle_proof = tx.get_raw_merkle_proof();
+                let merkle_proof = tx.get_merkle_proof();
                 if block.height <= current_height - CONFIRMATIONS + 1 {
                     assert_ok!(RuntimeCall::BTCRelay(BTCRelayCall::verify_transaction_inclusion {
                         tx_id: txid,
-                        raw_merkle_proof: raw_merkle_proof,
+                        merkle_proof,
                         confirmations: None,
                     })
                     .dispatch(origin_of(account_of(ALICE))));
@@ -82,7 +81,7 @@ fn integration_test_submit_block_headers_and_verify_transaction_inclusion() {
                     assert_noop!(
                         RuntimeCall::BTCRelay(BTCRelayCall::verify_transaction_inclusion {
                             tx_id: txid,
-                            raw_merkle_proof: raw_merkle_proof,
+                            merkle_proof,
                             confirmations: None,
                         })
                         .dispatch(origin_of(account_of(ALICE))),

--- a/standalone/runtime/tests/test_replace.rs
+++ b/standalone/runtime/tests/test_replace.rs
@@ -705,7 +705,7 @@ fn execute_replace_with_amount(replace_id: H256, amount: Amount<Runtime>) -> Dis
     let replace = ReplacePallet::get_open_or_cancelled_replace_request(&replace_id).unwrap();
 
     // send the btc from the old_vault to the new_vault
-    let (_tx_id, _tx_block_height, merkle_proof, raw_tx, _) = generate_transaction_and_mine(
+    let (_tx_id, _tx_block_height, merkle_proof, transaction) = generate_transaction_and_mine(
         Default::default(),
         vec![],
         vec![(replace.btc_address, amount)],
@@ -715,9 +715,9 @@ fn execute_replace_with_amount(replace_id: H256, amount: Amount<Runtime>) -> Dis
     SecurityPallet::set_active_block_number(SecurityPallet::active_block_number() + CONFIRMATIONS);
 
     RuntimeCall::Replace(ReplaceCall::execute_replace {
-        replace_id: replace_id,
-        merkle_proof: merkle_proof,
-        raw_tx: raw_tx,
+        replace_id,
+        merkle_proof,
+        transaction,
     })
     .dispatch(origin_of(account_of(OLD_VAULT)))
 }


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Closes https://github.com/interlay/interbtc/issues/605

Open points:
- Should we remove the `hash` field from `BlockHeader`?
- Should we use `BoundedVec` for the scripts and witnesses?