### PR TITLE
feat: fork collator-selection and use escrow for bonding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "collator-selection"
+version = "3.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-aura",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-session",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+ "sp-tracing",
+]
+
+[[package]]
 name = "comfy-table"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3756,6 +3782,7 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "collator-selection",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -3798,7 +3825,6 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
  "pallet-collective",
  "pallet-identity",
  "pallet-membership",
@@ -4109,6 +4135,7 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "collator-selection",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -4152,7 +4179,6 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
  "pallet-collective",
  "pallet-identity",
  "pallet-membership",
@@ -6384,26 +6410,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-collator-selection"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.24#95ca5a085727c1494ddeeae4a2b2e69c4ee1933b"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-authorship",
- "pallet-session",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "sp-runtime",
- "sp-staking",
  "sp-std",
 ]
 
@@ -12303,6 +12309,7 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "collator-selection",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -12346,7 +12353,6 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
  "pallet-collective",
  "pallet-identity",
  "pallet-membership",
@@ -12402,6 +12408,7 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "collator-selection",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -12445,7 +12452,6 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-collator-selection",
  "pallet-collective",
  "pallet-identity",
  "pallet-membership",

--- a/crates/collator-selection/Cargo.toml
+++ b/crates/collator-selection/Cargo.toml
@@ -1,0 +1,64 @@
+[package]
+authors = ["Anonymous"]
+description = "Simple staking pallet with a fixed stake."
+edition = "2021"
+homepage = "https://substrate.io"
+license = "Apache-2.0"
+name = "pallet-collator-selection"
+readme = "README.md"
+repository = "https://github.com/paritytech/cumulus/"
+version = "3.0.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+log = { version = "0.4.17", default-features = false }
+codec = { default-features = false, features = ["derive"], package = "parity-scale-codec", version = "3.0.0" }
+rand = { version = "0.8.5", features = ["std_rng"], default-features = false }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+serde = { version = "1.0.137", default-features = false }
+
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-staking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+pallet-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+
+frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+
+[dev-dependencies]
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+
+[features]
+default = ["std"]
+runtime-benchmarks = [
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+]
+std = [
+	"codec/std",
+	"log/std",
+	"scale-info/std",
+	"rand/std",
+	"sp-runtime/std",
+	"sp-staking/std",
+	"sp-std/std",
+	"frame-support/std",
+	"frame-system/std",
+	"frame-benchmarking/std",
+	"pallet-authorship/std",
+	"pallet-session/std",
+]
+
+try-runtime = [ "frame-support/try-runtime" ]

--- a/crates/collator-selection/Cargo.toml
+++ b/crates/collator-selection/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-authors = ["Anonymous"]
+authors = ["Interlay Ltd"]
 description = "Simple staking pallet with a fixed stake."
 edition = "2021"
 homepage = "https://substrate.io"
 license = "Apache-2.0"
-name = "pallet-collator-selection"
+name = "collator-selection"
 readme = "README.md"
 repository = "https://github.com/paritytech/cumulus/"
 version = "3.0.0"

--- a/crates/collator-selection/README.md
+++ b/crates/collator-selection/README.md
@@ -1,1 +1,0 @@
-License: Apache-2.0

--- a/crates/collator-selection/README.md
+++ b/crates/collator-selection/README.md
@@ -1,0 +1,1 @@
+License: Apache-2.0

--- a/crates/collator-selection/src/benchmarking.rs
+++ b/crates/collator-selection/src/benchmarking.rs
@@ -1,0 +1,258 @@
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Benchmarking setup for pallet-collator-selection
+
+use super::*;
+
+#[allow(unused)]
+use crate::Pallet as CollatorSelection;
+use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
+use frame_support::{
+	assert_ok,
+	codec::Decode,
+	traits::{Currency, EnsureOrigin, Get},
+};
+use frame_system::{EventRecord, RawOrigin};
+use pallet_authorship::EventHandler;
+use pallet_session::{self as session, SessionManager};
+use sp_std::prelude::*;
+
+pub type BalanceOf<T> =
+	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+const SEED: u32 = 0;
+
+// TODO: remove if this is given in substrate commit.
+macro_rules! whitelist {
+	($acc:ident) => {
+		frame_benchmarking::benchmarking::add_to_whitelist(
+			frame_system::Account::<T>::hashed_key_for(&$acc).into(),
+		);
+	};
+}
+
+fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
+	let events = frame_system::Pallet::<T>::events();
+	let system_event: <T as frame_system::Config>::Event = generic_event.into();
+	// compare to the last event record
+	let EventRecord { event, .. } = &events[events.len() - 1];
+	assert_eq!(event, &system_event);
+}
+
+fn create_funded_user<T: Config>(
+	string: &'static str,
+	n: u32,
+	balance_factor: u32,
+) -> T::AccountId {
+	let user = account(string, n, SEED);
+	let balance = T::Currency::minimum_balance() * balance_factor.into();
+	let _ = T::Currency::make_free_balance_be(&user, balance);
+	user
+}
+
+fn keys<T: Config + session::Config>(c: u32) -> <T as session::Config>::Keys {
+	use rand::{RngCore, SeedableRng};
+
+	let keys = {
+		let mut keys = [0u8; 128];
+
+		if c > 0 {
+			let mut rng = rand::rngs::StdRng::seed_from_u64(c as u64);
+			rng.fill_bytes(&mut keys);
+		}
+
+		keys
+	};
+
+	Decode::decode(&mut &keys[..]).unwrap()
+}
+
+fn validator<T: Config + session::Config>(c: u32) -> (T::AccountId, <T as session::Config>::Keys) {
+	(create_funded_user::<T>("candidate", c, 1000), keys::<T>(c))
+}
+
+fn register_validators<T: Config + session::Config>(count: u32) -> Vec<T::AccountId> {
+	let validators = (0..count).map(|c| validator::<T>(c)).collect::<Vec<_>>();
+
+	for (who, keys) in validators.clone() {
+		<session::Pallet<T>>::set_keys(RawOrigin::Signed(who).into(), keys, Vec::new()).unwrap();
+	}
+
+	validators.into_iter().map(|(who, _)| who).collect()
+}
+
+fn register_candidates<T: Config>(count: u32) {
+	let candidates = (0..count).map(|c| account("candidate", c, SEED)).collect::<Vec<_>>();
+	assert!(<CandidacyBond<T>>::get() > 0u32.into(), "Bond cannot be zero!");
+
+	for who in candidates {
+		T::Currency::make_free_balance_be(&who, <CandidacyBond<T>>::get() * 2u32.into());
+		<CollatorSelection<T>>::register_as_candidate(RawOrigin::Signed(who).into()).unwrap();
+	}
+}
+
+benchmarks! {
+	where_clause { where T: pallet_authorship::Config + session::Config }
+
+	set_invulnerables {
+		let b in 1 .. T::MaxInvulnerables::get();
+		let new_invulnerables = register_validators::<T>(b);
+		let origin = T::UpdateOrigin::successful_origin();
+	}: {
+		assert_ok!(
+			<CollatorSelection<T>>::set_invulnerables(origin, new_invulnerables.clone())
+		);
+	}
+	verify {
+		assert_last_event::<T>(Event::NewInvulnerables{invulnerables: new_invulnerables}.into());
+	}
+
+	set_desired_candidates {
+		let max: u32 = 999;
+		let origin = T::UpdateOrigin::successful_origin();
+	}: {
+		assert_ok!(
+			<CollatorSelection<T>>::set_desired_candidates(origin, max.clone())
+		);
+	}
+	verify {
+		assert_last_event::<T>(Event::NewDesiredCandidates{desired_candidates: max}.into());
+	}
+
+	set_candidacy_bond {
+		let bond_amount: BalanceOf<T> = T::Currency::minimum_balance() * 10u32.into();
+		let origin = T::UpdateOrigin::successful_origin();
+	}: {
+		assert_ok!(
+			<CollatorSelection<T>>::set_candidacy_bond(origin, bond_amount.clone())
+		);
+	}
+	verify {
+		assert_last_event::<T>(Event::NewCandidacyBond{bond_amount}.into());
+	}
+
+	// worse case is when we have all the max-candidate slots filled except one, and we fill that
+	// one.
+	register_as_candidate {
+		let c in 1 .. T::MaxCandidates::get();
+
+		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
+		<DesiredCandidates<T>>::put(c + 1);
+
+		register_validators::<T>(c);
+		register_candidates::<T>(c);
+
+		let caller: T::AccountId = whitelisted_caller();
+		let bond: BalanceOf<T> = T::Currency::minimum_balance() * 2u32.into();
+		T::Currency::make_free_balance_be(&caller, bond.clone());
+
+		<session::Pallet<T>>::set_keys(
+			RawOrigin::Signed(caller.clone()).into(),
+			keys::<T>(c + 1),
+			Vec::new()
+		).unwrap();
+
+	}: _(RawOrigin::Signed(caller.clone()))
+	verify {
+		assert_last_event::<T>(Event::CandidateAdded{account_id: caller, deposit: bond / 2u32.into()}.into());
+	}
+
+	// worse case is the last candidate leaving.
+	leave_intent {
+		let c in (T::MinCandidates::get() + 1) .. T::MaxCandidates::get();
+		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
+		<DesiredCandidates<T>>::put(c);
+
+		register_validators::<T>(c);
+		register_candidates::<T>(c);
+
+		let leaving = <Candidates<T>>::get().last().unwrap().who.clone();
+		whitelist!(leaving);
+	}: _(RawOrigin::Signed(leaving.clone()))
+	verify {
+		assert_last_event::<T>(Event::CandidateRemoved{account_id: leaving}.into());
+	}
+
+	// worse case is paying a non-existing candidate account.
+	note_author {
+		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
+		T::Currency::make_free_balance_be(
+			&<CollatorSelection<T>>::account_id(),
+			T::Currency::minimum_balance() * 4u32.into(),
+		);
+		let author = account("author", 0, SEED);
+		let new_block: T::BlockNumber = 10u32.into();
+
+		frame_system::Pallet::<T>::set_block_number(new_block);
+		assert!(T::Currency::free_balance(&author) == 0u32.into());
+	}: {
+		<CollatorSelection<T> as EventHandler<_, _>>::note_author(author.clone())
+	} verify {
+		assert!(T::Currency::free_balance(&author) > 0u32.into());
+		assert_eq!(frame_system::Pallet::<T>::block_number(), new_block);
+	}
+
+	// worst case for new session.
+	new_session {
+		let r in 1 .. T::MaxCandidates::get();
+		let c in 1 .. T::MaxCandidates::get();
+
+		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
+		<DesiredCandidates<T>>::put(c);
+		frame_system::Pallet::<T>::set_block_number(0u32.into());
+
+		register_validators::<T>(c);
+		register_candidates::<T>(c);
+
+		let new_block: T::BlockNumber = 1800u32.into();
+		let zero_block: T::BlockNumber = 0u32.into();
+		let candidates = <Candidates<T>>::get();
+
+		let non_removals = c.saturating_sub(r);
+
+		for i in 0..c {
+			<LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), zero_block);
+		}
+
+		if non_removals > 0 {
+			for i in 0..non_removals {
+				<LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), new_block);
+			}
+		} else {
+			for i in 0..c {
+				<LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), new_block);
+			}
+		}
+
+		let pre_length = <Candidates<T>>::get().len();
+
+		frame_system::Pallet::<T>::set_block_number(new_block);
+
+		assert!(<Candidates<T>>::get().len() == c as usize);
+	}: {
+		<CollatorSelection<T> as SessionManager<_>>::new_session(0)
+	} verify {
+		if c > r && non_removals >= T::MinCandidates::get() {
+			assert!(<Candidates<T>>::get().len() < pre_length);
+		} else if c > r && non_removals < T::MinCandidates::get() {
+			assert!(<Candidates<T>>::get().len() == T::MinCandidates::get() as usize);
+		} else {
+			assert!(<Candidates<T>>::get().len() == pre_length);
+		}
+	}
+}
+
+impl_benchmark_test_suite!(CollatorSelection, crate::mock::new_test_ext(), crate::mock::Test,);

--- a/crates/collator-selection/src/benchmarking.rs
+++ b/crates/collator-selection/src/benchmarking.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Benchmarking setup for pallet-collator-selection
+//! Benchmarking setup for collator-selection
 
 use super::*;
 
@@ -21,238 +21,231 @@ use super::*;
 use crate::Pallet as CollatorSelection;
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_support::{
-	assert_ok,
-	codec::Decode,
-	traits::{Currency, EnsureOrigin, Get},
+    assert_ok,
+    codec::Decode,
+    traits::{Currency, EnsureOrigin, Get},
 };
 use frame_system::{EventRecord, RawOrigin};
 use pallet_authorship::EventHandler;
 use pallet_session::{self as session, SessionManager};
 use sp_std::prelude::*;
 
-pub type BalanceOf<T> =
-	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
 const SEED: u32 = 0;
 
 // TODO: remove if this is given in substrate commit.
 macro_rules! whitelist {
-	($acc:ident) => {
-		frame_benchmarking::benchmarking::add_to_whitelist(
-			frame_system::Account::<T>::hashed_key_for(&$acc).into(),
-		);
-	};
+    ($acc:ident) => {
+        frame_benchmarking::benchmarking::add_to_whitelist(frame_system::Account::<T>::hashed_key_for(&$acc).into());
+    };
 }
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
-	let events = frame_system::Pallet::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
+    let events = frame_system::Pallet::<T>::events();
+    let system_event: <T as frame_system::Config>::Event = generic_event.into();
+    // compare to the last event record
+    let EventRecord { event, .. } = &events[events.len() - 1];
+    assert_eq!(event, &system_event);
 }
 
-fn create_funded_user<T: Config>(
-	string: &'static str,
-	n: u32,
-	balance_factor: u32,
-) -> T::AccountId {
-	let user = account(string, n, SEED);
-	let balance = T::Currency::minimum_balance() * balance_factor.into();
-	let _ = T::Currency::make_free_balance_be(&user, balance);
-	user
+fn create_funded_user<T: Config>(string: &'static str, n: u32, balance_factor: u32) -> T::AccountId {
+    let user = account(string, n, SEED);
+    let balance = T::Currency::minimum_balance() * balance_factor.into();
+    let _ = T::Currency::make_free_balance_be(&user, balance);
+    user
 }
 
 fn keys<T: Config + session::Config>(c: u32) -> <T as session::Config>::Keys {
-	use rand::{RngCore, SeedableRng};
+    use rand::{RngCore, SeedableRng};
 
-	let keys = {
-		let mut keys = [0u8; 128];
+    let keys = {
+        let mut keys = [0u8; 128];
 
-		if c > 0 {
-			let mut rng = rand::rngs::StdRng::seed_from_u64(c as u64);
-			rng.fill_bytes(&mut keys);
-		}
+        if c > 0 {
+            let mut rng = rand::rngs::StdRng::seed_from_u64(c as u64);
+            rng.fill_bytes(&mut keys);
+        }
 
-		keys
-	};
+        keys
+    };
 
-	Decode::decode(&mut &keys[..]).unwrap()
+    Decode::decode(&mut &keys[..]).unwrap()
 }
 
 fn validator<T: Config + session::Config>(c: u32) -> (T::AccountId, <T as session::Config>::Keys) {
-	(create_funded_user::<T>("candidate", c, 1000), keys::<T>(c))
+    (create_funded_user::<T>("candidate", c, 1000), keys::<T>(c))
 }
 
 fn register_validators<T: Config + session::Config>(count: u32) -> Vec<T::AccountId> {
-	let validators = (0..count).map(|c| validator::<T>(c)).collect::<Vec<_>>();
+    let validators = (0..count).map(|c| validator::<T>(c)).collect::<Vec<_>>();
 
-	for (who, keys) in validators.clone() {
-		<session::Pallet<T>>::set_keys(RawOrigin::Signed(who).into(), keys, Vec::new()).unwrap();
-	}
+    for (who, keys) in validators.clone() {
+        <session::Pallet<T>>::set_keys(RawOrigin::Signed(who).into(), keys, Vec::new()).unwrap();
+    }
 
-	validators.into_iter().map(|(who, _)| who).collect()
+    validators.into_iter().map(|(who, _)| who).collect()
 }
 
 fn register_candidates<T: Config>(count: u32) {
-	let candidates = (0..count).map(|c| account("candidate", c, SEED)).collect::<Vec<_>>();
-	assert!(<CandidacyBond<T>>::get() > 0u32.into(), "Bond cannot be zero!");
+    let candidates = (0..count).map(|c| account("candidate", c, SEED)).collect::<Vec<_>>();
+    assert!(<CandidacyBond<T>>::get() > 0u32.into(), "Bond cannot be zero!");
 
-	for who in candidates {
-		T::Currency::make_free_balance_be(&who, <CandidacyBond<T>>::get() * 2u32.into());
-		<CollatorSelection<T>>::register_as_candidate(RawOrigin::Signed(who).into()).unwrap();
-	}
+    for who in candidates {
+        T::Currency::make_free_balance_be(&who, <CandidacyBond<T>>::get() * 2u32.into());
+        <CollatorSelection<T>>::register_as_candidate(RawOrigin::Signed(who).into()).unwrap();
+    }
 }
 
 benchmarks! {
-	where_clause { where T: pallet_authorship::Config + session::Config }
+    where_clause { where T: pallet_authorship::Config + session::Config }
 
-	set_invulnerables {
-		let b in 1 .. T::MaxInvulnerables::get();
-		let new_invulnerables = register_validators::<T>(b);
-		let origin = T::UpdateOrigin::successful_origin();
-	}: {
-		assert_ok!(
-			<CollatorSelection<T>>::set_invulnerables(origin, new_invulnerables.clone())
-		);
-	}
-	verify {
-		assert_last_event::<T>(Event::NewInvulnerables{invulnerables: new_invulnerables}.into());
-	}
+    set_invulnerables {
+        let b in 1 .. T::MaxInvulnerables::get();
+        let new_invulnerables = register_validators::<T>(b);
+        let origin = T::UpdateOrigin::successful_origin();
+    }: {
+        assert_ok!(
+            <CollatorSelection<T>>::set_invulnerables(origin, new_invulnerables.clone())
+        );
+    }
+    verify {
+        assert_last_event::<T>(Event::NewInvulnerables{invulnerables: new_invulnerables}.into());
+    }
 
-	set_desired_candidates {
-		let max: u32 = 999;
-		let origin = T::UpdateOrigin::successful_origin();
-	}: {
-		assert_ok!(
-			<CollatorSelection<T>>::set_desired_candidates(origin, max.clone())
-		);
-	}
-	verify {
-		assert_last_event::<T>(Event::NewDesiredCandidates{desired_candidates: max}.into());
-	}
+    set_desired_candidates {
+        let max: u32 = 999;
+        let origin = T::UpdateOrigin::successful_origin();
+    }: {
+        assert_ok!(
+            <CollatorSelection<T>>::set_desired_candidates(origin, max.clone())
+        );
+    }
+    verify {
+        assert_last_event::<T>(Event::NewDesiredCandidates{desired_candidates: max}.into());
+    }
 
-	set_candidacy_bond {
-		let bond_amount: BalanceOf<T> = T::Currency::minimum_balance() * 10u32.into();
-		let origin = T::UpdateOrigin::successful_origin();
-	}: {
-		assert_ok!(
-			<CollatorSelection<T>>::set_candidacy_bond(origin, bond_amount.clone())
-		);
-	}
-	verify {
-		assert_last_event::<T>(Event::NewCandidacyBond{bond_amount}.into());
-	}
+    set_candidacy_bond {
+        let bond_amount: BalanceOf<T> = T::Currency::minimum_balance() * 10u32.into();
+        let origin = T::UpdateOrigin::successful_origin();
+    }: {
+        assert_ok!(
+            <CollatorSelection<T>>::set_candidacy_bond(origin, bond_amount.clone())
+        );
+    }
+    verify {
+        assert_last_event::<T>(Event::NewCandidacyBond{bond_amount}.into());
+    }
 
-	// worse case is when we have all the max-candidate slots filled except one, and we fill that
-	// one.
-	register_as_candidate {
-		let c in 1 .. T::MaxCandidates::get();
+    // worse case is when we have all the max-candidate slots filled except one, and we fill that
+    // one.
+    register_as_candidate {
+        let c in 1 .. T::MaxCandidates::get();
 
-		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
-		<DesiredCandidates<T>>::put(c + 1);
+        <CandidacyBond<T>>::put(T::Currency::minimum_balance());
+        <DesiredCandidates<T>>::put(c + 1);
 
-		register_validators::<T>(c);
-		register_candidates::<T>(c);
+        register_validators::<T>(c);
+        register_candidates::<T>(c);
 
-		let caller: T::AccountId = whitelisted_caller();
-		let bond: BalanceOf<T> = T::Currency::minimum_balance() * 2u32.into();
-		T::Currency::make_free_balance_be(&caller, bond.clone());
+        let caller: T::AccountId = whitelisted_caller();
+        let bond: BalanceOf<T> = T::Currency::minimum_balance() * 2u32.into();
+        T::Currency::make_free_balance_be(&caller, bond.clone());
 
-		<session::Pallet<T>>::set_keys(
-			RawOrigin::Signed(caller.clone()).into(),
-			keys::<T>(c + 1),
-			Vec::new()
-		).unwrap();
+        <session::Pallet<T>>::set_keys(
+            RawOrigin::Signed(caller.clone()).into(),
+            keys::<T>(c + 1),
+            Vec::new()
+        ).unwrap();
 
-	}: _(RawOrigin::Signed(caller.clone()))
-	verify {
-		assert_last_event::<T>(Event::CandidateAdded{account_id: caller, deposit: bond / 2u32.into()}.into());
-	}
+    }: _(RawOrigin::Signed(caller.clone()))
+    verify {
+        assert_last_event::<T>(Event::CandidateAdded{account_id: caller, deposit: bond / 2u32.into()}.into());
+    }
 
-	// worse case is the last candidate leaving.
-	leave_intent {
-		let c in (T::MinCandidates::get() + 1) .. T::MaxCandidates::get();
-		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
-		<DesiredCandidates<T>>::put(c);
+    // worse case is the last candidate leaving.
+    leave_intent {
+        let c in (T::MinCandidates::get() + 1) .. T::MaxCandidates::get();
+        <CandidacyBond<T>>::put(T::Currency::minimum_balance());
+        <DesiredCandidates<T>>::put(c);
 
-		register_validators::<T>(c);
-		register_candidates::<T>(c);
+        register_validators::<T>(c);
+        register_candidates::<T>(c);
 
-		let leaving = <Candidates<T>>::get().last().unwrap().who.clone();
-		whitelist!(leaving);
-	}: _(RawOrigin::Signed(leaving.clone()))
-	verify {
-		assert_last_event::<T>(Event::CandidateRemoved{account_id: leaving}.into());
-	}
+        let leaving = <Candidates<T>>::get().last().unwrap().who.clone();
+        whitelist!(leaving);
+    }: _(RawOrigin::Signed(leaving.clone()))
+    verify {
+        assert_last_event::<T>(Event::CandidateRemoved{account_id: leaving}.into());
+    }
 
-	// worse case is paying a non-existing candidate account.
-	note_author {
-		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
-		T::Currency::make_free_balance_be(
-			&<CollatorSelection<T>>::account_id(),
-			T::Currency::minimum_balance() * 4u32.into(),
-		);
-		let author = account("author", 0, SEED);
-		let new_block: T::BlockNumber = 10u32.into();
+    // worse case is paying a non-existing candidate account.
+    note_author {
+        <CandidacyBond<T>>::put(T::Currency::minimum_balance());
+        T::Currency::make_free_balance_be(
+            &<CollatorSelection<T>>::account_id(),
+            T::Currency::minimum_balance() * 4u32.into(),
+        );
+        let author = account("author", 0, SEED);
+        let new_block: T::BlockNumber = 10u32.into();
 
-		frame_system::Pallet::<T>::set_block_number(new_block);
-		assert!(T::Currency::free_balance(&author) == 0u32.into());
-	}: {
-		<CollatorSelection<T> as EventHandler<_, _>>::note_author(author.clone())
-	} verify {
-		assert!(T::Currency::free_balance(&author) > 0u32.into());
-		assert_eq!(frame_system::Pallet::<T>::block_number(), new_block);
-	}
+        frame_system::Pallet::<T>::set_block_number(new_block);
+        assert!(T::Currency::free_balance(&author) == 0u32.into());
+    }: {
+        <CollatorSelection<T> as EventHandler<_, _>>::note_author(author.clone())
+    } verify {
+        assert!(T::Currency::free_balance(&author) > 0u32.into());
+        assert_eq!(frame_system::Pallet::<T>::block_number(), new_block);
+    }
 
-	// worst case for new session.
-	new_session {
-		let r in 1 .. T::MaxCandidates::get();
-		let c in 1 .. T::MaxCandidates::get();
+    // worst case for new session.
+    new_session {
+        let r in 1 .. T::MaxCandidates::get();
+        let c in 1 .. T::MaxCandidates::get();
 
-		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
-		<DesiredCandidates<T>>::put(c);
-		frame_system::Pallet::<T>::set_block_number(0u32.into());
+        <CandidacyBond<T>>::put(T::Currency::minimum_balance());
+        <DesiredCandidates<T>>::put(c);
+        frame_system::Pallet::<T>::set_block_number(0u32.into());
 
-		register_validators::<T>(c);
-		register_candidates::<T>(c);
+        register_validators::<T>(c);
+        register_candidates::<T>(c);
 
-		let new_block: T::BlockNumber = 1800u32.into();
-		let zero_block: T::BlockNumber = 0u32.into();
-		let candidates = <Candidates<T>>::get();
+        let new_block: T::BlockNumber = 1800u32.into();
+        let zero_block: T::BlockNumber = 0u32.into();
+        let candidates = <Candidates<T>>::get();
 
-		let non_removals = c.saturating_sub(r);
+        let non_removals = c.saturating_sub(r);
 
-		for i in 0..c {
-			<LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), zero_block);
-		}
+        for i in 0..c {
+            <LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), zero_block);
+        }
 
