### PR TITLE
feat: allow requester to call cancel_issue

### DIFF
--- a/crates/issue/src/lib.rs
+++ b/crates/issue/src/lib.rs
@@ -440,60 +440,53 @@ impl<T: Config> Pallet<T> {
     fn _cancel_issue(requester: T::AccountId, issue_id: H256) -> Result<(), DispatchError> {
         let issue = Self::get_pending_issue(&issue_id)?;
 
-        let griefing_collateral = if ext::btc_relay::has_request_expired::<T>(
-            issue.opentime,
-            issue.btc_height,
-            Self::issue_period().max(issue.period),
-        )? {
-            // anyone can cancel the issue request once expired
-            let griefing_collateral = issue.griefing_collateral();
-            if ext::vault_registry::is_vault_liquidated::<T>(&issue.vault)? {
-                griefing_collateral.unlock_on(&issue.requester)?;
-            } else {
-                ext::vault_registry::transfer_funds::<T>(
-                    CurrencySource::UserGriefing(issue.requester.clone()),
-                    CurrencySource::FreeBalance(issue.vault.account_id.clone()),
-                    &griefing_collateral,
-                )?;
-            }
-            griefing_collateral
-        } else if issue.requester == requester {
-            // slash/release griefing collateral proportionally to the time elapsed
-            let blocks_elapsed = ext::security::active_block_number::<T>().saturating_sub(issue.opentime);
-            // NOTE: if global issue period increases requester will get more griefing collateral
-            let expected_end = Self::issue_period().max(issue.period);
+        let expected_end = Self::issue_period().max(issue.period);
+        let griefing_collateral =
+            if ext::btc_relay::has_request_expired::<T>(issue.opentime, issue.btc_height, expected_end)? {
+                // anyone can cancel the issue request once expired
+                issue.griefing_collateral()
+            } else if issue.requester == requester {
+                // slash/release griefing collateral proportionally to the time elapsed
+                // NOTE: if global issue period increases requester will get more griefing collateral
+                let blocks_elapsed = ext::security::active_block_number::<T>().saturating_sub(issue.opentime);
 
-            let griefing_collateral = issue.griefing_collateral();
-            let slashed_collateral = ext::vault_registry::calculate_collateral::<T>(
-                &griefing_collateral,
-                // NOTE: workaround since BlockNumber doesn't inherit Into<U256>
-                &Amount::new(
-                    T::BlockNumberToBalance::convert(blocks_elapsed),
-                    griefing_collateral.currency(),
-                ),
-                &Amount::new(
-                    T::BlockNumberToBalance::convert(expected_end),
-                    griefing_collateral.currency(),
-                ),
-            )?
-            // we can never slash more than the griefing collateral
-            .min(&griefing_collateral)?;
-            // give this to the vault to cover the inconvenience
+                let griefing_collateral = issue.griefing_collateral();
+                let slashed_collateral = ext::vault_registry::calculate_collateral::<T>(
+                    &griefing_collateral,
+                    // NOTE: workaround since BlockNumber doesn't inherit Into<U256>
+                    &Amount::new(
+                        T::BlockNumberToBalance::convert(blocks_elapsed),
+                        griefing_collateral.currency(),
+                    ),
+                    &Amount::new(
+                        T::BlockNumberToBalance::convert(expected_end),
+                        griefing_collateral.currency(),
+                    ),
+                )?
+                // we can never slash more than the griefing collateral
+                .min(&griefing_collateral)?;
+
+                // refund anything not slashed
+                let released_collateral = griefing_collateral.saturating_sub(&slashed_collateral)?;
+                released_collateral.unlock_on(&requester)?;
+
+                // TODO: update `issue.griefing_collateral`?
+                slashed_collateral
+            } else {
+                return Err(Error::<T>::TimeNotExpired.into());
+            };
+
+        if ext::vault_registry::is_vault_liquidated::<T>(&issue.vault)? {
+            // return slashed griefing collateral if the vault is liquidated
+            griefing_collateral.unlock_on(&issue.requester)?;
+        } else {
+            // otherwise give all slashed griefing collateral to the vault
             ext::vault_registry::transfer_funds::<T>(
                 CurrencySource::UserGriefing(issue.requester.clone()),
                 CurrencySource::FreeBalance(issue.vault.account_id.clone()),
-                &slashed_collateral,
+                &griefing_collateral,
             )?;
-
-            // refund anything not slashed
-            let released_collateral = griefing_collateral.saturating_sub(&slashed_collateral)?;
-            released_collateral.unlock_on(&requester)?;
-
-            // TODO: update `issue.griefing_collateral`?
-            slashed_collateral
-        } else {
-            return Err(Error::<T>::TimeNotExpired.into());
-        };
+        }
 
         // decrease to-be-redeemed tokens
         let full_amount = issue.amount().checked_add(&issue.fee())?;

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -14,7 +14,7 @@ use sp_arithmetic::{FixedI128, FixedPointNumber, FixedU128};
 use sp_core::H256;
 use sp_runtime::{
     testing::{Header, TestXt},
-    traits::{BlakeTwo256, IdentityLookup, One, Zero},
+    traits::{BlakeTwo256, Convert, IdentityLookup, One, Zero},
 };
 
 type TestExtrinsic = TestXt<Call, ()>;
@@ -242,8 +242,17 @@ impl fee::Config for Test {
     type MaxExpectedValue = MaxExpectedValue;
 }
 
+pub struct BlockNumberToBalance;
+
+impl Convert<BlockNumber, Balance> for BlockNumberToBalance {
+    fn convert(a: BlockNumber) -> Balance {
+        a.into()
+    }
+}
+
 impl Config for Test {
     type Event = TestEvent;
+    type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();
 }
 

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -288,6 +288,7 @@ fn test_cancel_issue_not_expired_and_requester_succeeds() {
         ext::vault_registry::get_active_vault_from_id::<Test>
             .mock_safe(|_| MockResult::Return(Ok(init_zero_vault(VAULT))));
         ext::vault_registry::decrease_to_be_issued_tokens::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::is_vault_liquidated::<Test>.mock_safe(move |_| MockResult::Return(Ok(false)));
         ext::fee::get_issue_griefing_collateral::<Test>.mock_safe(move |_| MockResult::Return(Ok(griefing(100))));
 
         let issue_id = request_issue_ok(USER, 300, VAULT);

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -5,6 +5,7 @@ use btc_relay::{BtcAddress, BtcPublicKey};
 use currency::Amount;
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
 use mocktopus::mocking::*;
+use primitives::issue::IssueRequestStatus;
 use sp_arithmetic::FixedU128;
 use sp_core::H256;
 use sp_runtime::traits::One;
@@ -269,7 +270,7 @@ fn test_cancel_issue_not_found_fails() {
 }
 
 #[test]
-fn test_cancel_issue_not_expired_fails() {
+fn test_cancel_issue_not_expired_and_not_requester_fails() {
     run_test(|| {
         ext::vault_registry::get_active_vault_from_id::<Test>
             .mock_safe(|_| MockResult::Return(Ok(init_zero_vault(VAULT))));
@@ -277,7 +278,67 @@ fn test_cancel_issue_not_expired_fails() {
         let issue_id = request_issue_ok(USER, 3, VAULT);
         // issue period is 10, we issued at block 1, so at block 5 the cancel should fail
         <security::Pallet<Test>>::set_active_block_number(5);
-        assert_noop!(cancel_issue(USER, &issue_id), TestError::TimeNotExpired,);
+        assert_noop!(cancel_issue(3, &issue_id), TestError::TimeNotExpired);
+    })
+}
+
+#[test]
+fn test_cancel_issue_not_expired_and_requester_succeeds() {
+    run_test(|| {
+        ext::vault_registry::get_active_vault_from_id::<Test>
+            .mock_safe(|_| MockResult::Return(Ok(init_zero_vault(VAULT))));
+        ext::vault_registry::decrease_to_be_issued_tokens::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
+        ext::fee::get_issue_griefing_collateral::<Test>.mock_safe(move |_| MockResult::Return(Ok(griefing(100))));
+
+        let issue_id = request_issue_ok(USER, 300, VAULT);
+
+        unsafe {
+            // issue period is 10, we issued at block 1, so at block 4 the requester gets 70% griefing back
+            <security::Pallet<Test>>::set_active_block_number(4);
+
+            ext::vault_registry::transfer_funds::<Test>.mock_raw(|_, _, amount| {
+                assert_eq!(amount, &griefing(30));
+                MockResult::Return(Ok(()))
+            });
+
+            assert_ok!(cancel_issue(USER, &issue_id));
+
+            assert_eq!(
+                Issue::issue_requests(&issue_id).unwrap().status,
+                IssueRequestStatus::Cancelled
+            );
+        }
+    })
+}
+
+#[test]
+fn test_cancel_issue_expired_succeeds() {
+    run_test(|| {
+        ext::vault_registry::get_active_vault_from_id::<Test>
+            .mock_safe(|_| MockResult::Return(Ok(init_zero_vault(VAULT))));
+        ext::vault_registry::decrease_to_be_issued_tokens::<Test>.mock_safe(move |_, _| MockResult::Return(Ok(())));
+        ext::vault_registry::is_vault_liquidated::<Test>.mock_safe(move |_| MockResult::Return(Ok(false)));
+        ext::fee::get_issue_griefing_collateral::<Test>.mock_safe(move |_| MockResult::Return(Ok(griefing(100))));
+        ext::btc_relay::has_request_expired::<Test>.mock_safe(move |_, _, _| MockResult::Return(Ok(true)));
+
+        let issue_id = request_issue_ok(USER, 300, VAULT);
+
+        unsafe {
+            // issue period is 10, we issued at block 1, so at block 12 the request has expired
+            <security::Pallet<Test>>::set_active_block_number(12);
+
+            ext::vault_registry::transfer_funds::<Test>.mock_raw(|_, _, amount| {
+                assert_eq!(amount, &griefing(100));
+                MockResult::Return(Ok(()))
+            });
+
+            assert_ok!(cancel_issue(USER, &issue_id));
+
+            assert_eq!(
+                Issue::issue_requests(&issue_id).unwrap().status,
+                IssueRequestStatus::Cancelled
+            );
+        }
     })
 }
 

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1018,6 +1018,7 @@ pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
     type Event = Event;
+    type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();
 }
 

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1000,6 +1000,7 @@ pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
     type Event = Event;
+    type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();
 }
 

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -990,6 +990,7 @@ pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
     type Event = Event;
+    type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();
 }
 

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -990,6 +990,7 @@ pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
     type Event = Event;
+    type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();
 }
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -922,6 +922,7 @@ pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
     type Event = Event;
+    type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();
 }
 

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -56,7 +56,7 @@ mod expiry_test {
     }
 
     fn cancel_issue(issue_id: H256) -> DispatchResultWithPostInfo {
-        Call::Issue(IssueCall::cancel_issue { issue_id: issue_id }).dispatch(origin_of(account_of(USER)))
+        Call::Issue(IssueCall::cancel_issue { issue_id: issue_id }).dispatch(origin_of(account_of(VAULT)))
     }
 
     #[test]


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Allows the `requester` to call `cancel_issue` up until expiry but the closer to the deadline this is done the more griefing collateral will be slashed.