### PR TITLE
chore!: remove wallet from vault struct

### DIFF
--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -8,7 +8,7 @@ use mocktopus::mocking::*;
 use sp_arithmetic::FixedU128;
 use sp_core::H256;
 use sp_runtime::traits::One;
-use vault_registry::{DefaultVault, DefaultVaultId, Vault, VaultStatus, Wallet};
+use vault_registry::{DefaultVault, DefaultVaultId, Vault, VaultStatus};
 
 fn dummy_merkle_proof() -> MerkleProof {
     MerkleProof {
@@ -94,7 +94,6 @@ fn test_request_issue_banned_fails() {
                 to_be_redeemed_tokens: 0,
                 replace_collateral: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(),
                 banned_until: Some(1),
                 secure_collateral_threshold: None,
                 status: VaultStatus::Active(true),

--- a/crates/redeem/src/benchmarking.rs
+++ b/crates/redeem/src/benchmarking.rs
@@ -16,7 +16,7 @@ use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultCurrencyPai
 use sp_core::{H256, U256};
 use sp_runtime::traits::One;
 use sp_std::prelude::*;
-use vault_registry::types::{Vault, Wallet};
+use vault_registry::types::Vault;
 
 // Pallets
 use crate::Pallet as Redeem;
@@ -173,7 +173,6 @@ benchmarks! {
         register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
-            wallet: Wallet::new(),
             issued_tokens: amount,
             id: vault_id.clone(),
             ..Vault::new(vault_id.clone())
@@ -239,7 +238,6 @@ benchmarks! {
         register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
-            wallet: Wallet::new(),
             id: vault_id.clone(),
             ..Vault::new(vault_id.clone())
         };
@@ -330,7 +328,6 @@ BtcRelay::<T>::parachain_confirmations() + 1u32.into());
         register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
-            wallet: Wallet::new(),
             id: vault_id.clone(),
             ..Vault::new(vault_id.clone())
         };
@@ -365,7 +362,6 @@ BtcRelay::<T>::parachain_confirmations() + 1u32.into());
         register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
-            wallet: Wallet::new(),
             id: vault_id.clone(),
             ..Vault::new(vault_id.clone())
         };

--- a/crates/redeem/src/tests.rs
+++ b/crates/redeem/src/tests.rs
@@ -8,7 +8,7 @@ use frame_support::{assert_err, assert_noop, assert_ok, dispatch::DispatchError}
 use mocktopus::mocking::*;
 use security::Pallet as Security;
 use sp_core::{H160, H256};
-use vault_registry::{DefaultVault, VaultStatus, Wallet};
+use vault_registry::{DefaultVault, VaultStatus};
 
 type Event = crate::Event<Test>;
 