-		if non_removals > 0 {
-			for i in 0..non_removals {
-				<LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), new_block);
-			}
-		} else {
-			for i in 0..c {
-				<LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), new_block);
-			}
-		}
+        if non_removals > 0 {
+            for i in 0..non_removals {
+                <LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), new_block);
+            }
+        } else {
+            for i in 0..c {
+                <LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), new_block);
+            }
+        }
 
-		let pre_length = <Candidates<T>>::get().len();
+        let pre_length = <Candidates<T>>::get().len();
 
-		frame_system::Pallet::<T>::set_block_number(new_block);
+        frame_system::Pallet::<T>::set_block_number(new_block);
 
-		assert!(<Candidates<T>>::get().len() == c as usize);
-	}: {
-		<CollatorSelection<T> as SessionManager<_>>::new_session(0)
-	} verify {
-		if c > r && non_removals >= T::MinCandidates::get() {
-			assert!(<Candidates<T>>::get().len() < pre_length);
-		} else if c > r && non_removals < T::MinCandidates::get() {
-			assert!(<Candidates<T>>::get().len() == T::MinCandidates::get() as usize);
-		} else {
-			assert!(<Candidates<T>>::get().len() == pre_length);
-		}
-	}
+        assert!(<Candidates<T>>::get().len() == c as usize);
+    }: {
+        <CollatorSelection<T> as SessionManager<_>>::new_session(0)
+    } verify {
+        if c > r && non_removals >= T::MinCandidates::get() {
+            assert!(<Candidates<T>>::get().len() < pre_length);
+        } else if c > r && non_removals < T::MinCandidates::get() {
+            assert!(<Candidates<T>>::get().len() == T::MinCandidates::get() as usize);
+        } else {
+            assert!(<Candidates<T>>::get().len() == pre_length);
+        }
+    }
 }
 
 impl_benchmark_test_suite!(CollatorSelection, crate::mock::new_test_ext(), crate::mock::Test,);

--- a/crates/collator-selection/src/lib.rs
+++ b/crates/collator-selection/src/lib.rs
@@ -1,0 +1,524 @@
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Collator Selection pallet.
+//!
+//! A pallet to manage collators in a parachain.
+//!
+//! ## Overview
+//!
+//! The Collator Selection pallet manages the collators of a parachain. **Collation is _not_ a
+//! secure activity** and this pallet does not implement any game-theoretic mechanisms to meet BFT
+//! safety assumptions of the chosen set.
+//!
+//! ## Terminology
+//!
+//! - Collator: A parachain block producer.
+//! - Bond: An amount of `Balance` _reserved_ for candidate registration.
+//! - Invulnerable: An account guaranteed to be in the collator set.
+//!
+//! ## Implementation
+//!
+//! The final `Collators` are aggregated from two individual lists:
+//!
+//! 1. [`Invulnerables`]: a set of collators appointed by governance. These accounts will always be
+//!    collators.
+//! 2. [`Candidates`]: these are *candidates to the collation task* and may or may not be elected as
+//!    a final collator.
+//!
+//! The current implementation resolves congestion of [`Candidates`] in a first-come-first-serve
+//! manner.
+//!
+//! Candidates will not be allowed to get kicked or leave_intent if the total number of candidates
+//! fall below MinCandidates. This is for potential disaster recovery scenarios.
+//!
+//! ### Rewards
+//!
+//! The Collator Selection pallet maintains an on-chain account (the "Pot"). In each block, the
+//! collator who authored it receives:
+//!
+//! - Half the value of the Pot.
+//! - Half the value of the transaction fees within the block. The other half of the transaction
+//!   fees are deposited into the Pot.
+//!
+//! To initiate rewards an ED needs to be transferred to the pot address.
+//!
+//! Note: Eventually the Pot distribution may be modified as discussed in
+//! [this issue](https://github.com/paritytech/statemint/issues/21#issuecomment-810481073).
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+pub mod weights;
+
+#[frame_support::pallet]
+pub mod pallet {
+	pub use crate::weights::WeightInfo;
+	use core::ops::Div;
+	use frame_support::{
+		dispatch::DispatchResultWithPostInfo,
+		inherent::Vec,
+		pallet_prelude::*,
+		sp_runtime::{
+			traits::{AccountIdConversion, CheckedSub, Saturating, Zero},
+			RuntimeDebug,
+		},
+		traits::{
+			Currency, EnsureOrigin, ExistenceRequirement::KeepAlive, ReservableCurrency,
+			ValidatorRegistration,
+		},
+		weights::DispatchClass,
+		PalletId,
+	};
+	use frame_system::{pallet_prelude::*, Config as SystemConfig};
+	use pallet_session::SessionManager;
+	use sp_runtime::traits::Convert;
+	use sp_staking::SessionIndex;
+
+	type BalanceOf<T> =
+		<<T as Config>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;
+
+	/// A convertor from collators id. Since this pallet does not have stash/controller, this is
+	/// just identity.
+	pub struct IdentityCollator;
+	impl<T> sp_runtime::traits::Convert<T, Option<T>> for IdentityCollator {
+		fn convert(t: T) -> Option<T> {
+			Some(t)
+		}
+	}
+
+	/// Configure the pallet by specifying the parameters and types on which it depends.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// Overarching event type.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+		/// The currency mechanism.
+		type Currency: ReservableCurrency<Self::AccountId>;
+
+		/// Origin that can dictate updating parameters of this pallet.
+		type UpdateOrigin: EnsureOrigin<Self::Origin>;
+
+		/// Account Identifier from which the internal Pot is generated.
+		type PotId: Get<PalletId>;
+
+		/// Maximum number of candidates that we should have. This is used for benchmarking and is not
+		/// enforced.
+		///
+		/// This does not take into account the invulnerables.
+		type MaxCandidates: Get<u32>;
+
+		/// Minimum number of candidates that we should have. This is used for disaster recovery.
+		///
+		/// This does not take into account the invulnerables.
+		type MinCandidates: Get<u32>;
+
+		/// Maximum number of invulnerables.
+		///
+		/// Used only for benchmarking.
+		type MaxInvulnerables: Get<u32>;
+
+		// Will be kicked if block is not produced in threshold.
+		type KickThreshold: Get<Self::BlockNumber>;
+
+		/// A stable ID for a validator.
+		type ValidatorId: Member + Parameter;
+
+		/// A conversion from account ID to validator ID.
+		///
+		/// Its cost must be at most one storage read.
+		type ValidatorIdOf: Convert<Self::AccountId, Option<Self::ValidatorId>>;
+
+		/// Validate a user is registered
+		type ValidatorRegistration: ValidatorRegistration<Self::ValidatorId>;
+
+		/// The weight information of this pallet.
+		type WeightInfo: WeightInfo;
+	}
+
+	/// Basic information about a collation candidate.
+	#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, scale_info::TypeInfo)]
+	pub struct CandidateInfo<AccountId, Balance> {
+		/// Account identifier.
+		pub who: AccountId,
+		/// Reserved deposit.
+		pub deposit: Balance,
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(_);
+
+	/// The invulnerable, fixed collators.
+	#[pallet::storage]
+	#[pallet::getter(fn invulnerables)]
+	pub type Invulnerables<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+
+	/// The (community, limited) collation candidates.
+	#[pallet::storage]
+	#[pallet::getter(fn candidates)]
+	pub type Candidates<T: Config> =
+		StorageValue<_, Vec<CandidateInfo<T::AccountId, BalanceOf<T>>>, ValueQuery>;
+
+	/// Last block authored by collator.
+	#[pallet::storage]
+	#[pallet::getter(fn last_authored_block)]
+	pub type LastAuthoredBlock<T: Config> =
+		StorageMap<_, Twox64Concat, T::AccountId, T::BlockNumber, ValueQuery>;
+
+	/// Desired number of candidates.
+	///
+	/// This should ideally always be less than [`Config::MaxCandidates`] for weights to be correct.
+	#[pallet::storage]
+	#[pallet::getter(fn desired_candidates)]
+	pub type DesiredCandidates<T> = StorageValue<_, u32, ValueQuery>;
+
+	/// Fixed amount to deposit to become a collator.
+	///
+	/// When a collator calls `leave_intent` they immediately receive the deposit back.
+	#[pallet::storage]
+	#[pallet::getter(fn candidacy_bond)]
+	pub type CandidacyBond<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub invulnerables: Vec<T::AccountId>,
+		pub candidacy_bond: BalanceOf<T>,
+		pub desired_candidates: u32,
+	}
+
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self {
+				invulnerables: Default::default(),
+				candidacy_bond: Default::default(),
+				desired_candidates: Default::default(),
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+			let duplicate_invulnerables =
+				self.invulnerables.iter().collect::<std::collections::BTreeSet<_>>();
+			assert!(
+				duplicate_invulnerables.len() == self.invulnerables.len(),
+				"duplicate invulnerables in genesis."
+			);
+
+			assert!(
+				T::MaxInvulnerables::get() >= (self.invulnerables.len() as u32),
+				"genesis invulnerables are more than T::MaxInvulnerables",
+			);
+			assert!(
+				T::MaxCandidates::get() >= self.desired_candidates,
+				"genesis desired_candidates are more than T::MaxCandidates",
+			);
+
+			<DesiredCandidates<T>>::put(&self.desired_candidates);
+			<CandidacyBond<T>>::put(&self.candidacy_bond);
+			<Invulnerables<T>>::put(&self.invulnerables);
+		}
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		NewInvulnerables { invulnerables: Vec<T::AccountId> },
+		NewDesiredCandidates { desired_candidates: u32 },
+		NewCandidacyBond { bond_amount: BalanceOf<T> },
+		CandidateAdded { account_id: T::AccountId, deposit: BalanceOf<T> },
+		CandidateRemoved { account_id: T::AccountId },
+	}
+
+	// Errors inform users that something went wrong.
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Too many candidates
+		TooManyCandidates,
+		/// Too few candidates
+		TooFewCandidates,
+		/// Unknown error
+		Unknown,
+		/// Permission issue
+		Permission,
+		/// User is already a candidate
+		AlreadyCandidate,
+		/// User is not a candidate
+		NotCandidate,
+		/// User is already an Invulnerable
+		AlreadyInvulnerable,
+		/// Account has no associated validator ID
+		NoAssociatedValidatorId,
+		/// Validator ID is not yet registered
+		ValidatorNotRegistered,
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Set the list of invulnerable (fixed) collators.
+		#[pallet::weight(T::WeightInfo::set_invulnerables(new.len() as u32))]
+		pub fn set_invulnerables(
+			origin: OriginFor<T>,
+			new: Vec<T::AccountId>,
+		) -> DispatchResultWithPostInfo {
+			T::UpdateOrigin::ensure_origin(origin)?;
+			// we trust origin calls, this is just a for more accurate benchmarking
+			if (new.len() as u32) > T::MaxInvulnerables::get() {
+				log::warn!(
+					"invulnerables > T::MaxInvulnerables; you might need to run benchmarks again"
+				);
+			}
+
+			// check if the invulnerables have associated validator keys before they are set
+			for account_id in &new {
+				let validator_key = T::ValidatorIdOf::convert(account_id.clone())
+					.ok_or(Error::<T>::NoAssociatedValidatorId)?;
+				ensure!(
+					T::ValidatorRegistration::is_registered(&validator_key),
+					Error::<T>::ValidatorNotRegistered
+				);
+			}
+
+			<Invulnerables<T>>::put(&new);
+			Self::deposit_event(Event::NewInvulnerables { invulnerables: new });
+			Ok(().into())
+		}
+
+		/// Set the ideal number of collators (not including the invulnerables).
+		/// If lowering this number, then the number of running collators could be higher than this figure.
+		/// Aside from that edge case, there should be no other way to have more collators than the desired number.
+		#[pallet::weight(T::WeightInfo::set_desired_candidates())]
+		pub fn set_desired_candidates(
+			origin: OriginFor<T>,
+			max: u32,
+		) -> DispatchResultWithPostInfo {
+			T::UpdateOrigin::ensure_origin(origin)?;
+			// we trust origin calls, this is just a for more accurate benchmarking
+			if max > T::MaxCandidates::get() {
+				log::warn!("max > T::MaxCandidates; you might need to run benchmarks again");
+			}
+			<DesiredCandidates<T>>::put(&max);
+			Self::deposit_event(Event::NewDesiredCandidates { desired_candidates: max });
+			Ok(().into())
+		}
+
+		/// Set the candidacy bond amount.
+		#[pallet::weight(T::WeightInfo::set_candidacy_bond())]
+		pub fn set_candidacy_bond(
+			origin: OriginFor<T>,
+			bond: BalanceOf<T>,
+		) -> DispatchResultWithPostInfo {
+			T::UpdateOrigin::ensure_origin(origin)?;
+			<CandidacyBond<T>>::put(&bond);
+			Self::deposit_event(Event::NewCandidacyBond { bond_amount: bond });
+			Ok(().into())
+		}
+
+		/// Register this account as a collator candidate. The account must (a) already have
+		/// registered session keys and (b) be able to reserve the `CandidacyBond`.
+		///
+		/// This call is not available to `Invulnerable` collators.
+		#[pallet::weight(T::WeightInfo::register_as_candidate(T::MaxCandidates::get()))]
+		pub fn register_as_candidate(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			let who = ensure_signed(origin)?;
+
+			// ensure we are below limit.
+			let length = <Candidates<T>>::decode_len().unwrap_or_default();
+			ensure!((length as u32) < Self::desired_candidates(), Error::<T>::TooManyCandidates);
+			ensure!(!Self::invulnerables().contains(&who), Error::<T>::AlreadyInvulnerable);
+
+			let validator_key = T::ValidatorIdOf::convert(who.clone())
+				.ok_or(Error::<T>::NoAssociatedValidatorId)?;
+			ensure!(
+				T::ValidatorRegistration::is_registered(&validator_key),
+				Error::<T>::ValidatorNotRegistered
+			);
+
+			let deposit = Self::candidacy_bond();
+			// First authored block is current block plus kick threshold to handle session delay
+			let incoming = CandidateInfo { who: who.clone(), deposit };
+
+			let current_count =
+				<Candidates<T>>::try_mutate(|candidates| -> Result<usize, DispatchError> {
+					if candidates.iter().any(|candidate| candidate.who == who) {
+						Err(Error::<T>::AlreadyCandidate)?
+					} else {
+						T::Currency::reserve(&who, deposit)?;
+						candidates.push(incoming);
+						<LastAuthoredBlock<T>>::insert(
+							who.clone(),
+							frame_system::Pallet::<T>::block_number() + T::KickThreshold::get(),
+						);
+						Ok(candidates.len())
+					}
+				})?;
+
+			Self::deposit_event(Event::CandidateAdded { account_id: who, deposit });
+			Ok(Some(T::WeightInfo::register_as_candidate(current_count as u32)).into())
+		}
+
+		/// Deregister `origin` as a collator candidate. Note that the collator can only leave on
+		/// session change. The `CandidacyBond` will be unreserved immediately.
+		///
+		/// This call will fail if the total number of candidates would drop below `MinCandidates`.
+		///
+		/// This call is not available to `Invulnerable` collators.
+		#[pallet::weight(T::WeightInfo::leave_intent(T::MaxCandidates::get()))]
+		pub fn leave_intent(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			let who = ensure_signed(origin)?;
+			ensure!(
+				Self::candidates().len() as u32 > T::MinCandidates::get(),
+				Error::<T>::TooFewCandidates
+			);
+			let current_count = Self::try_remove_candidate(&who)?;
+
+			Ok(Some(T::WeightInfo::leave_intent(current_count as u32)).into())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Get a unique, inaccessible account id from the `PotId`.
+		pub fn account_id() -> T::AccountId {
+			T::PotId::get().into_account_truncating()
+		}
+
+		/// Removes a candidate if they exist and sends them back their deposit
+		fn try_remove_candidate(who: &T::AccountId) -> Result<usize, DispatchError> {
+			let current_count =
+				<Candidates<T>>::try_mutate(|candidates| -> Result<usize, DispatchError> {
+					let index = candidates
+						.iter()
+						.position(|candidate| candidate.who == *who)
+						.ok_or(Error::<T>::NotCandidate)?;
+					let candidate = candidates.remove(index);
+					T::Currency::unreserve(who, candidate.deposit);
+					<LastAuthoredBlock<T>>::remove(who.clone());
+					Ok(candidates.len())
+				})?;
+			Self::deposit_event(Event::CandidateRemoved { account_id: who.clone() });
+			Ok(current_count)
+		}
+
+		/// Assemble the current set of candidates and invulnerables into the next collator set.
+		///
+		/// This is done on the fly, as frequent as we are told to do so, as the session manager.
+		pub fn assemble_collators(candidates: Vec<T::AccountId>) -> Vec<T::AccountId> {
+			let mut collators = Self::invulnerables();
+			collators.extend(candidates);
+			collators
+		}
+
+		/// Kicks out candidates that did not produce a block in the kick threshold
+		/// and refund their deposits.
+		pub fn kick_stale_candidates(
+			candidates: Vec<CandidateInfo<T::AccountId, BalanceOf<T>>>,
+		) -> Vec<T::AccountId> {
+			let now = frame_system::Pallet::<T>::block_number();
+			let kick_threshold = T::KickThreshold::get();
+			candidates
+				.into_iter()
+				.filter_map(|c| {
+					let last_block = <LastAuthoredBlock<T>>::get(c.who.clone());
+					let since_last = now.saturating_sub(last_block);
+					if since_last < kick_threshold ||
+						Self::candidates().len() as u32 <= T::MinCandidates::get()
+					{
+						Some(c.who)
+					} else {
+						let outcome = Self::try_remove_candidate(&c.who);
+						if let Err(why) = outcome {
+							log::warn!("Failed to remove candidate {:?}", why);
+							debug_assert!(false, "failed to remove candidate {:?}", why);
+						}
+						None
+					}
+				})
+				.collect()
+		}
+	}
+
+	/// Keep track of number of authored blocks per authority, uncles are counted as well since
+	/// they're a valid proof of being online.
+	impl<T: Config + pallet_authorship::Config>
+		pallet_authorship::EventHandler<T::AccountId, T::BlockNumber> for Pallet<T>
+	{
+		fn note_author(author: T::AccountId) {
+			let pot = Self::account_id();
+			// assumes an ED will be sent to pot.
+			let reward = T::Currency::free_balance(&pot)
+				.checked_sub(&T::Currency::minimum_balance())
+				.unwrap_or_else(Zero::zero)
+				.div(2u32.into());
+			// `reward` is half of pot account minus ED, this should never fail.
+			let _success = T::Currency::transfer(&pot, &author, reward, KeepAlive);
+			debug_assert!(_success.is_ok());
+			<LastAuthoredBlock<T>>::insert(author, frame_system::Pallet::<T>::block_number());
+
+			frame_system::Pallet::<T>::register_extra_weight_unchecked(
+				T::WeightInfo::note_author(),
+				DispatchClass::Mandatory,
+			);
+		}
+
+		fn note_uncle(_author: T::AccountId, _age: T::BlockNumber) {
+			//TODO can we ignore this?
+		}
+	}
+
+	/// Play the role of the session manager.
+	impl<T: Config> SessionManager<T::AccountId> for Pallet<T> {
+		fn new_session(index: SessionIndex) -> Option<Vec<T::AccountId>> {
+			log::info!(
+				"assembling new collators for new session {} at #{:?}",
+				index,
+				<frame_system::Pallet<T>>::block_number(),
+			);
+
+			let candidates = Self::candidates();
+			let candidates_len_before = candidates.len();
+			let active_candidates = Self::kick_stale_candidates(candidates);
+			let removed = candidates_len_before - active_candidates.len();
+			let result = Self::assemble_collators(active_candidates);
+
+			frame_system::Pallet::<T>::register_extra_weight_unchecked(
+				T::WeightInfo::new_session(candidates_len_before as u32, removed as u32),
+				DispatchClass::Mandatory,
+			);
+			Some(result)
+		}
+		fn start_session(_: SessionIndex) {
+			// we don't care.
+		}
+		fn end_session(_: SessionIndex) {
+			// we don't care.
+		}
+	}
+}

