### PR TITLE
Revert "chore: upgrade to nightly-2022-06-20"

### DIFF
--- a/crates/currency/src/lib.rs
+++ b/crates/currency/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(warnings)]
 #![cfg_attr(test, feature(proc_macro_hygiene))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(const_fn_trait_bound)]
 
 #[cfg(test)]
 mod mock;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-06-20"
+channel = "nightly-2022-02-08"
 components = [ "rustfmt", "rls" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
This reverts commit a87b256efb4e361dda5e01f1dd67faa1f3742462.

Signed-off-by: Gregory Hill <gregorydhill@outlook.com>