### PR TITLE
Reward pallet RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,6 +3559,7 @@ dependencies = [
  "module-redeem-rpc-runtime-api",
  "module-refund-rpc-runtime-api",
  "module-replace-rpc-runtime-api",
+ "module-reward-rpc-runtime-api",
  "module-vault-registry-rpc-runtime-api",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
@@ -3631,6 +3632,7 @@ dependencies = [
  "module-redeem-rpc",
  "module-refund-rpc",
  "module-replace-rpc",
+ "module-reward-rpc",
  "module-vault-registry-rpc",
  "pallet-transaction-payment-rpc",
  "sc-consensus-manual-seal",
@@ -3676,6 +3678,7 @@ dependencies = [
  "module-redeem-rpc-runtime-api",
  "module-refund-rpc-runtime-api",
  "module-replace-rpc-runtime-api",
+ "module-reward-rpc-runtime-api",
  "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
@@ -3812,6 +3815,7 @@ dependencies = [
  "module-redeem-rpc-runtime-api",
  "module-refund-rpc-runtime-api",
  "module-replace-rpc-runtime-api",
+ "module-reward-rpc-runtime-api",
  "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
@@ -4166,6 +4170,7 @@ dependencies = [
  "module-redeem-rpc-runtime-api",
  "module-refund-rpc-runtime-api",
  "module-replace-rpc-runtime-api",
+ "module-reward-rpc-runtime-api",
  "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
@@ -5528,6 +5533,29 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-std",
+]
+
+[[package]]
+name = "module-reward-rpc"
+version = "0.3.0"
+dependencies = [
+ "jsonrpsee",
+ "module-oracle-rpc-runtime-api",
+ "module-reward-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "module-reward-rpc-runtime-api"
+version = "0.3.0"
+dependencies = [
+ "frame-support",
+ "module-oracle-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
 ]
 
 [[package]]
@@ -12340,6 +12368,7 @@ dependencies = [
  "module-redeem-rpc-runtime-api",
  "module-refund-rpc-runtime-api",
  "module-replace-rpc-runtime-api",
+ "module-reward-rpc-runtime-api",
  "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
@@ -12439,6 +12468,7 @@ dependencies = [
  "module-redeem-rpc-runtime-api",
  "module-refund-rpc-runtime-api",
  "module-replace-rpc-runtime-api",
+ "module-reward-rpc-runtime-api",
  "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",

--- a/crates/reward/rpc/Cargo.toml
+++ b/crates/reward/rpc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors = ["Interlay Ltd"]
+edition = "2021"
+name = "module-reward-rpc"
+version = '0.3.0'
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0" }
+jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24" }
+module-reward-rpc-runtime-api = { path = "runtime-api" }
+
+[dependencies.module-oracle-rpc-runtime-api]
+path = '../../oracle/rpc/runtime-api'

--- a/crates/reward/rpc/runtime-api/Cargo.toml
+++ b/crates/reward/rpc/runtime-api/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors = ["Interlay Ltd"]
+edition = "2021"
+name = "module-reward-rpc-runtime-api"
+version = '0.3.0'
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.24", default-features = false }
+
+[dependencies.module-oracle-rpc-runtime-api]
+default-features = false
+path = '../../../oracle/rpc/runtime-api'
+
+[features]
+default = ["std"]
+std = [
+  "codec/std",
+  "frame-support/std",
+  "sp-api/std",
+  "module-oracle-rpc-runtime-api/std",
+]

--- a/crates/reward/rpc/runtime-api/src/lib.rs
+++ b/crates/reward/rpc/runtime-api/src/lib.rs
@@ -7,12 +7,16 @@ use frame_support::dispatch::DispatchError;
 use module_oracle_rpc_runtime_api::BalanceWrapper;
 
 sp_api::decl_runtime_apis! {
-    pub trait RewardApi<RewardId, CurrencyId, Balance> where
-        RewardId: Codec,
+    pub trait RewardApi<AccountId, VaultId, CurrencyId, Balance> where
+    AccountId: Codec,
+    VaultId: Codec,
         CurrencyId: Codec,
         Balance: Codec
     {
         /// Get a given user's rewards due
-        fn compute_reward(account_id: RewardId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
+        fn compute_escrow_reward(account_id: AccountId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
+
+        /// Get a given vault's rewards due
+        fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
     }
 }

--- a/crates/reward/rpc/runtime-api/src/lib.rs
+++ b/crates/reward/rpc/runtime-api/src/lib.rs
@@ -1,0 +1,18 @@
+//! Runtime API definition for the Reward Module.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::Codec;
+use frame_support::dispatch::DispatchError;
+use module_oracle_rpc_runtime_api::BalanceWrapper;
+
+sp_api::decl_runtime_apis! {
+    pub trait RewardApi<RewardId, CurrencyId, Balance> where
+        RewardId: Codec,
+        CurrencyId: Codec,
+        Balance: Codec
+    {
+        /// Get a given user's rewards due
+        fn compute_reward(account_id: RewardId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
+    }
+}

--- a/crates/reward/rpc/src/lib.rs
+++ b/crates/reward/rpc/src/lib.rs
@@ -7,7 +7,7 @@ use jsonrpsee::{
     types::error::{CallError, ErrorCode, ErrorObject},
 };
 use module_oracle_rpc_runtime_api::BalanceWrapper;
-use sp_api::{ApiError, ProvideRuntimeApi};
+use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{
     generic::BlockId,
@@ -67,9 +67,6 @@ impl<C, B> Reward<C, B> {
     }
 }
 
-// fn handle_response<T>(result: Result<T, ApiError>, msg: String) -> RpcResult<T> {
-//     result.map_err(|err| internal_err(format!("Runtime error: {:?}: {:?}", msg, err)))
-// }
 fn handle_response<T, E: std::fmt::Debug>(result: Result<Result<T, DispatchError>, E>, msg: String) -> RpcResult<T> {
     result
         .map_err(|err| internal_err(format!("Runtime error: {:?}: {:?}", msg, err)))?

--- a/crates/reward/rpc/src/lib.rs
+++ b/crates/reward/rpc/src/lib.rs
@@ -1,0 +1,95 @@
+//! RPC interface for the Reward Module.
+
+use codec::Codec;
+use jsonrpsee::{
+    core::{async_trait, Error as JsonRpseeError, RpcResult},
+    proc_macros::rpc,
+    types::error::{CallError, ErrorCode, ErrorObject},
+};
+use module_oracle_rpc_runtime_api::BalanceWrapper;
+use sp_api::{ApiError, ProvideRuntimeApi};
+use sp_blockchain::HeaderBackend;
+use sp_runtime::{
+    generic::BlockId,
+    traits::{Block as BlockT, MaybeDisplay, MaybeFromStr},
+    DispatchError,
+};
+use std::sync::Arc;
+
+pub use module_reward_rpc_runtime_api::RewardApi as RewardRuntimeApi;
+
+#[rpc(client, server)]
+pub trait RewardApi<BlockHash, RewardId, CurrencyId, Balance>
+where
+    Balance: Codec + MaybeDisplay + MaybeFromStr,
+    RewardId: Codec,
+    CurrencyId: Codec,
+{
+    #[method(name = "reward_computeReward")]
+    fn compute_reward(
+        &self,
+        account_id: RewardId,
+        currency_id: CurrencyId,
+        at: Option<BlockHash>,
+    ) -> RpcResult<BalanceWrapper<Balance>>;
+}
+
+fn internal_err<T: ToString>(message: T) -> JsonRpseeError {
+    JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
+        ErrorCode::InternalError.code(),
+        message.to_string(),
+        None::<()>,
+    )))
+}
+
+/// A struct that implements the [`RewardApi`].
+pub struct Reward<C, B> {
+    client: Arc<C>,
+    _marker: std::marker::PhantomData<B>,
+}
+
+impl<C, B> Reward<C, B> {
+    /// Create new `Reward` with the given reference to the client.
+    pub fn new(client: Arc<C>) -> Self {
+        Reward {
+            client,
+            _marker: Default::default(),
+        }
+    }
+}
+
+// fn handle_response<T>(result: Result<T, ApiError>, msg: String) -> RpcResult<T> {
+//     result.map_err(|err| internal_err(format!("Runtime error: {:?}: {:?}", msg, err)))
+// }
+fn handle_response<T, E: std::fmt::Debug>(result: Result<Result<T, DispatchError>, E>, msg: String) -> RpcResult<T> {
+    result
+        .map_err(|err| internal_err(format!("Runtime error: {:?}: {:?}", msg, err)))?
+        .map_err(|err| internal_err(format!("Execution error: {:?}: {:?}", msg, err)))
+}
+
+#[async_trait]
+impl<C, Block, RewardId, CurrencyId, Balance> RewardApiServer<<Block as BlockT>::Hash, RewardId, CurrencyId, Balance>
+    for Reward<C, Block>
+where
+    Block: BlockT,
+    C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+    C::Api: RewardRuntimeApi<Block, RewardId, CurrencyId, Balance>,
+    RewardId: Codec,
+    CurrencyId: Codec,
+    Balance: Codec + MaybeDisplay + MaybeFromStr,
+{
+    fn compute_reward(
+        &self,
+        account_id: RewardId,
+        currency_id: CurrencyId,
+        at: Option<<Block as BlockT>::Hash>,
+    ) -> RpcResult<BalanceWrapper<Balance>> {
+        let api = self.client.runtime_api();
+        let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
+
+        handle_response(
+            api.compute_reward(&at, account_id, currency_id),
+            "Unable to obtain the current reward".into(),
+        )
+    }
+}

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -38,6 +38,7 @@ module-btc-relay-rpc-runtime-api = { path = "../crates/btc-relay/rpc/runtime-api
 module-oracle-rpc-runtime-api = { path = "../crates/oracle/rpc/runtime-api" }
 module-vault-registry-rpc-runtime-api = { path = "../crates/vault-registry/rpc/runtime-api" }
 module-escrow-rpc-runtime-api = { path = "../crates/escrow/rpc/runtime-api" }
+module-reward-rpc-runtime-api = { path = "../crates/reward/rpc/runtime-api" }
 module-issue-rpc-runtime-api = { path = "../crates/issue/rpc/runtime-api" }
 module-redeem-rpc-runtime-api = { path = "../crates/redeem/rpc/runtime-api" }
 module-replace-rpc-runtime-api = { path = "../crates/replace/rpc/runtime-api" }

--- a/parachain/runtime/interlay/Cargo.toml
+++ b/parachain/runtime/interlay/Cargo.toml
@@ -100,6 +100,7 @@ module-btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runti
 module-oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
 module-vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
 module-escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
+module-reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
 module-issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
 module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
 module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
@@ -213,6 +214,7 @@ std = [
   "module-oracle-rpc-runtime-api/std",
   "module-vault-registry-rpc-runtime-api/std",
   "module-escrow-rpc-runtime-api/std",
+  "module-reward-rpc-runtime-api/std",
   "module-issue-rpc-runtime-api/std",
   "module-redeem-rpc-runtime-api/std",
   "module-replace-rpc-runtime-api/std",

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1424,8 +1424,8 @@ impl_runtime_apis! {
         Balance
     > for Runtime {
         fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
-            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }
     }

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1419,12 +1419,19 @@ impl_runtime_apis! {
 
     impl module_reward_rpc_runtime_api::RewardApi<
         Block,
+        AccountId,
         VaultId,
         CurrencyId,
         Balance
     > for Runtime {
-        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+        fn compute_escrow_reward(account_id: AccountId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
+            Ok(balance)
+        }
+
+        fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&vault_id, currency_id)?;
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1417,6 +1417,19 @@ impl_runtime_apis! {
         }
     }
 
+    impl module_reward_rpc_runtime_api::RewardApi<
+        Block,
+        VaultId,
+        CurrencyId,
+        Balance
+    > for Runtime {
+        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
+            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            Ok(balance)
+        }
+    }
+
     impl module_issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,

--- a/parachain/runtime/kintsugi/Cargo.toml
+++ b/parachain/runtime/kintsugi/Cargo.toml
@@ -100,6 +100,7 @@ module-btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runti
 module-oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
 module-vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
 module-escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
+module-reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
 module-issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
 module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
 module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
@@ -217,6 +218,7 @@ std = [
   "module-oracle-rpc-runtime-api/std",
   "module-vault-registry-rpc-runtime-api/std",
   "module-escrow-rpc-runtime-api/std",
+  "module-reward-rpc-runtime-api/std",
   "module-issue-rpc-runtime-api/std",
   "module-redeem-rpc-runtime-api/std",
   "module-replace-rpc-runtime-api/std",

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1522,8 +1522,8 @@ impl_runtime_apis! {
         Balance
     > for Runtime {
         fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
-            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }
     }

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1515,6 +1515,19 @@ impl_runtime_apis! {
         }
     }
 
+    impl module_reward_rpc_runtime_api::RewardApi<
+        Block,
+        VaultId,
+        CurrencyId,
+        Balance
+    > for Runtime {
+        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
+            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            Ok(balance)
+        }
+    }
+
     impl module_issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1517,12 +1517,19 @@ impl_runtime_apis! {
 
     impl module_reward_rpc_runtime_api::RewardApi<
         Block,
+        AccountId,
         VaultId,
         CurrencyId,
         Balance
     > for Runtime {
-        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+        fn compute_escrow_reward(account_id: AccountId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
+            Ok(balance)
+        }
+
+        fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&vault_id, currency_id)?;
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/parachain/runtime/testnet-interlay/Cargo.toml
+++ b/parachain/runtime/testnet-interlay/Cargo.toml
@@ -101,6 +101,7 @@ module-btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runti
 module-oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
 module-vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
 module-escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
+module-reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
 module-issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
 module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
 module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
@@ -218,6 +219,7 @@ std = [
   "module-oracle-rpc-runtime-api/std",
   "module-vault-registry-rpc-runtime-api/std",
   "module-escrow-rpc-runtime-api/std",
+  "module-reward-rpc-runtime-api/std",
   "module-issue-rpc-runtime-api/std",
   "module-redeem-rpc-runtime-api/std",
   "module-replace-rpc-runtime-api/std",

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -1389,6 +1389,20 @@ impl_runtime_apis! {
         }
     }
 
+    impl module_reward_rpc_runtime_api::RewardApi<
+        Block,
+        VaultId,
+        CurrencyId,
+        Balance
+    > for Runtime {
+        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
+            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            Ok(balance)
+        }
+    }
+
+
     impl module_issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -1396,8 +1396,8 @@ impl_runtime_apis! {
         Balance
     > for Runtime {
         fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
-            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }
     }

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -1391,12 +1391,19 @@ impl_runtime_apis! {
 
     impl module_reward_rpc_runtime_api::RewardApi<
         Block,
+        AccountId,
         VaultId,
         CurrencyId,
         Balance
     > for Runtime {
-        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+        fn compute_escrow_reward(account_id: AccountId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
+            Ok(balance)
+        }
+
+        fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&vault_id, currency_id)?;
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/parachain/runtime/testnet-kintsugi/Cargo.toml
+++ b/parachain/runtime/testnet-kintsugi/Cargo.toml
@@ -101,6 +101,7 @@ module-btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runti
 module-oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
 module-vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
 module-escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
+module-reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
 module-issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
 module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
 module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
@@ -218,6 +219,7 @@ std = [
   "module-oracle-rpc-runtime-api/std",
   "module-vault-registry-rpc-runtime-api/std",
   "module-escrow-rpc-runtime-api/std",
+  "module-reward-rpc-runtime-api/std",
   "module-issue-rpc-runtime-api/std",
   "module-redeem-rpc-runtime-api/std",
   "module-replace-rpc-runtime-api/std",

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -1396,8 +1396,8 @@ impl_runtime_apis! {
         Balance
     > for Runtime {
         fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
-            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }
     }

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -1389,6 +1389,19 @@ impl_runtime_apis! {
         }
     }
 
+    impl module_reward_rpc_runtime_api::RewardApi<
+        Block,
+        VaultId,
+        CurrencyId,
+        Balance
+    > for Runtime {
+        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
+            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            Ok(balance)
+        }
+    }
+
     impl module_issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -1391,12 +1391,19 @@ impl_runtime_apis! {
 
     impl module_reward_rpc_runtime_api::RewardApi<
         Block,
+        AccountId,
         VaultId,
         CurrencyId,
         Balance
     > for Runtime {
-        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+        fn compute_escrow_reward(account_id: AccountId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
+            Ok(balance)
+        }
+
+        fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&vault_id, currency_id)?;
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/parachain/src/service.rs
+++ b/parachain/src/service.rs
@@ -98,7 +98,7 @@ pub trait RuntimeApiCollection:
         AccountId,
         H256,
         refund::RefundRequest<AccountId, Balance, CurrencyId>,
-    >
+    > + module_reward_rpc_runtime_api::RewardApi<Block, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>
 where
     <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
@@ -145,7 +145,7 @@ where
             AccountId,
             H256,
             refund::RefundRequest<AccountId, Balance, CurrencyId>,
-        >,
+        > + module_reward_rpc_runtime_api::RewardApi<Block, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>,
     <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
 }

--- a/parachain/src/service.rs
+++ b/parachain/src/service.rs
@@ -98,7 +98,7 @@ pub trait RuntimeApiCollection:
         AccountId,
         H256,
         refund::RefundRequest<AccountId, Balance, CurrencyId>,
-    > + module_reward_rpc_runtime_api::RewardApi<Block, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>
+    > + module_reward_rpc_runtime_api::RewardApi<Block, AccountId, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>
 where
     <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
@@ -145,7 +145,7 @@ where
             AccountId,
             H256,
             refund::RefundRequest<AccountId, Balance, CurrencyId>,
-        > + module_reward_rpc_runtime_api::RewardApi<Block, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>,
+        > + module_reward_rpc_runtime_api::RewardApi<Block, AccountId, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>,
     <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -17,6 +17,7 @@ module-redeem-rpc = { path = "../crates/redeem/rpc" }
 module-replace-rpc = { path = "../crates/replace/rpc" }
 module-refund-rpc = { path = "../crates/refund/rpc" }
 module-escrow-rpc = { path = "../crates/escrow/rpc" }
+module-reward-rpc = { path = "../crates/reward/rpc" }
 
 vault-registry = { path = "../crates/vault-registry" }
 primitives = { package = "interbtc-primitives", path = "../primitives" }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -74,7 +74,7 @@ where
         ReplaceRequest<AccountId, BlockNumber, Balance, CurrencyId>,
     >,
     C::Api: module_escrow_rpc::EscrowRuntimeApi<Block, AccountId, BlockNumber, Balance>,
-    C::Api: module_reward_rpc::RewardRuntimeApi<Block, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>,
+    C::Api: module_reward_rpc::RewardRuntimeApi<Block, AccountId, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
 {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -74,6 +74,7 @@ where
         ReplaceRequest<AccountId, BlockNumber, Balance, CurrencyId>,
     >,
     C::Api: module_escrow_rpc::EscrowRuntimeApi<Block, AccountId, BlockNumber, Balance>,
+    C::Api: module_reward_rpc::RewardRuntimeApi<Block, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
 {
@@ -84,6 +85,7 @@ where
     use module_redeem_rpc::{Redeem, RedeemApiServer};
     use module_refund_rpc::{Refund, RefundApiServer};
     use module_replace_rpc::{Replace, ReplaceApiServer};
+    use module_reward_rpc::{Reward, RewardApiServer};
     use module_vault_registry_rpc::{VaultRegistry, VaultRegistryApiServer};
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};
@@ -115,6 +117,8 @@ where
     module.merge(VaultRegistry::new(client.clone()).into_rpc())?;
 
     module.merge(Escrow::new(client.clone()).into_rpc())?;
+
+    module.merge(Reward::new(client.clone()).into_rpc())?;
 
     module.merge(Issue::new(client.clone()).into_rpc())?;
 

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -81,6 +81,7 @@ module-btc-relay-rpc-runtime-api = { path = "../../crates/btc-relay/rpc/runtime-
 module-oracle-rpc-runtime-api = { path = "../../crates/oracle/rpc/runtime-api", default-features = false }
 module-vault-registry-rpc-runtime-api = { path = "../../crates/vault-registry/rpc/runtime-api", default-features = false }
 module-escrow-rpc-runtime-api = { path = "../../crates/escrow/rpc/runtime-api", default-features = false }
+module-reward-rpc-runtime-api = { path = "../../crates/reward/rpc/runtime-api", default-features = false }
 module-issue-rpc-runtime-api = { path = "../../crates/issue/rpc/runtime-api", default-features = false }
 module-redeem-rpc-runtime-api = { path = "../../crates/redeem/rpc/runtime-api", default-features = false }
 module-replace-rpc-runtime-api = { path = "../../crates/replace/rpc/runtime-api", default-features = false }
@@ -179,6 +180,7 @@ std = [
   "module-oracle-rpc-runtime-api/std",
   "module-vault-registry-rpc-runtime-api/std",
   "module-escrow-rpc-runtime-api/std",
+  "module-reward-rpc-runtime-api/std",
   "module-issue-rpc-runtime-api/std",
   "module-redeem-rpc-runtime-api/std",
   "module-replace-rpc-runtime-api/std",

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1364,8 +1364,8 @@ impl_runtime_apis! {
         Balance
     > for Runtime {
         fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
-            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }
     }

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1359,12 +1359,19 @@ impl_runtime_apis! {
 
     impl module_reward_rpc_runtime_api::RewardApi<
         Block,
+        AccountId,
         VaultId,
         CurrencyId,
         Balance
     > for Runtime {
-        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+        fn compute_escrow_reward(account_id: AccountId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <EscrowRewards as reward::Rewards<AccountId, Balance, CurrencyId>>::compute_reward(&account_id, currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
+            Ok(balance)
+        }
+
+        fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let amount = <VaultRewards as reward::Rewards<VaultId, Balance, CurrencyId>>::compute_reward(&vault_id, currency_id)?;
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1357,6 +1357,19 @@ impl_runtime_apis! {
         }
     }
 
+    impl module_reward_rpc_runtime_api::RewardApi<
+        Block,
+        VaultId,
+        CurrencyId,
+        Balance
+    > for Runtime {
+        fn compute_reward(account_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            let result = VaultRewards::compute_reward(currency_id, &account_id)?;
+            let balance = BalanceWrapper::<Balance> { amount: result.try_into().map_err(|_| DispatchError::from(reward::Error::<Runtime, reward::Instance2>::TryIntoIntError))? };
+            Ok(balance)
+        }
+    }
+
     impl module_issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,


### PR DESCRIPTION
A few questions I'm blocked on at this point:

1. Build failure. This looks very similar to what I was getting when failing to implement the RPC in the runtimes, but here I've definitely added it to all four parachain runtimes and the standalone. Could you take a look please?
2. See comment below regarding possibly cleaning up the cast into Balance
3. We have two instances of the reward pallet, once using `VaultId` as the RewardId for vault block rewards, one using `AccountId` for escrow rewards. Right now I'm just trying to get the VaultId one to work for starters, as it's also going to be the main one useful for simplifying the lib, but I think it would be good to have both available as RPCs - how would I define that? The naive way of just adding a second impl to the runtimes doesn't work, and I'm not familiar enough with the inner workings of substrate to figure out how to approach this.