--- a/crates/collator-selection/src/lib.rs
+++ b/crates/collator-selection/src/lib.rs
@@ -1,18 +1,3 @@
-// Copyright (C) 2021 Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 //! Collator Selection pallet.
 //!
 //! A pallet to manage collators in a parachain.
@@ -50,8 +35,8 @@
 //! collator who authored it receives:
 //!
 //! - Half the value of the Pot.
-//! - Half the value of the transaction fees within the block. The other half of the transaction
-//!   fees are deposited into the Pot.
+//! - Half the value of the transaction fees within the block. The other half of the transaction fees are deposited into
+//!   the Pot.
 //!
 //! To initiate rewards an ED needs to be transferred to the pot address.
 //!
@@ -74,451 +59,450 @@ pub mod weights;
 
 #[frame_support::pallet]
 pub mod pallet {
-	pub use crate::weights::WeightInfo;
-	use core::ops::Div;
-	use frame_support::{
-		dispatch::DispatchResultWithPostInfo,
-		inherent::Vec,
-		pallet_prelude::*,
-		sp_runtime::{
-			traits::{AccountIdConversion, CheckedSub, Saturating, Zero},
-			RuntimeDebug,
-		},
-		traits::{
-			Currency, EnsureOrigin, ExistenceRequirement::KeepAlive, ReservableCurrency,
-			ValidatorRegistration,
-		},
-		weights::DispatchClass,
-		PalletId,
-	};
-	use frame_system::{pallet_prelude::*, Config as SystemConfig};
-	use pallet_session::SessionManager;
-	use sp_runtime::traits::Convert;
-	use sp_staking::SessionIndex;
+    pub use crate::weights::WeightInfo;
+    use core::ops::Div;
+    use frame_support::{
+        dispatch::DispatchResultWithPostInfo,
+        inherent::Vec,
+        pallet_prelude::*,
+        sp_runtime::{
+            traits::{AccountIdConversion, CheckedSub, Saturating, Zero},
+            RuntimeDebug,
+        },
+        traits::{Currency, EnsureOrigin, ExistenceRequirement::KeepAlive, ReservableCurrency, ValidatorRegistration},
+        weights::DispatchClass,
+        PalletId,
+    };
+    use frame_system::{pallet_prelude::*, Config as SystemConfig};
+    use pallet_session::SessionManager;
+    use sp_runtime::traits::Convert;
+    use sp_staking::SessionIndex;
 
-	type BalanceOf<T> =
-		<<T as Config>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;
+    type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;
 
-	/// A convertor from collators id. Since this pallet does not have stash/controller, this is
-	/// just identity.
-	pub struct IdentityCollator;
-	impl<T> sp_runtime::traits::Convert<T, Option<T>> for IdentityCollator {
-		fn convert(t: T) -> Option<T> {
-			Some(t)
-		}
-	}
+    /// A convertor from collators id. Since this pallet does not have stash/controller, this is
+    /// just identity.
+    pub struct IdentityCollator;
+    impl<T> sp_runtime::traits::Convert<T, Option<T>> for IdentityCollator {
+        fn convert(t: T) -> Option<T> {
+            Some(t)
+        }
+    }
 
-	/// Configure the pallet by specifying the parameters and types on which it depends.
-	#[pallet::config]
-	pub trait Config: frame_system::Config {
-		/// Overarching event type.
-		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+    /// Configure the pallet by specifying the parameters and types on which it depends.
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// Overarching event type.
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
-		/// The currency mechanism.
-		type Currency: ReservableCurrency<Self::AccountId>;
+        /// The currency mechanism.
+        type Currency: ReservableCurrency<Self::AccountId>;
 
-		/// Origin that can dictate updating parameters of this pallet.
-		type UpdateOrigin: EnsureOrigin<Self::Origin>;
+        /// Origin that can dictate updating parameters of this pallet.
+        type UpdateOrigin: EnsureOrigin<Self::Origin>;
 
-		/// Account Identifier from which the internal Pot is generated.
-		type PotId: Get<PalletId>;
+        /// Account Identifier from which the internal Pot is generated.
+        type PotId: Get<PalletId>;
 
-		/// Maximum number of candidates that we should have. This is used for benchmarking and is not
-		/// enforced.
-		///
-		/// This does not take into account the invulnerables.
-		type MaxCandidates: Get<u32>;
+        /// Maximum number of candidates that we should have. This is used for benchmarking and is not
+        /// enforced.
+        ///
+        /// This does not take into account the invulnerables.
+        type MaxCandidates: Get<u32>;
 
-		/// Minimum number of candidates that we should have. This is used for disaster recovery.
-		///
-		/// This does not take into account the invulnerables.
-		type MinCandidates: Get<u32>;
+        /// Minimum number of candidates that we should have. This is used for disaster recovery.
+        ///
+        /// This does not take into account the invulnerables.
+        type MinCandidates: Get<u32>;
 
-		/// Maximum number of invulnerables.
-		///
-		/// Used only for benchmarking.
-		type MaxInvulnerables: Get<u32>;
+        /// Maximum number of invulnerables.
+        ///
+        /// Used only for benchmarking.
+        type MaxInvulnerables: Get<u32>;
 
-		// Will be kicked if block is not produced in threshold.
-		type KickThreshold: Get<Self::BlockNumber>;
+        // Will be kicked if block is not produced in threshold.
+        type KickThreshold: Get<Self::BlockNumber>;
 
-		/// A stable ID for a validator.
-		type ValidatorId: Member + Parameter;
+        /// A stable ID for a validator.
+        type ValidatorId: Member + Parameter;
 
-		/// A conversion from account ID to validator ID.
-		///
-		/// Its cost must be at most one storage read.
-		type ValidatorIdOf: Convert<Self::AccountId, Option<Self::ValidatorId>>;
+        /// A conversion from account ID to validator ID.
+        ///
+        /// Its cost must be at most one storage read.
+        type ValidatorIdOf: Convert<Self::AccountId, Option<Self::ValidatorId>>;
 
-		/// Validate a user is registered
-		type ValidatorRegistration: ValidatorRegistration<Self::ValidatorId>;
+        /// Validate a user is registered
+        type ValidatorRegistration: ValidatorRegistration<Self::ValidatorId>;
 
-		/// The weight information of this pallet.
-		type WeightInfo: WeightInfo;
-	}
+        /// The weight information of this pallet.
+        type WeightInfo: WeightInfo;
+    }
 
-	/// Basic information about a collation candidate.
-	#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, scale_info::TypeInfo)]
-	pub struct CandidateInfo<AccountId, Balance> {
-		/// Account identifier.
-		pub who: AccountId,
-		/// Reserved deposit.
-		pub deposit: Balance,
-	}
+    /// Basic information about a collation candidate.
+    #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, scale_info::TypeInfo)]
+    pub struct CandidateInfo<AccountId, Balance> {
+        /// Account identifier.
+        pub who: AccountId,
+        /// Reserved deposit.
+        pub deposit: Balance,
+    }
 
-	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
-	pub struct Pallet<T>(_);
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    #[pallet::without_storage_info]
+    pub struct Pallet<T>(_);
 
-	/// The invulnerable, fixed collators.
-	#[pallet::storage]
-	#[pallet::getter(fn invulnerables)]
-	pub type Invulnerables<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+    /// The invulnerable, fixed collators.
+    #[pallet::storage]
+    #[pallet::getter(fn invulnerables)]
+    pub type Invulnerables<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
-	/// The (community, limited) collation candidates.
-	#[pallet::storage]
-	#[pallet::getter(fn candidates)]
-	pub type Candidates<T: Config> =
-		StorageValue<_, Vec<CandidateInfo<T::AccountId, BalanceOf<T>>>, ValueQuery>;
+    /// The (community, limited) collation candidates.
+    #[pallet::storage]
+    #[pallet::getter(fn candidates)]
+    pub type Candidates<T: Config> = StorageValue<_, Vec<CandidateInfo<T::AccountId, BalanceOf<T>>>, ValueQuery>;
 
-	/// Last block authored by collator.
-	#[pallet::storage]
-	#[pallet::getter(fn last_authored_block)]
-	pub type LastAuthoredBlock<T: Config> =
-		StorageMap<_, Twox64Concat, T::AccountId, T::BlockNumber, ValueQuery>;
+    /// Last block authored by collator.
+    #[pallet::storage]
+    #[pallet::getter(fn last_authored_block)]
+    pub type LastAuthoredBlock<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, T::BlockNumber, ValueQuery>;
 
-	/// Desired number of candidates.
-	///
-	/// This should ideally always be less than [`Config::MaxCandidates`] for weights to be correct.
-	#[pallet::storage]
-	#[pallet::getter(fn desired_candidates)]
-	pub type DesiredCandidates<T> = StorageValue<_, u32, ValueQuery>;
+    /// Desired number of candidates.
+    ///
+    /// This should ideally always be less than [`Config::MaxCandidates`] for weights to be correct.
+    #[pallet::storage]
+    #[pallet::getter(fn desired_candidates)]
+    pub type DesiredCandidates<T> = StorageValue<_, u32, ValueQuery>;
 
-	/// Fixed amount to deposit to become a collator.
-	///
-	/// When a collator calls `leave_intent` they immediately receive the deposit back.
-	#[pallet::storage]
-	#[pallet::getter(fn candidacy_bond)]
-	pub type CandidacyBond<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+    /// Fixed amount to deposit to become a collator.
+    ///
+    /// When a collator calls `leave_intent` they immediately receive the deposit back.
+    #[pallet::storage]
+    #[pallet::getter(fn candidacy_bond)]
+    pub type CandidacyBond<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
-	#[pallet::genesis_config]
-	pub struct GenesisConfig<T: Config> {
-		pub invulnerables: Vec<T::AccountId>,
-		pub candidacy_bond: BalanceOf<T>,
-		pub desired_candidates: u32,
-	}
+    #[pallet::genesis_config]
+    pub struct GenesisConfig<T: Config> {
+        pub invulnerables: Vec<T::AccountId>,
+        pub candidacy_bond: BalanceOf<T>,
+        pub desired_candidates: u32,
+    }
 
-	#[cfg(feature = "std")]
-	impl<T: Config> Default for GenesisConfig<T> {
-		fn default() -> Self {
-			Self {
-				invulnerables: Default::default(),
-				candidacy_bond: Default::default(),
-				desired_candidates: Default::default(),
-			}
-		}
-	}
+    #[cfg(feature = "std")]
+    impl<T: Config> Default for GenesisConfig<T> {
+        fn default() -> Self {
+            Self {
+                invulnerables: Default::default(),
+                candidacy_bond: Default::default(),
+                desired_candidates: Default::default(),
+            }
+        }
+    }
 
-	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
-		fn build(&self) {
-			let duplicate_invulnerables =
-				self.invulnerables.iter().collect::<std::collections::BTreeSet<_>>();
-			assert!(
-				duplicate_invulnerables.len() == self.invulnerables.len(),
-				"duplicate invulnerables in genesis."
-			);
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+        fn build(&self) {
+            let duplicate_invulnerables = self.invulnerables.iter().collect::<std::collections::BTreeSet<_>>();
+            assert!(
+                duplicate_invulnerables.len() == self.invulnerables.len(),
+                "duplicate invulnerables in genesis."
+            );
 
-			assert!(
-				T::MaxInvulnerables::get() >= (self.invulnerables.len() as u32),
-				"genesis invulnerables are more than T::MaxInvulnerables",
-			);
-			assert!(
-				T::MaxCandidates::get() >= self.desired_candidates,
-				"genesis desired_candidates are more than T::MaxCandidates",
-			);
+            assert!(
+                T::MaxInvulnerables::get() >= (self.invulnerables.len() as u32),
+                "genesis invulnerables are more than T::MaxInvulnerables",
+            );
+            assert!(
+                T::MaxCandidates::get() >= self.desired_candidates,
+                "genesis desired_candidates are more than T::MaxCandidates",
+            );
 
-			<DesiredCandidates<T>>::put(&self.desired_candidates);
-			<CandidacyBond<T>>::put(&self.candidacy_bond);
-			<Invulnerables<T>>::put(&self.invulnerables);
-		}
-	}
+            <DesiredCandidates<T>>::put(&self.desired_candidates);
+            <CandidacyBond<T>>::put(&self.candidacy_bond);
+            <Invulnerables<T>>::put(&self.invulnerables);
+        }
+    }
 
-	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
-	pub enum Event<T: Config> {
-		NewInvulnerables { invulnerables: Vec<T::AccountId> },
-		NewDesiredCandidates { desired_candidates: u32 },
-		NewCandidacyBond { bond_amount: BalanceOf<T> },
-		CandidateAdded { account_id: T::AccountId, deposit: BalanceOf<T> },
-		CandidateRemoved { account_id: T::AccountId },
-	}
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        NewInvulnerables {
+            invulnerables: Vec<T::AccountId>,
+        },
+        NewDesiredCandidates {
+            desired_candidates: u32,
+        },
+        NewCandidacyBond {
+            bond_amount: BalanceOf<T>,
+        },
+        CandidateAdded {
+            account_id: T::AccountId,
+            deposit: BalanceOf<T>,
+        },
+        CandidateRemoved {
+            account_id: T::AccountId,
+        },
+    }
 