@@ -58,7 +58,6 @@ fn default_vault() -> DefaultVault<Test> {
         replace_collateral: 0,
         to_be_redeemed_tokens: 0,
         active_replace_collateral: 0,
-        wallet: Wallet::new(),
         banned_until: None,
         secure_collateral_threshold: None,
         status: VaultStatus::Active(true),
@@ -93,7 +92,6 @@ fn test_request_redeem_fails_with_amount_below_minimum() {
                 replace_collateral: 0,
                 to_be_redeemed_tokens: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(),
                 banned_until: None,
                 secure_collateral_threshold: None,
                 status: VaultStatus::Active(true),
@@ -166,7 +164,6 @@ fn test_request_redeem_succeeds_with_normal_redeem() {
                 to_be_redeemed_tokens: 0,
                 replace_collateral: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(),
                 banned_until: None,
                 secure_collateral_threshold: None,
                 status: VaultStatus::Active(true),
@@ -267,7 +264,6 @@ fn test_request_redeem_succeeds_with_self_redeem() {
                 to_be_redeemed_tokens: 0,
                 active_replace_collateral: 0,
                 replace_collateral: 0,
-                wallet: Wallet::new(),
                 banned_until: None,
                 secure_collateral_threshold: None,
                 status: VaultStatus::Active(true),
@@ -398,7 +394,6 @@ fn test_execute_redeem_succeeds_with_another_account() {
                 to_be_redeemed_tokens: 200,
                 replace_collateral: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(),
                 banned_until: None,
                 secure_collateral_threshold: None,
                 status: VaultStatus::Active(true),
@@ -480,7 +475,6 @@ fn test_execute_redeem_succeeds() {
                 to_be_redeemed_tokens: 200,
                 replace_collateral: 0,
                 active_replace_collateral: 0,
-                wallet: Wallet::new(),
                 banned_until: None,
                 secure_collateral_threshold: None,
                 status: VaultStatus::Active(true),
@@ -839,7 +833,6 @@ mod spec_based_tests {
                     issued_tokens: 200,
                     to_be_redeemed_tokens: 200,
                     replace_collateral: 0,
-                    wallet: Wallet::new(),
                     banned_until: None,
                     status: VaultStatus::Active(true),
                     ..default_vault()

--- a/crates/replace/src/benchmarking.rs
+++ b/crates/replace/src/benchmarking.rs
@@ -16,7 +16,7 @@ use primitives::{CurrencyId, VaultCurrencyPair, VaultId};
 use sp_core::{H256, U256};
 use sp_runtime::{traits::One, FixedPointNumber};
 use sp_std::prelude::*;
-use vault_registry::types::{DefaultVaultCurrencyPair, Vault, Wallet};
+use vault_registry::types::{DefaultVaultCurrencyPair, Vault};
 
 // Pallets
 use crate::Pallet as Replace;
@@ -159,7 +159,6 @@ benchmarks! {
         register_public_key::<T>(vault_id.clone());
 
         let vault = Vault {
-            wallet: Wallet::new(),
             id: vault_id.clone(),
             issued_tokens: amount,
             ..Vault::new(vault_id.clone())
@@ -239,7 +238,6 @@ benchmarks! {
         Replace::<T>::insert_replace_request(&replace_id, &replace_request);
 
         let old_vault = Vault {
-            wallet: Wallet::new(),
             id: old_vault_id.clone(),
             ..Vault::new(old_vault_id.clone())
         };
@@ -249,7 +247,6 @@ benchmarks! {
         );
 
         let new_vault = Vault {
-            wallet: Wallet::new(),
             id: new_vault_id.clone(),
             ..Vault::new(new_vault_id.clone())
         };

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -49,7 +49,6 @@ pub(crate) mod btc_relay {
 #[cfg_attr(test, mockable)]
 pub(crate) mod vault_registry {
     use crate::DefaultVaultId;
-    use btc_relay::BtcAddress;
     use currency::Amount;
     use frame_support::dispatch::{DispatchError, DispatchResult};
     use vault_registry::types::CurrencySource;
@@ -92,13 +91,6 @@ pub(crate) mod vault_registry {
 
     pub fn ensure_not_banned<T: crate::Config>(vault_id: &DefaultVaultId<T>) -> DispatchResult {
         <vault_registry::Pallet<T>>::_ensure_not_banned(vault_id)
-    }
-
-    pub fn insert_vault_deposit_address<T: crate::Config>(
-        vault_id: DefaultVaultId<T>,
-        btc_address: BtcAddress,
-    ) -> DispatchResult {
-        <vault_registry::Pallet<T>>::insert_vault_deposit_address(vault_id, btc_address)
     }
 
     pub fn try_increase_to_be_issued_tokens<T: crate::Config>(

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -415,10 +415,6 @@ impl<T: Config> Pallet<T> {
         // Check that new vault is not currently banned
         ext::vault_registry::ensure_not_banned::<T>(&new_vault_id)?;
 
-        // Add the new replace address to the vault's wallet,
-        // this should also verify that the vault exists
-        ext::vault_registry::insert_vault_deposit_address::<T>(new_vault_id.clone(), btc_address)?;
-
         // decrease old-vault's to-be-replaced tokens
         let (redeemable_tokens, griefing_collateral) =
             ext::vault_registry::decrease_to_be_replaced_tokens::<T>(&old_vault_id, &amount_btc)?;

--- a/crates/replace/src/tests.rs
+++ b/crates/replace/src/tests.rs
@@ -124,7 +124,6 @@ mod accept_replace_tests {
 
     fn setup_mocks() {
         ext::vault_registry::ensure_not_banned::<Test>.mock_safe(|_| MockResult::Return(Ok(())));
-        ext::vault_registry::insert_vault_deposit_address::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));
         ext::vault_registry::decrease_to_be_replaced_tokens::<Test>
             .mock_safe(|_, _| MockResult::Return(Ok((wrapped(5), griefing(10)))));
         ext::vault_registry::try_deposit_collateral::<Test>.mock_safe(|_, _| MockResult::Return(Ok(())));

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -83,12 +83,6 @@ benchmarks! {
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
     }: _(RawOrigin::Signed(vault_id.account_id), BtcPublicKey::default())
 
-    register_address {
-        let vault_id = get_vault_id::<T>();
-        mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
-        register_vault_with_collateral::<T>(vault_id.clone(), 100000000);
-    }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone(), BtcAddress::default())
-
     accept_new_issues {
         let vault_id = get_vault_id::<T>();
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());

--- a/crates/vault-registry/src/default_weights.rs
+++ b/crates/vault-registry/src/default_weights.rs
@@ -38,7 +38,6 @@ pub trait WeightInfo {
 	fn deposit_collateral() -> Weight;
 	fn withdraw_collateral() -> Weight;
 	fn register_public_key() -> Weight;
-	fn register_address() -> Weight;
 	fn accept_new_issues() -> Weight;
     fn set_minimum_collateral() -> Weight;
 	fn set_system_collateral_ceiling() -> Weight;
@@ -118,13 +117,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		(27_632_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-	}
-	// Storage: VaultRegistry ReservedAddresses (r:1 w:1)
-	// Storage: VaultRegistry Vaults (r:1 w:1)
-	fn register_address() -> Weight {
-		(35_385_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	// Storage: VaultRegistry Vaults (r:1 w:1)
 	fn accept_new_issues() -> Weight {
@@ -273,13 +265,6 @@ impl WeightInfo for () {
 		(27_632_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
-	}
-	// Storage: VaultRegistry ReservedAddresses (r:1 w:1)
-	// Storage: VaultRegistry Vaults (r:1 w:1)
-	fn register_address() -> Weight {
-		(35_385_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
 	}
 	// Storage: VaultRegistry Vaults (r:1 w:1)
 	fn accept_new_issues() -> Weight {

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -1,8 +1,6 @@
 use crate::{
-    ext,
-    mock::*,
-    types::{BalanceOf, BtcAddress},
-    BtcPublicKey, CurrencySource, DefaultVaultId, DispatchError, Error, UpdatableVault, Vault, VaultStatus, Wallet,
+    ext, mock::*, types::BalanceOf, BtcPublicKey, CurrencySource, DefaultVaultId, DispatchError, Error, UpdatableVault,
+    Vault, VaultStatus,
 };
 use codec::Decode;
 use currency::Amount;
@@ -1572,41 +1570,6 @@ mod get_vaults_with_redeemable_tokens_test {
             );
         })
     }
-}
-
-// #[test]
-// fn wallet_add_btc_address_succeeds() {
-//     run_test(|| {
-//         let address1 = BtcAddress::random();
-//         let address2 = BtcAddress::random();
-//         let address3 = BtcAddress::random();
-
-//         let mut wallet = Wallet::new(address1);
-//         assert_eq!(wallet.get_btc_address(), address1);
-
-//         wallet.add_btc_address(address2);
-//         assert_eq!(wallet.get_btc_address(), address2);
-
-//         wallet.add_btc_address(address3);
-//         assert_eq!(wallet.get_btc_address(), address3);
-//     });
-// }
-
-#[test]
-fn wallet_has_btc_address_succeeds() {
-    use sp_std::collections::btree_set::BTreeSet;
-
-    run_test(|| {
-        let address1 = BtcAddress::random();
-        let address2 = BtcAddress::random();
-
-        let mut addresses = BTreeSet::new();
-        addresses.insert(address1);
-
-        let wallet = Wallet { addresses };
-        assert_eq!(wallet.has_btc_address(&address1), true);
-        assert_eq!(wallet.has_btc_address(&address2), false);
-    });
 }
 
 #[test]

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -1286,29 +1286,6 @@ impl TransactionGenerator {
     }
 }
 
-pub fn register_addresses_and_mine_transaction(
-    vault_id: DefaultVaultId<Runtime>,
-    signer: BtcPublicKey,
-    inputs: Vec<(Transaction, u32, Option<BtcPublicKey>)>,
-    outputs: Vec<(BtcAddress, Amount<Runtime>)>,
-    return_data: Vec<H256>,
-) -> (H256Le, u32, Vec<u8>, Vec<u8>, Transaction) {
-    register_vault_address(vault_id.clone(), signer.clone());
-    for (_, _, public_key) in inputs.iter() {
-        if let Some(key) = public_key {
-            register_vault_address(vault_id.clone(), key.clone());
-        }
-    }
-    generate_transaction_and_mine(signer, inputs, outputs, return_data)
-}
-
-pub fn register_vault_address(vault_id: DefaultVaultId<Runtime>, from: BtcPublicKey) {
-    assert_ok!(VaultRegistryPallet::insert_vault_deposit_address(
-        vault_id,
-        BtcAddress::P2PKH(from.to_hash())
-    ));
-}
-
 pub fn generate_transaction_and_mine(
     signer: BtcPublicKey,
     inputs: Vec<(Transaction, u32, Option<BtcPublicKey>)>,

--- a/standalone/runtime/tests/test_vault_registry.rs
+++ b/standalone/runtime/tests/test_vault_registry.rs
@@ -3,10 +3,7 @@ mod mock;
 use currency::Amount;
 use mock::{assert_eq, *};
 
-use crate::mock::{
-    issue_testing_utils::{execute_issue, request_issue},
-    redeem_testing_utils::{cancel_redeem, setup_redeem, ExecuteRedeemBuilder},
-};
+use crate::mock::issue_testing_utils::{execute_issue, request_issue};
 
 pub const USER: [u8; 32] = ALICE;
 pub const VAULT: [u8; 32] = BOB;
@@ -323,14 +320,6 @@ fn integration_test_vault_registry_with_parachain_shutdown_fails() {
         assert_noop!(
             Call::VaultRegistry(VaultRegistryCall::register_public_key {
                 public_key: Default::default()
-            })
-            .dispatch(origin_of(account_of(VAULT))),
-            SystemError::CallFiltered
-        );
-        assert_noop!(
-            Call::VaultRegistry(VaultRegistryCall::register_address {
-                currency_pair: vault_id.currencies.clone(),
-                btc_address: Default::default()
             })
             .dispatch(origin_of(account_of(VAULT))),
             SystemError::CallFiltered


### PR DESCRIPTION
With the removal of theft reporting, the wallet is no longer necessary.

Note: this will require the v4->v5 migration to run first. I tried leaving both in the code so they can be run back to back, but the `translate` function only allows you to put the current version, i.e. it does not allow you to put a VaultV5