-	// Errors inform users that something went wrong.
-	#[pallet::error]
-	pub enum Error<T> {
-		/// Too many candidates
-		TooManyCandidates,
-		/// Too few candidates
-		TooFewCandidates,
-		/// Unknown error
-		Unknown,
-		/// Permission issue
-		Permission,
-		/// User is already a candidate
-		AlreadyCandidate,
-		/// User is not a candidate
-		NotCandidate,
-		/// User is already an Invulnerable
-		AlreadyInvulnerable,
-		/// Account has no associated validator ID
-		NoAssociatedValidatorId,
-		/// Validator ID is not yet registered
-		ValidatorNotRegistered,
-	}
+    // Errors inform users that something went wrong.
+    #[pallet::error]
+    pub enum Error<T> {
+        /// Too many candidates
+        TooManyCandidates,
+        /// Too few candidates
+        TooFewCandidates,
+        /// Unknown error
+        Unknown,
+        /// Permission issue
+        Permission,
+        /// User is already a candidate
+        AlreadyCandidate,
+        /// User is not a candidate
+        NotCandidate,
+        /// User is already an Invulnerable
+        AlreadyInvulnerable,
+        /// Account has no associated validator ID
+        NoAssociatedValidatorId,
+        /// Validator ID is not yet registered
+        ValidatorNotRegistered,
+    }
 
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {
-		/// Set the list of invulnerable (fixed) collators.
-		#[pallet::weight(T::WeightInfo::set_invulnerables(new.len() as u32))]
-		pub fn set_invulnerables(
-			origin: OriginFor<T>,
-			new: Vec<T::AccountId>,
-		) -> DispatchResultWithPostInfo {
-			T::UpdateOrigin::ensure_origin(origin)?;
-			// we trust origin calls, this is just a for more accurate benchmarking
-			if (new.len() as u32) > T::MaxInvulnerables::get() {
-				log::warn!(
-					"invulnerables > T::MaxInvulnerables; you might need to run benchmarks again"
-				);
-			}
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Set the list of invulnerable (fixed) collators.
+        #[pallet::weight(T::WeightInfo::set_invulnerables(new.len() as u32))]
+        pub fn set_invulnerables(origin: OriginFor<T>, new: Vec<T::AccountId>) -> DispatchResultWithPostInfo {
+            T::UpdateOrigin::ensure_origin(origin)?;
+            // we trust origin calls, this is just a for more accurate benchmarking
+            if (new.len() as u32) > T::MaxInvulnerables::get() {
+                log::warn!("invulnerables > T::MaxInvulnerables; you might need to run benchmarks again");
+            }
 
-			// check if the invulnerables have associated validator keys before they are set
-			for account_id in &new {
-				let validator_key = T::ValidatorIdOf::convert(account_id.clone())
-					.ok_or(Error::<T>::NoAssociatedValidatorId)?;
-				ensure!(
-					T::ValidatorRegistration::is_registered(&validator_key),
-					Error::<T>::ValidatorNotRegistered
-				);
-			}
+            // check if the invulnerables have associated validator keys before they are set
+            for account_id in &new {
+                let validator_key =
+                    T::ValidatorIdOf::convert(account_id.clone()).ok_or(Error::<T>::NoAssociatedValidatorId)?;
+                ensure!(
+                    T::ValidatorRegistration::is_registered(&validator_key),
+                    Error::<T>::ValidatorNotRegistered
+                );
+            }
 
-			<Invulnerables<T>>::put(&new);
-			Self::deposit_event(Event::NewInvulnerables { invulnerables: new });
-			Ok(().into())
-		}
+            <Invulnerables<T>>::put(&new);
+            Self::deposit_event(Event::NewInvulnerables { invulnerables: new });
+            Ok(().into())
+        }
 
-		/// Set the ideal number of collators (not including the invulnerables).
-		/// If lowering this number, then the number of running collators could be higher than this figure.
-		/// Aside from that edge case, there should be no other way to have more collators than the desired number.
-		#[pallet::weight(T::WeightInfo::set_desired_candidates())]
-		pub fn set_desired_candidates(
-			origin: OriginFor<T>,
-			max: u32,
-		) -> DispatchResultWithPostInfo {
-			T::UpdateOrigin::ensure_origin(origin)?;
-			// we trust origin calls, this is just a for more accurate benchmarking
-			if max > T::MaxCandidates::get() {
-				log::warn!("max > T::MaxCandidates; you might need to run benchmarks again");
-			}
-			<DesiredCandidates<T>>::put(&max);
-			Self::deposit_event(Event::NewDesiredCandidates { desired_candidates: max });
-			Ok(().into())
-		}
+        /// Set the ideal number of collators (not including the invulnerables).
+        /// If lowering this number, then the number of running collators could be higher than this figure.
+        /// Aside from that edge case, there should be no other way to have more collators than the desired number.
+        #[pallet::weight(T::WeightInfo::set_desired_candidates())]
+        pub fn set_desired_candidates(origin: OriginFor<T>, max: u32) -> DispatchResultWithPostInfo {
+            T::UpdateOrigin::ensure_origin(origin)?;
+            // we trust origin calls, this is just a for more accurate benchmarking
+            if max > T::MaxCandidates::get() {
+                log::warn!("max > T::MaxCandidates; you might need to run benchmarks again");
+            }
+            <DesiredCandidates<T>>::put(&max);
+            Self::deposit_event(Event::NewDesiredCandidates {
+                desired_candidates: max,
+            });
+            Ok(().into())
+        }
 
-		/// Set the candidacy bond amount.
-		#[pallet::weight(T::WeightInfo::set_candidacy_bond())]
-		pub fn set_candidacy_bond(
-			origin: OriginFor<T>,
-			bond: BalanceOf<T>,
-		) -> DispatchResultWithPostInfo {
-			T::UpdateOrigin::ensure_origin(origin)?;
-			<CandidacyBond<T>>::put(&bond);
-			Self::deposit_event(Event::NewCandidacyBond { bond_amount: bond });
-			Ok(().into())
-		}
+        /// Set the candidacy bond amount.
+        #[pallet::weight(T::WeightInfo::set_candidacy_bond())]
+        pub fn set_candidacy_bond(origin: OriginFor<T>, bond: BalanceOf<T>) -> DispatchResultWithPostInfo {
+            T::UpdateOrigin::ensure_origin(origin)?;
+            <CandidacyBond<T>>::put(&bond);
+            Self::deposit_event(Event::NewCandidacyBond { bond_amount: bond });
+            Ok(().into())
+        }
 
-		/// Register this account as a collator candidate. The account must (a) already have
-		/// registered session keys and (b) be able to reserve the `CandidacyBond`.
-		///
-		/// This call is not available to `Invulnerable` collators.
-		#[pallet::weight(T::WeightInfo::register_as_candidate(T::MaxCandidates::get()))]
-		pub fn register_as_candidate(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			let who = ensure_signed(origin)?;
+        /// Register this account as a collator candidate. The account must (a) already have
+        /// registered session keys and (b) be able to reserve the `CandidacyBond`.
+        ///
+        /// This call is not available to `Invulnerable` collators.
+        #[pallet::weight(T::WeightInfo::register_as_candidate(T::MaxCandidates::get()))]
+        pub fn register_as_candidate(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+            let who = ensure_signed(origin)?;
 
-			// ensure we are below limit.
-			let length = <Candidates<T>>::decode_len().unwrap_or_default();
-			ensure!((length as u32) < Self::desired_candidates(), Error::<T>::TooManyCandidates);
-			ensure!(!Self::invulnerables().contains(&who), Error::<T>::AlreadyInvulnerable);
+            // ensure we are below limit.
+            let length = <Candidates<T>>::decode_len().unwrap_or_default();
+            ensure!(
+                (length as u32) < Self::desired_candidates(),
+                Error::<T>::TooManyCandidates
+            );
+            ensure!(!Self::invulnerables().contains(&who), Error::<T>::AlreadyInvulnerable);
 
-			let validator_key = T::ValidatorIdOf::convert(who.clone())
-				.ok_or(Error::<T>::NoAssociatedValidatorId)?;
-			ensure!(
-				T::ValidatorRegistration::is_registered(&validator_key),
-				Error::<T>::ValidatorNotRegistered
-			);
+            let validator_key = T::ValidatorIdOf::convert(who.clone()).ok_or(Error::<T>::NoAssociatedValidatorId)?;
+            ensure!(
+                T::ValidatorRegistration::is_registered(&validator_key),
+                Error::<T>::ValidatorNotRegistered
+            );
 
-			let deposit = Self::candidacy_bond();
-			// First authored block is current block plus kick threshold to handle session delay
-			let incoming = CandidateInfo { who: who.clone(), deposit };
+            let deposit = Self::candidacy_bond();
+            // First authored block is current block plus kick threshold to handle session delay
+            let incoming = CandidateInfo {
+                who: who.clone(),
+                deposit,
+            };
 
-			let current_count =
-				<Candidates<T>>::try_mutate(|candidates| -> Result<usize, DispatchError> {
-					if candidates.iter().any(|candidate| candidate.who == who) {
-						Err(Error::<T>::AlreadyCandidate)?
-					} else {
-						T::Currency::reserve(&who, deposit)?;
-						candidates.push(incoming);
-						<LastAuthoredBlock<T>>::insert(
-							who.clone(),
-							frame_system::Pallet::<T>::block_number() + T::KickThreshold::get(),
-						);
-						Ok(candidates.len())
-					}
-				})?;
+            let current_count = <Candidates<T>>::try_mutate(|candidates| -> Result<usize, DispatchError> {
+                if candidates.iter().any(|candidate| candidate.who == who) {
+                    Err(Error::<T>::AlreadyCandidate)?
+                } else {
+                    T::Currency::reserve(&who, deposit)?;
+                    candidates.push(incoming);
+                    <LastAuthoredBlock<T>>::insert(
+                        who.clone(),
+                        frame_system::Pallet::<T>::block_number() + T::KickThreshold::get(),
+                    );
+                    Ok(candidates.len())
+                }
+            })?;
 
-			Self::deposit_event(Event::CandidateAdded { account_id: who, deposit });
-			Ok(Some(T::WeightInfo::register_as_candidate(current_count as u32)).into())
-		}
+            Self::deposit_event(Event::CandidateAdded {
+                account_id: who,
+                deposit,
+            });
+            Ok(Some(T::WeightInfo::register_as_candidate(current_count as u32)).into())
+        }
 
-		/// Deregister `origin` as a collator candidate. Note that the collator can only leave on
-		/// session change. The `CandidacyBond` will be unreserved immediately.
-		///
-		/// This call will fail if the total number of candidates would drop below `MinCandidates`.
-		///
-		/// This call is not available to `Invulnerable` collators.
-		#[pallet::weight(T::WeightInfo::leave_intent(T::MaxCandidates::get()))]
-		pub fn leave_intent(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			let who = ensure_signed(origin)?;
-			ensure!(
-				Self::candidates().len() as u32 > T::MinCandidates::get(),
-				Error::<T>::TooFewCandidates
-			);
-			let current_count = Self::try_remove_candidate(&who)?;
+        /// Deregister `origin` as a collator candidate. Note that the collator can only leave on
+        /// session change. The `CandidacyBond` will be unreserved immediately.
+        ///
+        /// This call will fail if the total number of candidates would drop below `MinCandidates`.
+        ///
+        /// This call is not available to `Invulnerable` collators.
+        #[pallet::weight(T::WeightInfo::leave_intent(T::MaxCandidates::get()))]
+        pub fn leave_intent(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+            let who = ensure_signed(origin)?;
+            ensure!(
+                Self::candidates().len() as u32 > T::MinCandidates::get(),
+                Error::<T>::TooFewCandidates
+            );
+            let current_count = Self::try_remove_candidate(&who)?;
 
-			Ok(Some(T::WeightInfo::leave_intent(current_count as u32)).into())
-		}
-	}
+            Ok(Some(T::WeightInfo::leave_intent(current_count as u32)).into())
+        }
+    }
 
-	impl<T: Config> Pallet<T> {
-		/// Get a unique, inaccessible account id from the `PotId`.
-		pub fn account_id() -> T::AccountId {
-			T::PotId::get().into_account_truncating()
-		}
+    impl<T: Config> Pallet<T> {
+        /// Get a unique, inaccessible account id from the `PotId`.
+        pub fn account_id() -> T::AccountId {
+            T::PotId::get().into_account_truncating()
+        }
 
-		/// Removes a candidate if they exist and sends them back their deposit
-		fn try_remove_candidate(who: &T::AccountId) -> Result<usize, DispatchError> {
-			let current_count =
-				<Candidates<T>>::try_mutate(|candidates| -> Result<usize, DispatchError> {
-					let index = candidates
-						.iter()
-						.position(|candidate| candidate.who == *who)
-						.ok_or(Error::<T>::NotCandidate)?;
-					let candidate = candidates.remove(index);
-					T::Currency::unreserve(who, candidate.deposit);
-					<LastAuthoredBlock<T>>::remove(who.clone());
-					Ok(candidates.len())
-				})?;
-			Self::deposit_event(Event::CandidateRemoved { account_id: who.clone() });
-			Ok(current_count)
-		}
+        /// Removes a candidate if they exist and sends them back their deposit
+        fn try_remove_candidate(who: &T::AccountId) -> Result<usize, DispatchError> {
+            let current_count = <Candidates<T>>::try_mutate(|candidates| -> Result<usize, DispatchError> {
+                let index = candidates
+                    .iter()
+                    .position(|candidate| candidate.who == *who)
+                    .ok_or(Error::<T>::NotCandidate)?;
+                let candidate = candidates.remove(index);
+                T::Currency::unreserve(who, candidate.deposit);
+                <LastAuthoredBlock<T>>::remove(who.clone());
+                Ok(candidates.len())
+            })?;
+            Self::deposit_event(Event::CandidateRemoved {
+                account_id: who.clone(),
+            });
+            Ok(current_count)
+        }
 
-		/// Assemble the current set of candidates and invulnerables into the next collator set.
-		///
-		/// This is done on the fly, as frequent as we are told to do so, as the session manager.
-		pub fn assemble_collators(candidates: Vec<T::AccountId>) -> Vec<T::AccountId> {
-			let mut collators = Self::invulnerables();
-			collators.extend(candidates);
-			collators
-		}
+        /// Assemble the current set of candidates and invulnerables into the next collator set.
+        ///
+        /// This is done on the fly, as frequent as we are told to do so, as the session manager.
+        pub fn assemble_collators(candidates: Vec<T::AccountId>) -> Vec<T::AccountId> {
+            let mut collators = Self::invulnerables();
+            collators.extend(candidates);
+            collators
+        }
 
-		/// Kicks out candidates that did not produce a block in the kick threshold
-		/// and refund their deposits.
-		pub fn kick_stale_candidates(
-			candidates: Vec<CandidateInfo<T::AccountId, BalanceOf<T>>>,
-		) -> Vec<T::AccountId> {
-			let now = frame_system::Pallet::<T>::block_number();
-			let kick_threshold = T::KickThreshold::get();
-			candidates
-				.into_iter()
-				.filter_map(|c| {
-					let last_block = <LastAuthoredBlock<T>>::get(c.who.clone());
-					let since_last = now.saturating_sub(last_block);
-					if since_last < kick_threshold ||
-						Self::candidates().len() as u32 <= T::MinCandidates::get()
-					{
-						Some(c.who)
-					} else {
-						let outcome = Self::try_remove_candidate(&c.who);
-						if let Err(why) = outcome {
-							log::warn!("Failed to remove candidate {:?}", why);
-							debug_assert!(false, "failed to remove candidate {:?}", why);
-						}
-						None
-					}
-				})
-				.collect()
-		}
-	}
+        /// Kicks out candidates that did not produce a block in the kick threshold
+        /// and refund their deposits.
+        pub fn kick_stale_candidates(candidates: Vec<CandidateInfo<T::AccountId, BalanceOf<T>>>) -> Vec<T::AccountId> {
+            let now = frame_system::Pallet::<T>::block_number();
+            let kick_threshold = T::KickThreshold::get();
+            candidates
+                .into_iter()
+                .filter_map(|c| {
+                    let last_block = <LastAuthoredBlock<T>>::get(c.who.clone());
+                    let since_last = now.saturating_sub(last_block);
+                    if since_last < kick_threshold || Self::candidates().len() as u32 <= T::MinCandidates::get() {
+                        Some(c.who)
+                    } else {
+                        let outcome = Self::try_remove_candidate(&c.who);
+                        if let Err(why) = outcome {
+                            log::warn!("Failed to remove candidate {:?}", why);
+                            debug_assert!(false, "failed to remove candidate {:?}", why);
+                        }
+                        None
+                    }
+                })
+                .collect()
+        }
+    }
 
-	/// Keep track of number of authored blocks per authority, uncles are counted as well since
-	/// they're a valid proof of being online.
-	impl<T: Config + pallet_authorship::Config>
-		pallet_authorship::EventHandler<T::AccountId, T::BlockNumber> for Pallet<T>
-	{
-		fn note_author(author: T::AccountId) {
-			let pot = Self::account_id();
-			// assumes an ED will be sent to pot.
-			let reward = T::Currency::free_balance(&pot)
-				.checked_sub(&T::Currency::minimum_balance())
-				.unwrap_or_else(Zero::zero)
-				.div(2u32.into());
-			// `reward` is half of pot account minus ED, this should never fail.
-			let _success = T::Currency::transfer(&pot, &author, reward, KeepAlive);
-			debug_assert!(_success.is_ok());
-			<LastAuthoredBlock<T>>::insert(author, frame_system::Pallet::<T>::block_number());
+    /// Keep track of number of authored blocks per authority, uncles are counted as well since
+    /// they're a valid proof of being online.
+    impl<T: Config + pallet_authorship::Config> pallet_authorship::EventHandler<T::AccountId, T::BlockNumber>
+        for Pallet<T>
+    {
+        fn note_author(author: T::AccountId) {
+            let pot = Self::account_id();
+            // assumes an ED will be sent to pot.
+            let reward = T::Currency::free_balance(&pot)
+                .checked_sub(&T::Currency::minimum_balance())
+                .unwrap_or_else(Zero::zero)
+                .div(2u32.into());
+            // `reward` is half of pot account minus ED, this should never fail.
+            let _success = T::Currency::transfer(&pot, &author, reward, KeepAlive);
+            debug_assert!(_success.is_ok());
+            <LastAuthoredBlock<T>>::insert(author, frame_system::Pallet::<T>::block_number());
 
-			frame_system::Pallet::<T>::register_extra_weight_unchecked(
-				T::WeightInfo::note_author(),
-				DispatchClass::Mandatory,
-			);
-		}
+            frame_system::Pallet::<T>::register_extra_weight_unchecked(
+                T::WeightInfo::note_author(),
+                DispatchClass::Mandatory,
+            );
+        }
 
-		fn note_uncle(_author: T::AccountId, _age: T::BlockNumber) {
-			//TODO can we ignore this?
-		}
-	}
+        fn note_uncle(_author: T::AccountId, _age: T::BlockNumber) {
+            //TODO can we ignore this?
+        }
+    }
 
-	/// Play the role of the session manager.
-	impl<T: Config> SessionManager<T::AccountId> for Pallet<T> {
-		fn new_session(index: SessionIndex) -> Option<Vec<T::AccountId>> {
-			log::info!(
-				"assembling new collators for new session {} at #{:?}",
-				index,
-				<frame_system::Pallet<T>>::block_number(),
-			);
+    /// Play the role of the session manager.
+    impl<T: Config> SessionManager<T::AccountId> for Pallet<T> {
+        fn new_session(index: SessionIndex) -> Option<Vec<T::AccountId>> {
+            log::info!(
+                "assembling new collators for new session {} at #{:?}",
+                index,
+                <frame_system::Pallet<T>>::block_number(),
+            );
 
-			let candidates = Self::candidates();
-			let candidates_len_before = candidates.len();
-			let active_candidates = Self::kick_stale_candidates(candidates);
-			let removed = candidates_len_before - active_candidates.len();
-			let result = Self::assemble_collators(active_candidates);
+            let candidates = Self::candidates();
+            let candidates_len_before = candidates.len();
+            let active_candidates = Self::kick_stale_candidates(candidates);
+            let removed = candidates_len_before - active_candidates.len();
+            let result = Self::assemble_collators(active_candidates);
 
-			frame_system::Pallet::<T>::register_extra_weight_unchecked(
-				T::WeightInfo::new_session(candidates_len_before as u32, removed as u32),
-				DispatchClass::Mandatory,
-			);
-			Some(result)
-		}
-		fn start_session(_: SessionIndex) {
-			// we don't care.
-		}
-		fn end_session(_: SessionIndex) {
-			// we don't care.
-		}
-	}
+            frame_system::Pallet::<T>::register_extra_weight_unchecked(
+                T::WeightInfo::new_session(candidates_len_before as u32, removed as u32),
+                DispatchClass::Mandatory,
+            );
+            Some(result)
+        }
+        fn start_session(_: SessionIndex) {
+            // we don't care.
+        }
+        fn end_session(_: SessionIndex) {
+            // we don't care.
+        }
+    }
 }

--- a/crates/collator-selection/src/mock.rs
+++ b/crates/collator-selection/src/mock.rs
@@ -1,0 +1,255 @@
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use crate as collator_selection;
+use frame_support::{
+	ord_parameter_types, parameter_types,
+	traits::{FindAuthor, GenesisBuild, ValidatorRegistration},
+	PalletId,
+};
+use frame_system as system;
+use frame_system::EnsureSignedBy;
+use sp_core::H256;
+use sp_runtime::{
+	testing::{Header, UintAuthorityId},
+	traits::{BlakeTwo256, IdentityLookup, OpaqueKeys},
+	RuntimeAppPublic,
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
+		Aura: pallet_aura::{Pallet, Storage, Config<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		CollatorSelection: collator_selection::{Pallet, Call, Storage, Event<T>},
+		Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent},
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const SS58Prefix: u8 = 42;
+}
+
+impl system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Origin = Origin;
+	type Call = Call;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<u64>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: u64 = 5;
+	pub const MaxReserves: u32 = 50;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = u64;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxLocks = ();
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = [u8; 8];
+}
+
+pub struct Author4;
+impl FindAuthor<u64> for Author4 {
+	fn find_author<'a, I>(_digests: I) -> Option<u64>
+	where
+		I: 'a + IntoIterator<Item = (frame_support::ConsensusEngineId, &'a [u8])>,
+	{
+		Some(4)
+	}
+}
+
+impl pallet_authorship::Config for Test {
+	type FindAuthor = Author4;
+	type UncleGenerations = ();
+	type FilterUncle = ();
+	type EventHandler = CollatorSelection;
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 1;
+}
+
+impl pallet_timestamp::Config for Test {
+	type Moment = u64;
+	type OnTimestampSet = Aura;
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+impl pallet_aura::Config for Test {
+	type AuthorityId = sp_consensus_aura::sr25519::AuthorityId;
+	type MaxAuthorities = MaxAuthorities;
+	type DisabledValidators = ();
+}
+
+sp_runtime::impl_opaque_keys! {
+	pub struct MockSessionKeys {
+		// a key for aura authoring
+		pub aura: UintAuthorityId,
+	}
+}
+
+impl From<UintAuthorityId> for MockSessionKeys {
+	fn from(aura: sp_runtime::testing::UintAuthorityId) -> Self {
+		Self { aura }
+	}
+}
+
+parameter_types! {
+	pub static SessionHandlerCollators: Vec<u64> = Vec::new();
+	pub static SessionChangeBlock: u64 = 0;
+}
+
+pub struct TestSessionHandler;
+impl pallet_session::SessionHandler<u64> for TestSessionHandler {
+	const KEY_TYPE_IDS: &'static [sp_runtime::KeyTypeId] = &[UintAuthorityId::ID];
+	fn on_genesis_session<Ks: OpaqueKeys>(keys: &[(u64, Ks)]) {
+		SessionHandlerCollators::set(keys.into_iter().map(|(a, _)| *a).collect::<Vec<_>>())
+	}
+	fn on_new_session<Ks: OpaqueKeys>(_: bool, keys: &[(u64, Ks)], _: &[(u64, Ks)]) {
+		SessionChangeBlock::set(System::block_number());
+		dbg!(keys.len());
+		SessionHandlerCollators::set(keys.into_iter().map(|(a, _)| *a).collect::<Vec<_>>())
+	}
+	fn on_before_session_ending() {}
+	fn on_disabled(_: u32) {}
+}
+
+parameter_types! {
+	pub const Offset: u64 = 0;
+	pub const Period: u64 = 10;
+}
+
+impl pallet_session::Config for Test {
+	type Event = Event;
+	type ValidatorId = <Self as frame_system::Config>::AccountId;
+	// we don't have stash and controller, thus we don't need the convert as well.
+	type ValidatorIdOf = IdentityCollator;
+	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type SessionManager = CollatorSelection;
+	type SessionHandler = TestSessionHandler;
+	type Keys = MockSessionKeys;
+	type WeightInfo = ();
+}
+
+ord_parameter_types! {
+	pub const RootAccount: u64 = 777;
+}
+
+parameter_types! {
+	pub const PotId: PalletId = PalletId(*b"PotStake");
+	pub const MaxCandidates: u32 = 20;
+	pub const MaxInvulnerables: u32 = 20;
+	pub const MinCandidates: u32 = 1;
+	pub const MaxAuthorities: u32 = 100_000;
+}
+
+pub struct IsRegistered;
+impl ValidatorRegistration<u64> for IsRegistered {
+	fn is_registered(id: &u64) -> bool {
+		if *id == 7u64 {
+			false
+		} else {
+			true
+		}
+	}
+}
+
+impl Config for Test {
+	type Event = Event;
+	type Currency = Balances;
+	type UpdateOrigin = EnsureSignedBy<RootAccount, u64>;
+	type PotId = PotId;
+	type MaxCandidates = MaxCandidates;
+	type MinCandidates = MinCandidates;
+	type MaxInvulnerables = MaxInvulnerables;
+	type KickThreshold = Period;
+	type ValidatorId = <Self as frame_system::Config>::AccountId;
+	type ValidatorIdOf = IdentityCollator;
+	type ValidatorRegistration = IsRegistered;
+	type WeightInfo = ();
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	sp_tracing::try_init_simple();
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let invulnerables = vec![1, 2];
+
+	let balances = vec![(1, 100), (2, 100), (3, 100), (4, 100), (5, 100)];
+	let keys = balances
+		.iter()
+		.map(|&(i, _)| (i, i, MockSessionKeys { aura: UintAuthorityId(i) }))
+		.collect::<Vec<_>>();
+	let collator_selection = collator_selection::GenesisConfig::<Test> {
+		desired_candidates: 2,
+		candidacy_bond: 10,
+		invulnerables,
+	};
+	let session = pallet_session::GenesisConfig::<Test> { keys };
+	pallet_balances::GenesisConfig::<Test> { balances }
+		.assimilate_storage(&mut t)
+		.unwrap();
+	// collator selection must be initialized before session.
+	collator_selection.assimilate_storage(&mut t).unwrap();
+	session.assimilate_storage(&mut t).unwrap();
+
+	t.into()
+}
+
+pub fn initialize_to_block(n: u64) {
+	for i in System::block_number() + 1..=n {
+		System::set_block_number(i);
+		<AllPalletsWithSystem as frame_support::traits::OnInitialize<u64>>::on_initialize(i);
+	}
+}

--- a/crates/collator-selection/src/mock.rs
+++ b/crates/collator-selection/src/mock.rs
@@ -16,17 +16,17 @@
 use super::*;
 use crate as collator_selection;
 use frame_support::{
-	ord_parameter_types, parameter_types,
-	traits::{FindAuthor, GenesisBuild, ValidatorRegistration},
-	PalletId,
+    ord_parameter_types, parameter_types,
+    traits::{FindAuthor, GenesisBuild, ValidatorRegistration},
+    PalletId,
 };
 use frame_system as system;
 use frame_system::EnsureSignedBy;
 use sp_core::H256;
 use sp_runtime::{
-	testing::{Header, UintAuthorityId},
-	traits::{BlakeTwo256, IdentityLookup, OpaqueKeys},
-	RuntimeAppPublic,
+    testing::{Header, UintAuthorityId},
+    traits::{BlakeTwo256, IdentityLookup, OpaqueKeys},
+    RuntimeAppPublic,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -34,222 +34,230 @@ type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
-	pub enum Test where
-		Block = Block,
-		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
-	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
-		Aura: pallet_aura::{Pallet, Storage, Config<T>},
-		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		CollatorSelection: collator_selection::{Pallet, Call, Storage, Event<T>},
-		Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent},
-	}
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+        Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
+        Aura: pallet_aura::{Pallet, Storage, Config<T>},
+        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+        CollatorSelection: collator_selection::{Pallet, Call, Storage, Event<T>},
+        Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent},
+    }
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub const SS58Prefix: u8 = 42;
+    pub const BlockHashCount: u64 = 250;
+    pub const SS58Prefix: u8 = 42;
 }
 
 impl system::Config for Test {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = ();
-	type Origin = Origin;
-	type Call = Call;
-	type Index = u64;
-	type BlockNumber = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = u64;
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type Event = Event;
-	type BlockHashCount = BlockHashCount;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = pallet_balances::AccountData<u64>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = SS58Prefix;
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+    type BaseCallFilter = frame_support::traits::Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = pallet_balances::AccountData<u64>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = SS58Prefix;
+    type OnSetCode = ();
+    type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u64 = 5;
-	pub const MaxReserves: u32 = 50;
+    pub const ExistentialDeposit: u64 = 5;
+    pub const MaxReserves: u32 = 50;
 }
 
 impl pallet_balances::Config for Test {
-	type Balance = u64;
-	type Event = Event;
-	type DustRemoval = ();
-	type ExistentialDeposit = ExistentialDeposit;
-	type AccountStore = System;
-	type WeightInfo = ();
-	type MaxLocks = ();
-	type MaxReserves = MaxReserves;
-	type ReserveIdentifier = [u8; 8];
+    type Balance = u64;
+    type Event = Event;
+    type DustRemoval = ();
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+    type MaxLocks = ();
+    type MaxReserves = MaxReserves;
+    type ReserveIdentifier = [u8; 8];
 }
 
 pub struct Author4;
 impl FindAuthor<u64> for Author4 {
-	fn find_author<'a, I>(_digests: I) -> Option<u64>
-	where
-		I: 'a + IntoIterator<Item = (frame_support::ConsensusEngineId, &'a [u8])>,
-	{
-		Some(4)
-	}
+    fn find_author<'a, I>(_digests: I) -> Option<u64>
+    where
+        I: 'a + IntoIterator<Item = (frame_support::ConsensusEngineId, &'a [u8])>,
+    {
+        Some(4)
+    }
 }
 
 impl pallet_authorship::Config for Test {
-	type FindAuthor = Author4;
-	type UncleGenerations = ();
-	type FilterUncle = ();
-	type EventHandler = CollatorSelection;
+    type FindAuthor = Author4;
+    type UncleGenerations = ();
+    type FilterUncle = ();
+    type EventHandler = CollatorSelection;
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = 1;
+    pub const MinimumPeriod: u64 = 1;
 }
 
 impl pallet_timestamp::Config for Test {
-	type Moment = u64;
-	type OnTimestampSet = Aura;
-	type MinimumPeriod = MinimumPeriod;
-	type WeightInfo = ();
+    type Moment = u64;
+    type OnTimestampSet = Aura;
+    type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = ();
 }
 
 impl pallet_aura::Config for Test {
-	type AuthorityId = sp_consensus_aura::sr25519::AuthorityId;
-	type MaxAuthorities = MaxAuthorities;
-	type DisabledValidators = ();
+    type AuthorityId = sp_consensus_aura::sr25519::AuthorityId;
+    type MaxAuthorities = MaxAuthorities;
+    type DisabledValidators = ();
 }
 
 sp_runtime::impl_opaque_keys! {
-	pub struct MockSessionKeys {
-		// a key for aura authoring
-		pub aura: UintAuthorityId,
-	}
+    pub struct MockSessionKeys {
+        // a key for aura authoring
+        pub aura: UintAuthorityId,
+    }
 }
 
 impl From<UintAuthorityId> for MockSessionKeys {
-	fn from(aura: sp_runtime::testing::UintAuthorityId) -> Self {
-		Self { aura }
-	}
+    fn from(aura: sp_runtime::testing::UintAuthorityId) -> Self {
+        Self { aura }
+    }
 }
 
 parameter_types! {
-	pub static SessionHandlerCollators: Vec<u64> = Vec::new();
-	pub static SessionChangeBlock: u64 = 0;
+    pub static SessionHandlerCollators: Vec<u64> = Vec::new();
+    pub static SessionChangeBlock: u64 = 0;
 }
 
 pub struct TestSessionHandler;
 impl pallet_session::SessionHandler<u64> for TestSessionHandler {
-	const KEY_TYPE_IDS: &'static [sp_runtime::KeyTypeId] = &[UintAuthorityId::ID];
-	fn on_genesis_session<Ks: OpaqueKeys>(keys: &[(u64, Ks)]) {
-		SessionHandlerCollators::set(keys.into_iter().map(|(a, _)| *a).collect::<Vec<_>>())
-	}
-	fn on_new_session<Ks: OpaqueKeys>(_: bool, keys: &[(u64, Ks)], _: &[(u64, Ks)]) {
-		SessionChangeBlock::set(System::block_number());
-		dbg!(keys.len());
-		SessionHandlerCollators::set(keys.into_iter().map(|(a, _)| *a).collect::<Vec<_>>())
-	}
-	fn on_before_session_ending() {}
-	fn on_disabled(_: u32) {}
+    const KEY_TYPE_IDS: &'static [sp_runtime::KeyTypeId] = &[UintAuthorityId::ID];
+    fn on_genesis_session<Ks: OpaqueKeys>(keys: &[(u64, Ks)]) {
+        SessionHandlerCollators::set(keys.into_iter().map(|(a, _)| *a).collect::<Vec<_>>())
+    }
+    fn on_new_session<Ks: OpaqueKeys>(_: bool, keys: &[(u64, Ks)], _: &[(u64, Ks)]) {
+        SessionChangeBlock::set(System::block_number());
+        dbg!(keys.len());
+        SessionHandlerCollators::set(keys.into_iter().map(|(a, _)| *a).collect::<Vec<_>>())
+    }
+    fn on_before_session_ending() {}
+    fn on_disabled(_: u32) {}
 }
 
 parameter_types! {
-	pub const Offset: u64 = 0;
-	pub const Period: u64 = 10;
+    pub const Offset: u64 = 0;
+    pub const Period: u64 = 10;
 }
 
 impl pallet_session::Config for Test {
-	type Event = Event;
-	type ValidatorId = <Self as frame_system::Config>::AccountId;
-	// we don't have stash and controller, thus we don't need the convert as well.
-	type ValidatorIdOf = IdentityCollator;
-	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
-	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
-	type SessionManager = CollatorSelection;
-	type SessionHandler = TestSessionHandler;
-	type Keys = MockSessionKeys;
-	type WeightInfo = ();
+    type Event = Event;
+    type ValidatorId = <Self as frame_system::Config>::AccountId;
+    // we don't have stash and controller, thus we don't need the convert as well.
+    type ValidatorIdOf = IdentityCollator;
+    type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+    type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+    type SessionManager = CollatorSelection;
+    type SessionHandler = TestSessionHandler;
+    type Keys = MockSessionKeys;
+    type WeightInfo = ();
 }
 
 ord_parameter_types! {
-	pub const RootAccount: u64 = 777;
+    pub const RootAccount: u64 = 777;
 }
 
 parameter_types! {
-	pub const PotId: PalletId = PalletId(*b"PotStake");
-	pub const MaxCandidates: u32 = 20;
-	pub const MaxInvulnerables: u32 = 20;
-	pub const MinCandidates: u32 = 1;
-	pub const MaxAuthorities: u32 = 100_000;
+    pub const PotId: PalletId = PalletId(*b"PotStake");
+    pub const MaxCandidates: u32 = 20;
+    pub const MaxInvulnerables: u32 = 20;
+    pub const MinCandidates: u32 = 1;
+    pub const MaxAuthorities: u32 = 100_000;
 }
 
 pub struct IsRegistered;
 impl ValidatorRegistration<u64> for IsRegistered {
-	fn is_registered(id: &u64) -> bool {
-		if *id == 7u64 {
-			false
-		} else {
-			true
-		}
-	}
+    fn is_registered(id: &u64) -> bool {
+        if *id == 7u64 {
+            false
+        } else {
+            true
+        }
+    }
 }
 
 impl Config for Test {
-	type Event = Event;
-	type Currency = Balances;
-	type UpdateOrigin = EnsureSignedBy<RootAccount, u64>;
-	type PotId = PotId;
-	type MaxCandidates = MaxCandidates;
-	type MinCandidates = MinCandidates;
-	type MaxInvulnerables = MaxInvulnerables;
-	type KickThreshold = Period;
-	type ValidatorId = <Self as frame_system::Config>::AccountId;
-	type ValidatorIdOf = IdentityCollator;
-	type ValidatorRegistration = IsRegistered;
-	type WeightInfo = ();
+    type Event = Event;
+    type Currency = Balances;
+    type UpdateOrigin = EnsureSignedBy<RootAccount, u64>;
+    type PotId = PotId;
+    type MaxCandidates = MaxCandidates;
+    type MinCandidates = MinCandidates;
+    type MaxInvulnerables = MaxInvulnerables;
+    type KickThreshold = Period;
+    type ValidatorId = <Self as frame_system::Config>::AccountId;
+    type ValidatorIdOf = IdentityCollator;
+    type ValidatorRegistration = IsRegistered;
+    type WeightInfo = ();
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	sp_tracing::try_init_simple();
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-	let invulnerables = vec![1, 2];
+    sp_tracing::try_init_simple();
+    let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+    let invulnerables = vec![1, 2];
 
-	let balances = vec![(1, 100), (2, 100), (3, 100), (4, 100), (5, 100)];
-	let keys = balances
-		.iter()
-		.map(|&(i, _)| (i, i, MockSessionKeys { aura: UintAuthorityId(i) }))
-		.collect::<Vec<_>>();
-	let collator_selection = collator_selection::GenesisConfig::<Test> {
-		desired_candidates: 2,
-		candidacy_bond: 10,
-		invulnerables,
-	};
-	let session = pallet_session::GenesisConfig::<Test> { keys };
-	pallet_balances::GenesisConfig::<Test> { balances }
-		.assimilate_storage(&mut t)
-		.unwrap();
-	// collator selection must be initialized before session.
-	collator_selection.assimilate_storage(&mut t).unwrap();
-	session.assimilate_storage(&mut t).unwrap();
+    let balances = vec![(1, 100), (2, 100), (3, 100), (4, 100), (5, 100)];
+    let keys = balances
+        .iter()
+        .map(|&(i, _)| {
+            (
+                i,
+                i,
+                MockSessionKeys {
+                    aura: UintAuthorityId(i),
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    let collator_selection = collator_selection::GenesisConfig::<Test> {
+        desired_candidates: 2,
+        candidacy_bond: 10,
+        invulnerables,
+    };
+    let session = pallet_session::GenesisConfig::<Test> { keys };
+    pallet_balances::GenesisConfig::<Test> { balances }
+        .assimilate_storage(&mut t)
+        .unwrap();
+    // collator selection must be initialized before session.
+    collator_selection.assimilate_storage(&mut t).unwrap();
+    session.assimilate_storage(&mut t).unwrap();
 
-	t.into()
+    t.into()
 }
 
 pub fn initialize_to_block(n: u64) {
-	for i in System::block_number() + 1..=n {
-		System::set_block_number(i);
-		<AllPalletsWithSystem as frame_support::traits::OnInitialize<u64>>::on_initialize(i);
-	}
+    for i in System::block_number() + 1..=n {
+        System::set_block_number(i);
+        <AllPalletsWithSystem as frame_support::traits::OnInitialize<u64>>::on_initialize(i);
+    }
 }

--- a/crates/collator-selection/src/mock.rs
+++ b/crates/collator-selection/src/mock.rs
@@ -208,7 +208,8 @@ impl ValidatorRegistration<u64> for IsRegistered {
 
 impl Config for Test {
     type Event = Event;
-    type Currency = Balances;
+    type StakingCurrency = Balances;
+    type RewardsCurrency = Balances;
     type UpdateOrigin = EnsureSignedBy<RootAccount, u64>;
     type PotId = PotId;
     type MaxCandidates = MaxCandidates;

--- a/crates/collator-selection/src/tests.rs
+++ b/crates/collator-selection/src/tests.rs
@@ -1,0 +1,391 @@
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate as collator_selection;
+use crate::{mock::*, CandidateInfo, Error};
+use frame_support::{
+	assert_noop, assert_ok,
+	traits::{Currency, GenesisBuild, OnInitialize},
+};
+use pallet_balances::Error as BalancesError;
+use sp_runtime::traits::BadOrigin;
+
+#[test]
+fn basic_setup_works() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		assert!(CollatorSelection::candidates().is_empty());
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+	});
+}
+
+#[test]
+fn it_should_set_invulnerables() {
+	new_test_ext().execute_with(|| {
+		let new_set = vec![1, 2, 3, 4];
+		assert_ok!(CollatorSelection::set_invulnerables(
+			Origin::signed(RootAccount::get()),
+			new_set.clone()
+		));
+		assert_eq!(CollatorSelection::invulnerables(), new_set);
+
+		// cannot set with non-root.
+		assert_noop!(
+			CollatorSelection::set_invulnerables(Origin::signed(1), new_set.clone()),
+			BadOrigin
+		);
+
+		// cannot set invulnerables without associated validator keys
+		let invulnerables = vec![7];
+		assert_noop!(
+			CollatorSelection::set_invulnerables(
+				Origin::signed(RootAccount::get()),
+				invulnerables.clone()
+			),
+			Error::<Test>::ValidatorNotRegistered
+		);
+	});
+}
+
+#[test]
+fn set_desired_candidates_works() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+
+		// can set
+		assert_ok!(CollatorSelection::set_desired_candidates(
+			Origin::signed(RootAccount::get()),
+			7
+		));
+		assert_eq!(CollatorSelection::desired_candidates(), 7);
+
+		// rejects bad origin
+		assert_noop!(CollatorSelection::set_desired_candidates(Origin::signed(1), 8), BadOrigin);
+	});
+}
+
+#[test]
+fn set_candidacy_bond() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		// can set
+		assert_ok!(CollatorSelection::set_candidacy_bond(Origin::signed(RootAccount::get()), 7));
+		assert_eq!(CollatorSelection::candidacy_bond(), 7);
+
+		// rejects bad origin.
+		assert_noop!(CollatorSelection::set_candidacy_bond(Origin::signed(1), 8), BadOrigin);
+	});
+}
+
+#[test]
+fn cannot_register_candidate_if_too_many() {
+	new_test_ext().execute_with(|| {
+		// reset desired candidates:
+		<crate::DesiredCandidates<Test>>::put(0);
+
+		// can't accept anyone anymore.
+		assert_noop!(
+			CollatorSelection::register_as_candidate(Origin::signed(3)),
+			Error::<Test>::TooManyCandidates,
+		);
+
+		// reset desired candidates:
+		<crate::DesiredCandidates<Test>>::put(1);
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+
+		// but no more
+		assert_noop!(
+			CollatorSelection::register_as_candidate(Origin::signed(5)),
+			Error::<Test>::TooManyCandidates,
+		);
+	})
+}
+
+#[test]
+fn cannot_unregister_candidate_if_too_few() {
+	new_test_ext().execute_with(|| {
+		// reset desired candidates:
+		<crate::DesiredCandidates<Test>>::put(1);
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+
+		// can not remove too few
+		assert_noop!(
+			CollatorSelection::leave_intent(Origin::signed(4)),
+			Error::<Test>::TooFewCandidates,
+		);
+	})
+}
+
+#[test]
+fn cannot_register_as_candidate_if_invulnerable() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		// can't 1 because it is invulnerable.
+		assert_noop!(
+			CollatorSelection::register_as_candidate(Origin::signed(1)),
+			Error::<Test>::AlreadyInvulnerable,
+		);
+	})
+}
+
+#[test]
+fn cannot_register_as_candidate_if_keys_not_registered() {
+	new_test_ext().execute_with(|| {
+		// can't 7 because keys not registered.
+		assert_noop!(
+			CollatorSelection::register_as_candidate(Origin::signed(7)),
+			Error::<Test>::ValidatorNotRegistered
+		);
+	})
+}
+
+#[test]
+fn cannot_register_dupe_candidate() {
+	new_test_ext().execute_with(|| {
+		// can add 3 as candidate
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+		let addition = CandidateInfo { who: 3, deposit: 10 };
+		assert_eq!(CollatorSelection::candidates(), vec![addition]);
+		assert_eq!(CollatorSelection::last_authored_block(3), 10);
+		assert_eq!(Balances::free_balance(3), 90);
+
+		// but no more
+		assert_noop!(
+			CollatorSelection::register_as_candidate(Origin::signed(3)),
+			Error::<Test>::AlreadyCandidate,
+		);
+	})
+}
+
+#[test]
+fn cannot_register_as_candidate_if_poor() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(Balances::free_balance(&3), 100);
+		assert_eq!(Balances::free_balance(&33), 0);
+
+		// works
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+
+		// poor
+		assert_noop!(
+			CollatorSelection::register_as_candidate(Origin::signed(33)),
+			BalancesError::<Test>::InsufficientBalance,
+		);
+	});
+}
+
+#[test]
+fn register_as_candidate_works() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+		assert_eq!(CollatorSelection::candidates(), Vec::new());
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		// take two endowed, non-invulnerables accounts.
+		assert_eq!(Balances::free_balance(&3), 100);
+		assert_eq!(Balances::free_balance(&4), 100);
+
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+
+		assert_eq!(Balances::free_balance(&3), 90);
+		assert_eq!(Balances::free_balance(&4), 90);
+
+		assert_eq!(CollatorSelection::candidates().len(), 2);
+	});
+}
+
+#[test]
+fn leave_intent() {
+	new_test_ext().execute_with(|| {
+		// register a candidate.
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+		assert_eq!(Balances::free_balance(3), 90);
+
+		// register too so can leave above min candidates
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(5)));
+		assert_eq!(Balances::free_balance(5), 90);
+
+		// cannot leave if not candidate.
+		assert_noop!(
+			CollatorSelection::leave_intent(Origin::signed(4)),
+			Error::<Test>::NotCandidate
+		);
+
+		// bond is returned
+		assert_ok!(CollatorSelection::leave_intent(Origin::signed(3)));
+		assert_eq!(Balances::free_balance(3), 100);
+		assert_eq!(CollatorSelection::last_authored_block(3), 0);
+	});
+}
+
+#[test]
+fn authorship_event_handler() {
+	new_test_ext().execute_with(|| {
+		// put 100 in the pot + 5 for ED
+		Balances::make_free_balance_be(&CollatorSelection::account_id(), 105);
+
+		// 4 is the default author.
+		assert_eq!(Balances::free_balance(4), 100);
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+		// triggers `note_author`
+		Authorship::on_initialize(1);
+
+		let collator = CandidateInfo { who: 4, deposit: 10 };
+
+		assert_eq!(CollatorSelection::candidates(), vec![collator]);
+		assert_eq!(CollatorSelection::last_authored_block(4), 0);
+
+		// half of the pot goes to the collator who's the author (4 in tests).
+		assert_eq!(Balances::free_balance(4), 140);
+		// half + ED stays.
+		assert_eq!(Balances::free_balance(CollatorSelection::account_id()), 55);
+	});
+}
+
+#[test]
+fn fees_edgecases() {
+	new_test_ext().execute_with(|| {
+		// Nothing panics, no reward when no ED in balance
+		Authorship::on_initialize(1);
+		// put some money into the pot at ED
+		Balances::make_free_balance_be(&CollatorSelection::account_id(), 5);
+		// 4 is the default author.
+		assert_eq!(Balances::free_balance(4), 100);
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+		// triggers `note_author`
+		Authorship::on_initialize(1);
+
+		let collator = CandidateInfo { who: 4, deposit: 10 };
+
+		assert_eq!(CollatorSelection::candidates(), vec![collator]);
+		assert_eq!(CollatorSelection::last_authored_block(4), 0);
+		// Nothing received
+		assert_eq!(Balances::free_balance(4), 90);
+		// all fee stays
+		assert_eq!(Balances::free_balance(CollatorSelection::account_id()), 5);
+	});
+}
+
+#[test]
+fn session_management_works() {
+	new_test_ext().execute_with(|| {
+		initialize_to_block(1);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(4);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		// add a new collator
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+
+		// session won't see this.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+		// but we have a new candidate.
+		assert_eq!(CollatorSelection::candidates().len(), 1);
+
+		initialize_to_block(10);
+		assert_eq!(SessionChangeBlock::get(), 10);
+		// pallet-session has 1 session delay; current validators are the same.
+		assert_eq!(Session::validators(), vec![1, 2]);
+		// queued ones are changed, and now we have 3.
+		assert_eq!(Session::queued_keys().len(), 3);
+		// session handlers (aura, et. al.) cannot see this yet.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(20);
+		assert_eq!(SessionChangeBlock::get(), 20);
+		// changed are now reflected to session handlers.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3]);
+	});
+}
+
+#[test]
+fn kick_mechanism() {
+	new_test_ext().execute_with(|| {
+		// add a new collator
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+		initialize_to_block(10);
+		assert_eq!(CollatorSelection::candidates().len(), 2);
+		initialize_to_block(20);
+		assert_eq!(SessionChangeBlock::get(), 20);
+		// 4 authored this block, gets to stay 3 was kicked
+		assert_eq!(CollatorSelection::candidates().len(), 1);
+		// 3 will be kicked after 1 session delay
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3, 4]);
+		let collator = CandidateInfo { who: 4, deposit: 10 };
+		assert_eq!(CollatorSelection::candidates(), vec![collator]);
+		assert_eq!(CollatorSelection::last_authored_block(4), 20);
+		initialize_to_block(30);
+		// 3 gets kicked after 1 session delay
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 4]);
+		// kicked collator gets funds back
+		assert_eq!(Balances::free_balance(3), 100);
+	});
+}
+
+#[test]
+fn should_not_kick_mechanism_too_few() {
+	new_test_ext().execute_with(|| {
+		// add a new collator
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(5)));
+		initialize_to_block(10);
+		assert_eq!(CollatorSelection::candidates().len(), 2);
+		initialize_to_block(20);
+		assert_eq!(SessionChangeBlock::get(), 20);
+		// 4 authored this block, 5 gets to stay too few 3 was kicked
+		assert_eq!(CollatorSelection::candidates().len(), 1);
+		// 3 will be kicked after 1 session delay
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3, 5]);
+		let collator = CandidateInfo { who: 5, deposit: 10 };
+		assert_eq!(CollatorSelection::candidates(), vec![collator]);
+		assert_eq!(CollatorSelection::last_authored_block(4), 20);
+		initialize_to_block(30);
+		// 3 gets kicked after 1 session delay
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 5]);
+		// kicked collator gets funds back
+		assert_eq!(Balances::free_balance(3), 100);
+	});
+}
+
+#[test]
+#[should_panic = "duplicate invulnerables in genesis."]
+fn cannot_set_genesis_value_twice() {
+	sp_tracing::try_init_simple();
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let invulnerables = vec![1, 1];
+
+	let collator_selection = collator_selection::GenesisConfig::<Test> {
+		desired_candidates: 2,
+		candidacy_bond: 10,
+		invulnerables,
+	};
+	// collator selection must be initialized before session.
+	collator_selection.assimilate_storage(&mut t).unwrap();
+}

--- a/crates/collator-selection/src/tests.rs
+++ b/crates/collator-selection/src/tests.rs
@@ -16,376 +16,379 @@
 use crate as collator_selection;
 use crate::{mock::*, CandidateInfo, Error};
 use frame_support::{
-	assert_noop, assert_ok,
-	traits::{Currency, GenesisBuild, OnInitialize},
+    assert_noop, assert_ok,
+    traits::{Currency, GenesisBuild, OnInitialize},
 };
 use pallet_balances::Error as BalancesError;
 use sp_runtime::traits::BadOrigin;
 
 #[test]
 fn basic_setup_works() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(CollatorSelection::desired_candidates(), 2);
-		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+    new_test_ext().execute_with(|| {
+        assert_eq!(CollatorSelection::desired_candidates(), 2);
+        assert_eq!(CollatorSelection::candidacy_bond(), 10);
 
-		assert!(CollatorSelection::candidates().is_empty());
-		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
-	});
+        assert!(CollatorSelection::candidates().is_empty());
+        assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+    });
 }
 
 #[test]
 fn it_should_set_invulnerables() {
-	new_test_ext().execute_with(|| {
-		let new_set = vec![1, 2, 3, 4];
-		assert_ok!(CollatorSelection::set_invulnerables(
-			Origin::signed(RootAccount::get()),
-			new_set.clone()
-		));
-		assert_eq!(CollatorSelection::invulnerables(), new_set);
+    new_test_ext().execute_with(|| {
+        let new_set = vec![1, 2, 3, 4];
+        assert_ok!(CollatorSelection::set_invulnerables(
+            Origin::signed(RootAccount::get()),
+            new_set.clone()
+        ));
+        assert_eq!(CollatorSelection::invulnerables(), new_set);
 
-		// cannot set with non-root.
-		assert_noop!(
-			CollatorSelection::set_invulnerables(Origin::signed(1), new_set.clone()),
-			BadOrigin
-		);
+        // cannot set with non-root.
+        assert_noop!(
+            CollatorSelection::set_invulnerables(Origin::signed(1), new_set.clone()),
+            BadOrigin
+        );
 
-		// cannot set invulnerables without associated validator keys
-		let invulnerables = vec![7];
-		assert_noop!(
-			CollatorSelection::set_invulnerables(
-				Origin::signed(RootAccount::get()),
-				invulnerables.clone()
-			),
-			Error::<Test>::ValidatorNotRegistered
-		);
-	});
+        // cannot set invulnerables without associated validator keys
+        let invulnerables = vec![7];
+        assert_noop!(
+            CollatorSelection::set_invulnerables(Origin::signed(RootAccount::get()), invulnerables.clone()),
+            Error::<Test>::ValidatorNotRegistered
+        );
+    });
 }
 
 #[test]
 fn set_desired_candidates_works() {
-	new_test_ext().execute_with(|| {
-		// given
-		assert_eq!(CollatorSelection::desired_candidates(), 2);
+    new_test_ext().execute_with(|| {
+        // given
+        assert_eq!(CollatorSelection::desired_candidates(), 2);
 
-		// can set
-		assert_ok!(CollatorSelection::set_desired_candidates(
-			Origin::signed(RootAccount::get()),
-			7
-		));
-		assert_eq!(CollatorSelection::desired_candidates(), 7);
+        // can set
+        assert_ok!(CollatorSelection::set_desired_candidates(
+            Origin::signed(RootAccount::get()),
+            7
+        ));
+        assert_eq!(CollatorSelection::desired_candidates(), 7);
 
-		// rejects bad origin
-		assert_noop!(CollatorSelection::set_desired_candidates(Origin::signed(1), 8), BadOrigin);
-	});
+        // rejects bad origin
+        assert_noop!(
+            CollatorSelection::set_desired_candidates(Origin::signed(1), 8),
+            BadOrigin
+        );
+    });
 }
 
 #[test]
 fn set_candidacy_bond() {
-	new_test_ext().execute_with(|| {
-		// given
-		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+    new_test_ext().execute_with(|| {
+        // given
+        assert_eq!(CollatorSelection::candidacy_bond(), 10);
 
-		// can set
-		assert_ok!(CollatorSelection::set_candidacy_bond(Origin::signed(RootAccount::get()), 7));
-		assert_eq!(CollatorSelection::candidacy_bond(), 7);
+        // can set
+        assert_ok!(CollatorSelection::set_candidacy_bond(
+            Origin::signed(RootAccount::get()),
+            7
+        ));
+        assert_eq!(CollatorSelection::candidacy_bond(), 7);
 
-		// rejects bad origin.
-		assert_noop!(CollatorSelection::set_candidacy_bond(Origin::signed(1), 8), BadOrigin);
-	});
+        // rejects bad origin.
+        assert_noop!(CollatorSelection::set_candidacy_bond(Origin::signed(1), 8), BadOrigin);
+    });
 }
 
 #[test]
 fn cannot_register_candidate_if_too_many() {
-	new_test_ext().execute_with(|| {
-		// reset desired candidates:
-		<crate::DesiredCandidates<Test>>::put(0);
+    new_test_ext().execute_with(|| {
+        // reset desired candidates:
+        <crate::DesiredCandidates<Test>>::put(0);
 
-		// can't accept anyone anymore.
-		assert_noop!(
-			CollatorSelection::register_as_candidate(Origin::signed(3)),
-			Error::<Test>::TooManyCandidates,
-		);
+        // can't accept anyone anymore.
+        assert_noop!(
+            CollatorSelection::register_as_candidate(Origin::signed(3)),
+            Error::<Test>::TooManyCandidates,
+        );
 
-		// reset desired candidates:
-		<crate::DesiredCandidates<Test>>::put(1);
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+        // reset desired candidates:
+        <crate::DesiredCandidates<Test>>::put(1);
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
 
-		// but no more
-		assert_noop!(
-			CollatorSelection::register_as_candidate(Origin::signed(5)),
-			Error::<Test>::TooManyCandidates,
-		);
-	})
+        // but no more
+        assert_noop!(
+            CollatorSelection::register_as_candidate(Origin::signed(5)),
+            Error::<Test>::TooManyCandidates,
+        );
+    })
 }
 
 #[test]
 fn cannot_unregister_candidate_if_too_few() {
-	new_test_ext().execute_with(|| {
-		// reset desired candidates:
-		<crate::DesiredCandidates<Test>>::put(1);
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+    new_test_ext().execute_with(|| {
+        // reset desired candidates:
+        <crate::DesiredCandidates<Test>>::put(1);
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
 
-		// can not remove too few
-		assert_noop!(
-			CollatorSelection::leave_intent(Origin::signed(4)),
-			Error::<Test>::TooFewCandidates,
-		);
-	})
+        // can not remove too few
+        assert_noop!(
+            CollatorSelection::leave_intent(Origin::signed(4)),
+            Error::<Test>::TooFewCandidates,
+        );
+    })
 }
 
 #[test]
 fn cannot_register_as_candidate_if_invulnerable() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+    new_test_ext().execute_with(|| {
+        assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
 
-		// can't 1 because it is invulnerable.
-		assert_noop!(
-			CollatorSelection::register_as_candidate(Origin::signed(1)),
-			Error::<Test>::AlreadyInvulnerable,
-		);
-	})
+        // can't 1 because it is invulnerable.
+        assert_noop!(
+            CollatorSelection::register_as_candidate(Origin::signed(1)),
+            Error::<Test>::AlreadyInvulnerable,
+        );
+    })
 }
 
 #[test]
 fn cannot_register_as_candidate_if_keys_not_registered() {
-	new_test_ext().execute_with(|| {
-		// can't 7 because keys not registered.
-		assert_noop!(
-			CollatorSelection::register_as_candidate(Origin::signed(7)),
-			Error::<Test>::ValidatorNotRegistered
-		);
-	})
+    new_test_ext().execute_with(|| {
+        // can't 7 because keys not registered.
+        assert_noop!(
+            CollatorSelection::register_as_candidate(Origin::signed(7)),
+            Error::<Test>::ValidatorNotRegistered
+        );
+    })
 }
 
 #[test]
 fn cannot_register_dupe_candidate() {
-	new_test_ext().execute_with(|| {
-		// can add 3 as candidate
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
-		let addition = CandidateInfo { who: 3, deposit: 10 };
-		assert_eq!(CollatorSelection::candidates(), vec![addition]);
-		assert_eq!(CollatorSelection::last_authored_block(3), 10);
-		assert_eq!(Balances::free_balance(3), 90);
+    new_test_ext().execute_with(|| {
+        // can add 3 as candidate
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+        let addition = CandidateInfo { who: 3, deposit: 10 };
+        assert_eq!(CollatorSelection::candidates(), vec![addition]);
+        assert_eq!(CollatorSelection::last_authored_block(3), 10);
+        assert_eq!(Balances::free_balance(3), 90);
 
-		// but no more
-		assert_noop!(
-			CollatorSelection::register_as_candidate(Origin::signed(3)),
-			Error::<Test>::AlreadyCandidate,
-		);
-	})
+        // but no more
+        assert_noop!(
+            CollatorSelection::register_as_candidate(Origin::signed(3)),
+            Error::<Test>::AlreadyCandidate,
+        );
+    })
 }
 
 #[test]
 fn cannot_register_as_candidate_if_poor() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(Balances::free_balance(&3), 100);
-		assert_eq!(Balances::free_balance(&33), 0);
+    new_test_ext().execute_with(|| {
+        assert_eq!(Balances::free_balance(&3), 100);
+        assert_eq!(Balances::free_balance(&33), 0);
 
-		// works
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+        // works
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
 
-		// poor
-		assert_noop!(
-			CollatorSelection::register_as_candidate(Origin::signed(33)),
-			BalancesError::<Test>::InsufficientBalance,
-		);
-	});
+        // poor
+        assert_noop!(
+            CollatorSelection::register_as_candidate(Origin::signed(33)),
+            BalancesError::<Test>::InsufficientBalance,
+        );
+    });
 }
 
 #[test]
 fn register_as_candidate_works() {
-	new_test_ext().execute_with(|| {
-		// given
-		assert_eq!(CollatorSelection::desired_candidates(), 2);
-		assert_eq!(CollatorSelection::candidacy_bond(), 10);
-		assert_eq!(CollatorSelection::candidates(), Vec::new());
-		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+    new_test_ext().execute_with(|| {
+        // given
+        assert_eq!(CollatorSelection::desired_candidates(), 2);
+        assert_eq!(CollatorSelection::candidacy_bond(), 10);
+        assert_eq!(CollatorSelection::candidates(), Vec::new());
+        assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
 
-		// take two endowed, non-invulnerables accounts.
-		assert_eq!(Balances::free_balance(&3), 100);
-		assert_eq!(Balances::free_balance(&4), 100);
+        // take two endowed, non-invulnerables accounts.
+        assert_eq!(Balances::free_balance(&3), 100);
+        assert_eq!(Balances::free_balance(&4), 100);
 
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
 
-		assert_eq!(Balances::free_balance(&3), 90);
-		assert_eq!(Balances::free_balance(&4), 90);
+        assert_eq!(Balances::free_balance(&3), 90);
+        assert_eq!(Balances::free_balance(&4), 90);
 
-		assert_eq!(CollatorSelection::candidates().len(), 2);
-	});
+        assert_eq!(CollatorSelection::candidates().len(), 2);
+    });
 }
 
 #[test]
 fn leave_intent() {
-	new_test_ext().execute_with(|| {
-		// register a candidate.
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
-		assert_eq!(Balances::free_balance(3), 90);
+    new_test_ext().execute_with(|| {
+        // register a candidate.
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+        assert_eq!(Balances::free_balance(3), 90);
 
-		// register too so can leave above min candidates
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(5)));
-		assert_eq!(Balances::free_balance(5), 90);
+        // register too so can leave above min candidates
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(5)));
+        assert_eq!(Balances::free_balance(5), 90);
 
-		// cannot leave if not candidate.
-		assert_noop!(
-			CollatorSelection::leave_intent(Origin::signed(4)),
-			Error::<Test>::NotCandidate
-		);
+        // cannot leave if not candidate.
+        assert_noop!(
+            CollatorSelection::leave_intent(Origin::signed(4)),
+            Error::<Test>::NotCandidate
+        );
 
-		// bond is returned
-		assert_ok!(CollatorSelection::leave_intent(Origin::signed(3)));
-		assert_eq!(Balances::free_balance(3), 100);
-		assert_eq!(CollatorSelection::last_authored_block(3), 0);
-	});
+        // bond is returned
+        assert_ok!(CollatorSelection::leave_intent(Origin::signed(3)));
+        assert_eq!(Balances::free_balance(3), 100);
+        assert_eq!(CollatorSelection::last_authored_block(3), 0);
+    });
 }
 
 #[test]
 fn authorship_event_handler() {
-	new_test_ext().execute_with(|| {
-		// put 100 in the pot + 5 for ED
-		Balances::make_free_balance_be(&CollatorSelection::account_id(), 105);
+    new_test_ext().execute_with(|| {
+        // put 100 in the pot + 5 for ED
+        Balances::make_free_balance_be(&CollatorSelection::account_id(), 105);
 
-		// 4 is the default author.
-		assert_eq!(Balances::free_balance(4), 100);
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
-		// triggers `note_author`
-		Authorship::on_initialize(1);
+        // 4 is the default author.
+        assert_eq!(Balances::free_balance(4), 100);
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+        // triggers `note_author`
+        Authorship::on_initialize(1);
 
-		let collator = CandidateInfo { who: 4, deposit: 10 };
+        let collator = CandidateInfo { who: 4, deposit: 10 };
 
-		assert_eq!(CollatorSelection::candidates(), vec![collator]);
-		assert_eq!(CollatorSelection::last_authored_block(4), 0);
+        assert_eq!(CollatorSelection::candidates(), vec![collator]);
+        assert_eq!(CollatorSelection::last_authored_block(4), 0);
 
-		// half of the pot goes to the collator who's the author (4 in tests).
-		assert_eq!(Balances::free_balance(4), 140);
-		// half + ED stays.
-		assert_eq!(Balances::free_balance(CollatorSelection::account_id()), 55);
-	});
+        // half of the pot goes to the collator who's the author (4 in tests).
+        assert_eq!(Balances::free_balance(4), 140);
+        // half + ED stays.
+        assert_eq!(Balances::free_balance(CollatorSelection::account_id()), 55);
+    });
 }
 
 #[test]
 fn fees_edgecases() {
-	new_test_ext().execute_with(|| {
-		// Nothing panics, no reward when no ED in balance
-		Authorship::on_initialize(1);
-		// put some money into the pot at ED
-		Balances::make_free_balance_be(&CollatorSelection::account_id(), 5);
-		// 4 is the default author.
-		assert_eq!(Balances::free_balance(4), 100);
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
-		// triggers `note_author`
-		Authorship::on_initialize(1);
+    new_test_ext().execute_with(|| {
+        // Nothing panics, no reward when no ED in balance
+        Authorship::on_initialize(1);
+        // put some money into the pot at ED
+        Balances::make_free_balance_be(&CollatorSelection::account_id(), 5);
+        // 4 is the default author.
+        assert_eq!(Balances::free_balance(4), 100);
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+        // triggers `note_author`
+        Authorship::on_initialize(1);
 
-		let collator = CandidateInfo { who: 4, deposit: 10 };
+        let collator = CandidateInfo { who: 4, deposit: 10 };
 
-		assert_eq!(CollatorSelection::candidates(), vec![collator]);
-		assert_eq!(CollatorSelection::last_authored_block(4), 0);
-		// Nothing received
-		assert_eq!(Balances::free_balance(4), 90);
-		// all fee stays
-		assert_eq!(Balances::free_balance(CollatorSelection::account_id()), 5);
-	});
+        assert_eq!(CollatorSelection::candidates(), vec![collator]);
+        assert_eq!(CollatorSelection::last_authored_block(4), 0);
+        // Nothing received
+        assert_eq!(Balances::free_balance(4), 90);
+        // all fee stays
+        assert_eq!(Balances::free_balance(CollatorSelection::account_id()), 5);
+    });
 }
 
 #[test]
 fn session_management_works() {
-	new_test_ext().execute_with(|| {
-		initialize_to_block(1);
+    new_test_ext().execute_with(|| {
+        initialize_to_block(1);
 
-		assert_eq!(SessionChangeBlock::get(), 0);
-		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+        assert_eq!(SessionChangeBlock::get(), 0);
+        assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
 
-		initialize_to_block(4);
+        initialize_to_block(4);
 
-		assert_eq!(SessionChangeBlock::get(), 0);
-		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+        assert_eq!(SessionChangeBlock::get(), 0);
+        assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
 
-		// add a new collator
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+        // add a new collator
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
 
-		// session won't see this.
-		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
-		// but we have a new candidate.
-		assert_eq!(CollatorSelection::candidates().len(), 1);
+        // session won't see this.
+        assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+        // but we have a new candidate.
+        assert_eq!(CollatorSelection::candidates().len(), 1);
 
-		initialize_to_block(10);
-		assert_eq!(SessionChangeBlock::get(), 10);
-		// pallet-session has 1 session delay; current validators are the same.
-		assert_eq!(Session::validators(), vec![1, 2]);
-		// queued ones are changed, and now we have 3.
-		assert_eq!(Session::queued_keys().len(), 3);
-		// session handlers (aura, et. al.) cannot see this yet.
-		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+        initialize_to_block(10);
+        assert_eq!(SessionChangeBlock::get(), 10);
+        // pallet-session has 1 session delay; current validators are the same.
+        assert_eq!(Session::validators(), vec![1, 2]);
+        // queued ones are changed, and now we have 3.
+        assert_eq!(Session::queued_keys().len(), 3);
+        // session handlers (aura, et. al.) cannot see this yet.
+        assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
 
-		initialize_to_block(20);
-		assert_eq!(SessionChangeBlock::get(), 20);
-		// changed are now reflected to session handlers.
-		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3]);
-	});
+        initialize_to_block(20);
+        assert_eq!(SessionChangeBlock::get(), 20);
+        // changed are now reflected to session handlers.
+        assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3]);
+    });
 }
 
 #[test]
 fn kick_mechanism() {
-	new_test_ext().execute_with(|| {
-		// add a new collator
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
-		initialize_to_block(10);
-		assert_eq!(CollatorSelection::candidates().len(), 2);
-		initialize_to_block(20);
-		assert_eq!(SessionChangeBlock::get(), 20);
-		// 4 authored this block, gets to stay 3 was kicked
-		assert_eq!(CollatorSelection::candidates().len(), 1);
-		// 3 will be kicked after 1 session delay
-		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3, 4]);
-		let collator = CandidateInfo { who: 4, deposit: 10 };
-		assert_eq!(CollatorSelection::candidates(), vec![collator]);
-		assert_eq!(CollatorSelection::last_authored_block(4), 20);
-		initialize_to_block(30);
-		// 3 gets kicked after 1 session delay
-		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 4]);
-		// kicked collator gets funds back
-		assert_eq!(Balances::free_balance(3), 100);
-	});
+    new_test_ext().execute_with(|| {
+        // add a new collator
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(4)));
+        initialize_to_block(10);
+        assert_eq!(CollatorSelection::candidates().len(), 2);
+        initialize_to_block(20);
+        assert_eq!(SessionChangeBlock::get(), 20);
+        // 4 authored this block, gets to stay 3 was kicked
+        assert_eq!(CollatorSelection::candidates().len(), 1);
+        // 3 will be kicked after 1 session delay
+        assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3, 4]);
+        let collator = CandidateInfo { who: 4, deposit: 10 };
+        assert_eq!(CollatorSelection::candidates(), vec![collator]);
+        assert_eq!(CollatorSelection::last_authored_block(4), 20);
+        initialize_to_block(30);
+        // 3 gets kicked after 1 session delay
+        assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 4]);
+        // kicked collator gets funds back
+        assert_eq!(Balances::free_balance(3), 100);
+    });
 }
 
 #[test]
 fn should_not_kick_mechanism_too_few() {
-	new_test_ext().execute_with(|| {
-		// add a new collator
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
-		assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(5)));
-		initialize_to_block(10);
-		assert_eq!(CollatorSelection::candidates().len(), 2);
-		initialize_to_block(20);
-		assert_eq!(SessionChangeBlock::get(), 20);
-		// 4 authored this block, 5 gets to stay too few 3 was kicked
-		assert_eq!(CollatorSelection::candidates().len(), 1);
-		// 3 will be kicked after 1 session delay
-		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3, 5]);
-		let collator = CandidateInfo { who: 5, deposit: 10 };
-		assert_eq!(CollatorSelection::candidates(), vec![collator]);
-		assert_eq!(CollatorSelection::last_authored_block(4), 20);
-		initialize_to_block(30);
-		// 3 gets kicked after 1 session delay
-		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 5]);
-		// kicked collator gets funds back
-		assert_eq!(Balances::free_balance(3), 100);
-	});
+    new_test_ext().execute_with(|| {
+        // add a new collator
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(3)));
+        assert_ok!(CollatorSelection::register_as_candidate(Origin::signed(5)));
+        initialize_to_block(10);
+        assert_eq!(CollatorSelection::candidates().len(), 2);
+        initialize_to_block(20);
+        assert_eq!(SessionChangeBlock::get(), 20);
+        // 4 authored this block, 5 gets to stay too few 3 was kicked
+        assert_eq!(CollatorSelection::candidates().len(), 1);
+        // 3 will be kicked after 1 session delay
+        assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3, 5]);
+        let collator = CandidateInfo { who: 5, deposit: 10 };
+        assert_eq!(CollatorSelection::candidates(), vec![collator]);
+        assert_eq!(CollatorSelection::last_authored_block(4), 20);
+        initialize_to_block(30);
+        // 3 gets kicked after 1 session delay
+        assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 5]);
+        // kicked collator gets funds back
+        assert_eq!(Balances::free_balance(3), 100);
+    });
 }
 
 #[test]
 #[should_panic = "duplicate invulnerables in genesis."]
 fn cannot_set_genesis_value_twice() {
-	sp_tracing::try_init_simple();
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-	let invulnerables = vec![1, 1];
+    sp_tracing::try_init_simple();
+    let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+    let invulnerables = vec![1, 1];
 
-	let collator_selection = collator_selection::GenesisConfig::<Test> {
-		desired_candidates: 2,
-		candidacy_bond: 10,
-		invulnerables,
-	};
-	// collator selection must be initialized before session.
-	collator_selection.assimilate_storage(&mut t).unwrap();
+    let collator_selection = collator_selection::GenesisConfig::<Test> {
+        desired_candidates: 2,
+        candidacy_bond: 10,
+        invulnerables,
+    };
+    // collator selection must be initialized before session.
+    collator_selection.assimilate_storage(&mut t).unwrap();
 }

--- a/crates/collator-selection/src/weights.rs
+++ b/crates/collator-selection/src/weights.rs
@@ -1,0 +1,129 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::{
+	traits::Get,
+	weights::{constants::RocksDbWeight, Weight},
+};
+use sp_std::marker::PhantomData;
+
+// The weight info trait for `pallet_collator_selection`.
+pub trait WeightInfo {
+	fn set_invulnerables(_b: u32) -> Weight;
+	fn set_desired_candidates() -> Weight;
+	fn set_candidacy_bond() -> Weight;
+	fn register_as_candidate(_c: u32) -> Weight;
+	fn leave_intent(_c: u32) -> Weight;
+	fn note_author() -> Weight;
+	fn new_session(_c: u32, _r: u32) -> Weight;
+}
+
+/// Weights for pallet_collator_selection using the Substrate node and recommended hardware.
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	fn set_invulnerables(b: u32) -> Weight {
+		(18_563_000 as Weight)
+			// Standard Error: 0
+			.saturating_add((68_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	fn set_desired_candidates() -> Weight {
+		(16_363_000 as Weight).saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	fn set_candidacy_bond() -> Weight {
+		(16_840_000 as Weight).saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
+	fn register_as_candidate(c: u32) -> Weight {
+		(71_196_000 as Weight)
+			// Standard Error: 0
+			.saturating_add((198_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	fn leave_intent(c: u32) -> Weight {
+		(55_336_000 as Weight)
+			// Standard Error: 0
+			.saturating_add((151_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	fn note_author() -> Weight {
+		(71_461_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+	}
+	fn new_session(r: u32, c: u32) -> Weight {
+		(0 as Weight)
+			// Standard Error: 1_010_000
+			.saturating_add((109_961_000 as Weight).saturating_mul(r as Weight))
+			// Standard Error: 1_010_000
+			.saturating_add((151_952_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(c as Weight)))
+	}
+}
+
+// For backwards compatibility and tests
+impl WeightInfo for () {
+	fn set_invulnerables(b: u32) -> Weight {
+		(18_563_000 as Weight)
+			// Standard Error: 0
+			.saturating_add((68_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	fn set_desired_candidates() -> Weight {
+		(16_363_000 as Weight).saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	fn set_candidacy_bond() -> Weight {
+		(16_840_000 as Weight).saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	fn register_as_candidate(c: u32) -> Weight {
+		(71_196_000 as Weight)
+			// Standard Error: 0
+			.saturating_add((198_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+	}
+	fn leave_intent(c: u32) -> Weight {
+		(55_336_000 as Weight)
+			// Standard Error: 0
+			.saturating_add((151_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+	}
+	fn note_author() -> Weight {
+		(71_461_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+	}
+	fn new_session(r: u32, c: u32) -> Weight {
+		(0 as Weight)
+			// Standard Error: 1_010_000
+			.saturating_add((109_961_000 as Weight).saturating_mul(r as Weight))
+			// Standard Error: 1_010_000
+			.saturating_add((151_952_000 as Weight).saturating_mul(c as Weight))
+			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(RocksDbWeight::get().reads((2 as Weight).saturating_mul(c as Weight)))
+			.saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(c as Weight)))
+	}
+}

--- a/crates/collator-selection/src/weights.rs
+++ b/crates/collator-selection/src/weights.rs
@@ -19,111 +19,111 @@
 #![allow(unused_imports)]
 
 use frame_support::{
-	traits::Get,
-	weights::{constants::RocksDbWeight, Weight},
+    traits::Get,
+    weights::{constants::RocksDbWeight, Weight},
 };
 use sp_std::marker::PhantomData;
 
-// The weight info trait for `pallet_collator_selection`.
+// The weight info trait for `collator_selection`.
 pub trait WeightInfo {
-	fn set_invulnerables(_b: u32) -> Weight;
-	fn set_desired_candidates() -> Weight;
-	fn set_candidacy_bond() -> Weight;
-	fn register_as_candidate(_c: u32) -> Weight;
-	fn leave_intent(_c: u32) -> Weight;
-	fn note_author() -> Weight;
-	fn new_session(_c: u32, _r: u32) -> Weight;
+    fn set_invulnerables(_b: u32) -> Weight;
+    fn set_desired_candidates() -> Weight;
+    fn set_candidacy_bond() -> Weight;
+    fn register_as_candidate(_c: u32) -> Weight;
+    fn leave_intent(_c: u32) -> Weight;
+    fn note_author() -> Weight;
+    fn new_session(_c: u32, _r: u32) -> Weight;
 }
 
-/// Weights for pallet_collator_selection using the Substrate node and recommended hardware.
+/// Weights for collator_selection using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn set_invulnerables(b: u32) -> Weight {
-		(18_563_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((68_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-	}
-	fn set_desired_candidates() -> Weight {
-		(16_363_000 as Weight).saturating_add(T::DbWeight::get().writes(1 as Weight))
-	}
-	fn set_candidacy_bond() -> Weight {
-		(16_840_000 as Weight).saturating_add(T::DbWeight::get().writes(1 as Weight))
-	}
-	fn register_as_candidate(c: u32) -> Weight {
-		(71_196_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((198_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-	}
-	fn leave_intent(c: u32) -> Weight {
-		(55_336_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((151_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-	}
-	fn note_author() -> Weight {
-		(71_461_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-	}
-	fn new_session(r: u32, c: u32) -> Weight {
-		(0 as Weight)
-			// Standard Error: 1_010_000
-			.saturating_add((109_961_000 as Weight).saturating_mul(r as Weight))
-			// Standard Error: 1_010_000
-			.saturating_add((151_952_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(c as Weight)))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(c as Weight)))
-	}
+    fn set_invulnerables(b: u32) -> Weight {
+        (18_563_000 as Weight)
+            // Standard Error: 0
+            .saturating_add((68_000 as Weight).saturating_mul(b as Weight))
+            .saturating_add(T::DbWeight::get().writes(1 as Weight))
+    }
+    fn set_desired_candidates() -> Weight {
+        (16_363_000 as Weight).saturating_add(T::DbWeight::get().writes(1 as Weight))
+    }
+    fn set_candidacy_bond() -> Weight {
+        (16_840_000 as Weight).saturating_add(T::DbWeight::get().writes(1 as Weight))
+    }
+    fn register_as_candidate(c: u32) -> Weight {
+        (71_196_000 as Weight)
+            // Standard Error: 0
+            .saturating_add((198_000 as Weight).saturating_mul(c as Weight))
+            .saturating_add(T::DbWeight::get().reads(4 as Weight))
+            .saturating_add(T::DbWeight::get().writes(2 as Weight))
+    }
+    fn leave_intent(c: u32) -> Weight {
+        (55_336_000 as Weight)
+            // Standard Error: 0
+            .saturating_add((151_000 as Weight).saturating_mul(c as Weight))
+            .saturating_add(T::DbWeight::get().reads(1 as Weight))
+            .saturating_add(T::DbWeight::get().writes(2 as Weight))
+    }
+    fn note_author() -> Weight {
+        (71_461_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(3 as Weight))
+            .saturating_add(T::DbWeight::get().writes(4 as Weight))
+    }
+    fn new_session(r: u32, c: u32) -> Weight {
+        (0 as Weight)
+            // Standard Error: 1_010_000
+            .saturating_add((109_961_000 as Weight).saturating_mul(r as Weight))
+            // Standard Error: 1_010_000
+            .saturating_add((151_952_000 as Weight).saturating_mul(c as Weight))
+            .saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
+            .saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(c as Weight)))
+            .saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
+            .saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(c as Weight)))
+    }
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn set_invulnerables(b: u32) -> Weight {
-		(18_563_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((68_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
-	}
-	fn set_desired_candidates() -> Weight {
-		(16_363_000 as Weight).saturating_add(RocksDbWeight::get().writes(1 as Weight))
-	}
-	fn set_candidacy_bond() -> Weight {
-		(16_840_000 as Weight).saturating_add(RocksDbWeight::get().writes(1 as Weight))
-	}
-	fn register_as_candidate(c: u32) -> Weight {
-		(71_196_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((198_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(4 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
-	}
-	fn leave_intent(c: u32) -> Weight {
-		(55_336_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((151_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
-	}
-	fn note_author() -> Weight {
-		(71_461_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
-	}
-	fn new_session(r: u32, c: u32) -> Weight {
-		(0 as Weight)
-			// Standard Error: 1_010_000
-			.saturating_add((109_961_000 as Weight).saturating_mul(r as Weight))
-			// Standard Error: 1_010_000
-			.saturating_add((151_952_000 as Weight).saturating_mul(c as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(RocksDbWeight::get().reads((2 as Weight).saturating_mul(c as Weight)))
-			.saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
-			.saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(c as Weight)))
-	}
+    fn set_invulnerables(b: u32) -> Weight {
+        (18_563_000 as Weight)
+            // Standard Error: 0
+            .saturating_add((68_000 as Weight).saturating_mul(b as Weight))
+            .saturating_add(RocksDbWeight::get().writes(1 as Weight))
+    }
+    fn set_desired_candidates() -> Weight {
+        (16_363_000 as Weight).saturating_add(RocksDbWeight::get().writes(1 as Weight))
+    }
+    fn set_candidacy_bond() -> Weight {
+        (16_840_000 as Weight).saturating_add(RocksDbWeight::get().writes(1 as Weight))
+    }
+    fn register_as_candidate(c: u32) -> Weight {
+        (71_196_000 as Weight)
+            // Standard Error: 0
+            .saturating_add((198_000 as Weight).saturating_mul(c as Weight))
+            .saturating_add(RocksDbWeight::get().reads(4 as Weight))
+            .saturating_add(RocksDbWeight::get().writes(2 as Weight))
+    }
+    fn leave_intent(c: u32) -> Weight {
+        (55_336_000 as Weight)
+            // Standard Error: 0
+            .saturating_add((151_000 as Weight).saturating_mul(c as Weight))
+            .saturating_add(RocksDbWeight::get().reads(1 as Weight))
+            .saturating_add(RocksDbWeight::get().writes(2 as Weight))
+    }
+    fn note_author() -> Weight {
+        (71_461_000 as Weight)
+            .saturating_add(RocksDbWeight::get().reads(3 as Weight))
+            .saturating_add(RocksDbWeight::get().writes(4 as Weight))
+    }
+    fn new_session(r: u32, c: u32) -> Weight {
+        (0 as Weight)
+            // Standard Error: 1_010_000
+            .saturating_add((109_961_000 as Weight).saturating_mul(r as Weight))
+            // Standard Error: 1_010_000
+            .saturating_add((151_952_000 as Weight).saturating_mul(c as Weight))
+            .saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(r as Weight)))
+            .saturating_add(RocksDbWeight::get().reads((2 as Weight).saturating_mul(c as Weight)))
+            .saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
+            .saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(c as Weight)))
+    }
 }

--- a/parachain/runtime/interlay/Cargo.toml
+++ b/parachain/runtime/interlay/Cargo.toml
@@ -65,7 +65,6 @@ cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", br
 cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
-pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 
 # Polkadot dependencies
@@ -93,6 +92,7 @@ escrow = { path = "../../../crates/escrow", default-features = false }
 democracy = { path = "../../../crates/democracy", default-features = false }
 annuity = { path = "../../../crates/annuity", default-features = false }
 supply = { path = "../../../crates/supply", default-features = false }
+collator-selection = { path = "../../../crates/collator-selection", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../../primitives", default-features = false }
 
@@ -179,7 +179,6 @@ std = [
   "cumulus-primitives-core/std",
   "cumulus-primitives-timestamp/std",
   "cumulus-primitives-utility/std",
-  "pallet-collator-selection/std",
 
   "polkadot-parachain/std",
   "xcm/std",
@@ -204,6 +203,7 @@ std = [
   "democracy/std",
   "annuity/std",
   "supply/std",
+  "collator-selection/std",
 
   "primitives/std",
 

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -270,7 +270,8 @@ pub type CollatorSelectionUpdateOrigin =
 
 impl collator_selection::Config for Runtime {
     type Event = Event;
-    type Currency = NativeCurrency;
+    type StakingCurrency = Escrow;
+    type RewardsCurrency = NativeCurrency;
     type UpdateOrigin = CollatorSelectionUpdateOrigin;
     type PotId = CollatorPotId;
     type MaxCandidates = MaxCandidates;

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -246,7 +246,7 @@ impl pallet_session::Config for Runtime {
     type Event = Event;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
     // we don't have stash and controller, thus we don't need the convert as well.
-    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ValidatorIdOf = collator_selection::IdentityCollator;
     type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
     type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
     type SessionManager = CollatorSelection;
@@ -268,7 +268,7 @@ parameter_types! {
 pub type CollatorSelectionUpdateOrigin =
     EnsureOneOf<EnsureRoot<AccountId>, EnsureXcm<IsMajorityOfBody<ParentLocation, ExecutiveBody>>>;
 
-impl pallet_collator_selection::Config for Runtime {
+impl collator_selection::Config for Runtime {
     type Event = Event;
     type Currency = NativeCurrency;
     type UpdateOrigin = CollatorSelectionUpdateOrigin;
@@ -279,7 +279,7 @@ impl pallet_collator_selection::Config for Runtime {
     // should be a multiple of session or things will get inconsistent
     type KickThreshold = Period;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ValidatorIdOf = collator_selection::IdentityCollator;
     type ValidatorRegistration = Session;
     type WeightInfo = ();
 }
@@ -1090,7 +1090,7 @@ construct_runtime! {
         Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>} = 73,
 
         Authorship: pallet_authorship::{Pallet, Call, Storage} = 80,
-        CollatorSelection: pallet_collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 81,
+        CollatorSelection: collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 81,
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 82,
         Aura: pallet_aura::{Pallet, Storage, Config<T>} = 83,
         AuraExt: cumulus_pallet_aura_ext::{Pallet, Storage, Config} = 84,

--- a/parachain/runtime/kintsugi/Cargo.toml
+++ b/parachain/runtime/kintsugi/Cargo.toml
@@ -65,7 +65,6 @@ cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", br
 cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
-pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 
 # Polkadot dependencies
@@ -93,6 +92,7 @@ escrow = { path = "../../../crates/escrow", default-features = false }
 democracy = { path = "../../../crates/democracy", default-features = false }
 annuity = { path = "../../../crates/annuity", default-features = false }
 supply = { path = "../../../crates/supply", default-features = false }
+collator-selection = { path = "../../../crates/collator-selection", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../../primitives", default-features = false }
 
@@ -183,7 +183,6 @@ std = [
   "cumulus-primitives-core/std",
   "cumulus-primitives-timestamp/std",
   "cumulus-primitives-utility/std",
-  "pallet-collator-selection/std",
 
   "polkadot-parachain/std",
   "xcm/std",
@@ -208,6 +207,7 @@ std = [
   "democracy/std",
   "annuity/std",
   "supply/std",
+  "collator-selection/std",
 
   "primitives/std",
 

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -269,7 +269,8 @@ pub type CollatorSelectionUpdateOrigin =
 
 impl collator_selection::Config for Runtime {
     type Event = Event;
-    type Currency = NativeCurrency;
+    type StakingCurrency = Escrow;
+    type RewardsCurrency = NativeCurrency;
     type UpdateOrigin = CollatorSelectionUpdateOrigin;
     type PotId = CollatorPotId;
     type MaxCandidates = MaxCandidates;

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -245,7 +245,7 @@ impl pallet_session::Config for Runtime {
     type Event = Event;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
     // we don't have stash and controller, thus we don't need the convert as well.
-    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ValidatorIdOf = collator_selection::IdentityCollator;
     type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
     type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
     type SessionManager = CollatorSelection;
@@ -267,7 +267,7 @@ parameter_types! {
 pub type CollatorSelectionUpdateOrigin =
     EnsureOneOf<EnsureRoot<AccountId>, EnsureXcm<IsMajorityOfBody<ParentLocation, ExecutiveBody>>>;
 
-impl pallet_collator_selection::Config for Runtime {
+impl collator_selection::Config for Runtime {
     type Event = Event;
     type Currency = NativeCurrency;
     type UpdateOrigin = CollatorSelectionUpdateOrigin;
@@ -278,14 +278,14 @@ impl pallet_collator_selection::Config for Runtime {
     // should be a multiple of session or things will get inconsistent
     type KickThreshold = Period;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ValidatorIdOf = collator_selection::IdentityCollator;
     type ValidatorRegistration = Session;
     type WeightInfo = ();
 }
 
 mod migrate_aura {
     use super::*;
-    use pallet_collator_selection::{CandidacyBond, DesiredCandidates, Invulnerables};
+    use collator_selection::{CandidacyBond, DesiredCandidates, Invulnerables};
     use pallet_session::{NextKeys, QueuedKeys, SessionHandler, SessionManager, Validators};
 
     type ValidatorId = <Runtime as frame_system::Config>::AccountId;
@@ -294,7 +294,7 @@ mod migrate_aura {
         <NextKeys<Runtime>>::get(v)
     }
 
-    fn pallet_collator_selection_build(invulnerables: Vec<AccountId>) {
+    fn collator_selection_build(invulnerables: Vec<AccountId>) {
         // we can root call `set_desired_candidates` to accept registrations
         <DesiredCandidates<Runtime>>::put(0);
         // we can root call `set_candidacy_bond` to set the deposit
@@ -350,7 +350,7 @@ mod migrate_aura {
         frame_support::migration::remove_storage_prefix(b"Aura", b"Authorities", &[]);
 
         // do CollatorSelection GenesisBuild
-        pallet_collator_selection_build(invulnerables.iter().cloned().map(|(acc, _)| acc).collect());
+        collator_selection_build(invulnerables.iter().cloned().map(|(acc, _)| acc).collect());
 
         // do Session GenesisBuild
         if let Err(err) = pallet_session_build(
@@ -1188,7 +1188,7 @@ construct_runtime! {
         Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>} = 73,
 
         Authorship: pallet_authorship::{Pallet, Call, Storage} = 80,
-        CollatorSelection: pallet_collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 81,
+        CollatorSelection: collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 81,
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 82,
         Aura: pallet_aura::{Pallet, Storage, Config<T>} = 83,
         AuraExt: cumulus_pallet_aura_ext::{Pallet, Storage, Config} = 84,

--- a/parachain/runtime/testnet-interlay/Cargo.toml
+++ b/parachain/runtime/testnet-interlay/Cargo.toml
@@ -66,7 +66,6 @@ cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", br
 cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
-pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 
 # Polkadot dependencies
@@ -94,6 +93,7 @@ escrow = { path = "../../../crates/escrow", default-features = false }
 democracy = { path = "../../../crates/democracy", default-features = false }
 annuity = { path = "../../../crates/annuity", default-features = false }
 supply = { path = "../../../crates/supply", default-features = false }
+collator-selection = { path = "../../../crates/collator-selection", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../../primitives", default-features = false }
 
@@ -184,7 +184,6 @@ std = [
   "cumulus-primitives-core/std",
   "cumulus-primitives-timestamp/std",
   "cumulus-primitives-utility/std",
-  "pallet-collator-selection/std",
 
   "polkadot-parachain/std",
   "xcm/std",
@@ -209,6 +208,7 @@ std = [
   "democracy/std",
   "annuity/std",
   "supply/std",
+  "collator-selection/std",
 
   "primitives/std",
 

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -271,7 +271,8 @@ pub type CollatorSelectionUpdateOrigin =
 
 impl collator_selection::Config for Runtime {
     type Event = Event;
-    type Currency = NativeCurrency;
+    type StakingCurrency = Escrow;
+    type RewardsCurrency = NativeCurrency;
     type UpdateOrigin = CollatorSelectionUpdateOrigin;
     type PotId = CollatorPotId;
     type MaxCandidates = MaxCandidates;

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -247,7 +247,7 @@ impl pallet_session::Config for Runtime {
     type Event = Event;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
     // we don't have stash and controller, thus we don't need the convert as well.
-    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ValidatorIdOf = collator_selection::IdentityCollator;
     type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
     type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
     type SessionManager = CollatorSelection;
@@ -269,7 +269,7 @@ parameter_types! {
 pub type CollatorSelectionUpdateOrigin =
     EnsureOneOf<EnsureRoot<AccountId>, EnsureXcm<IsMajorityOfBody<ParentLocation, ExecutiveBody>>>;
 
-impl pallet_collator_selection::Config for Runtime {
+impl collator_selection::Config for Runtime {
     type Event = Event;
     type Currency = NativeCurrency;
     type UpdateOrigin = CollatorSelectionUpdateOrigin;
@@ -280,7 +280,7 @@ impl pallet_collator_selection::Config for Runtime {
     // should be a multiple of session or things will get inconsistent
     type KickThreshold = Period;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ValidatorIdOf = collator_selection::IdentityCollator;
     type ValidatorRegistration = Session;
     type WeightInfo = ();
 }
@@ -1062,7 +1062,7 @@ construct_runtime! {
         Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>} = 73,
 
         Authorship: pallet_authorship::{Pallet, Call, Storage} = 80,
-        CollatorSelection: pallet_collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 81,
+        CollatorSelection: collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 81,
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 82,
         Aura: pallet_aura::{Pallet, Storage, Config<T>} = 83,
         AuraExt: cumulus_pallet_aura_ext::{Pallet, Storage, Config} = 84,

--- a/parachain/runtime/testnet-kintsugi/Cargo.toml
+++ b/parachain/runtime/testnet-kintsugi/Cargo.toml
@@ -66,7 +66,6 @@ cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus", br
 cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
-pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.24", default-features = false }
 
 # Polkadot dependencies
@@ -94,6 +93,7 @@ escrow = { path = "../../../crates/escrow", default-features = false }
 democracy = { path = "../../../crates/democracy", default-features = false }
 annuity = { path = "../../../crates/annuity", default-features = false }
 supply = { path = "../../../crates/supply", default-features = false }
+collator-selection = { path = "../../../crates/collator-selection", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../../primitives", default-features = false }
 
@@ -184,7 +184,6 @@ std = [
   "cumulus-primitives-core/std",
   "cumulus-primitives-timestamp/std",
   "cumulus-primitives-utility/std",
-  "pallet-collator-selection/std",
 
   "polkadot-parachain/std",
   "xcm/std",
@@ -209,6 +208,7 @@ std = [
   "democracy/std",
   "annuity/std",
   "supply/std",
+  "collator-selection/std",
 
   "primitives/std",
 

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -271,7 +271,8 @@ pub type CollatorSelectionUpdateOrigin =
 
 impl collator_selection::Config for Runtime {
     type Event = Event;
-    type Currency = NativeCurrency;
+    type StakingCurrency = Escrow;
+    type RewardsCurrency = NativeCurrency;
     type UpdateOrigin = CollatorSelectionUpdateOrigin;
     type PotId = CollatorPotId;
     type MaxCandidates = MaxCandidates;

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -247,7 +247,7 @@ impl pallet_session::Config for Runtime {
     type Event = Event;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
     // we don't have stash and controller, thus we don't need the convert as well.
-    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ValidatorIdOf = collator_selection::IdentityCollator;
     type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
     type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
     type SessionManager = CollatorSelection;
@@ -269,7 +269,7 @@ parameter_types! {
 pub type CollatorSelectionUpdateOrigin =
     EnsureOneOf<EnsureRoot<AccountId>, EnsureXcm<IsMajorityOfBody<ParentLocation, ExecutiveBody>>>;
 
-impl pallet_collator_selection::Config for Runtime {
+impl collator_selection::Config for Runtime {
     type Event = Event;
     type Currency = NativeCurrency;
     type UpdateOrigin = CollatorSelectionUpdateOrigin;
@@ -280,7 +280,7 @@ impl pallet_collator_selection::Config for Runtime {
     // should be a multiple of session or things will get inconsistent
     type KickThreshold = Period;
     type ValidatorId = <Self as frame_system::Config>::AccountId;
-    type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
+    type ValidatorIdOf = collator_selection::IdentityCollator;
     type ValidatorRegistration = Session;
     type WeightInfo = ();
 }
@@ -1062,7 +1062,7 @@ construct_runtime! {
         Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>} = 73,
 
         Authorship: pallet_authorship::{Pallet, Call, Storage} = 80,
-        CollatorSelection: pallet_collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 81,
+        CollatorSelection: collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 81,
         Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 82,
         Aura: pallet_aura::{Pallet, Storage, Config<T>} = 83,
         AuraExt: cumulus_pallet_aura_ext::{Pallet, Storage, Config} = 84,


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Forks [`pallet-collator-selection`](https://github.com/paritytech/cumulus/tree/polkadot-v0.9.24/pallets/collator-selection) and distinguishes `StakingCurrency` and `RewardsCurrency` so that we can use the illiquid `Escrow` balance for candidacy bonds. 

The reason for the split is because the `ReservableCurrency` implementation on the `Escrow` pallet is incompatible with the calls made in [`note_author`](https://github.com/paritytech/cumulus/blob/polkadot-v0.9.24/pallets/collator-selection/src/lib.rs#L473-L489).