### PR TITLE
feat: configurable nomination limit

### DIFF
--- a/crates/nomination/src/benchmarking.rs
+++ b/crates/nomination/src/benchmarking.rs
@@ -54,6 +54,11 @@ benchmarks! {
     set_nomination_enabled {
     }: _(RawOrigin::Root, true)
 
+    set_nomination_limit {
+        let vault_id = get_vault_id::<T>();
+        let amount = 100u32.into();
+    }: _(RawOrigin::Signed(vault_id.account_id), vault_id.currencies.clone(), amount)
+
     opt_in_to_nomination {
         setup_exchange_rate::<T>();
         <NominationEnabled<T>>::set(true);
@@ -81,6 +86,13 @@ benchmarks! {
         <NominationEnabled<T>>::set(true);
 
         let vault_id = get_vault_id::<T>();
+
+        Nomination::<T>::set_nomination_limit(
+            RawOrigin::Signed(vault_id.account_id.clone()).into(),
+            vault_id.currencies.clone(),
+            (1u32 << 31).into()
+        ).unwrap();
+
         mint_collateral::<T>(&vault_id.account_id, (1u32 << 31).into());
         register_vault::<T>(vault_id.clone());
 
@@ -101,6 +113,12 @@ benchmarks! {
         register_vault::<T>(vault_id.clone());
 
         <Vaults<T>>::insert(&vault_id, true);
+
+        Nomination::<T>::set_nomination_limit(
+            RawOrigin::Signed(vault_id.account_id.clone()).into(),
+            vault_id.currencies.clone(),
+            (1u32 << 31).into()
+        ).unwrap();
 
         let nominator: T::AccountId = account("Nominator", 0, 0);
         mint_collateral::<T>(&nominator, (1u32 << 31).into());

--- a/crates/nomination/src/default_weights.rs
+++ b/crates/nomination/src/default_weights.rs
@@ -39,6 +39,7 @@ pub trait WeightInfo {
 	fn opt_out_of_nomination() -> Weight;
 	fn deposit_collateral() -> Weight;
 	fn withdraw_collateral() -> Weight;
+	fn set_nomination_limit() -> Weight;
 }
 
 /// Weights for nomination using the Substrate node and recommended hardware.
@@ -127,6 +128,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(21 as Weight))
 			.saturating_add(T::DbWeight::get().writes(10 as Weight))
 	}
+	// Storage: Nomination Nominationlimit (r:0 w:1)
+	fn set_nomination_limit() -> Weight {
+		(2_835_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
@@ -213,6 +219,11 @@ impl WeightInfo for () {
 		(259_690_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(21 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(10 as Weight))
+	}
+	// Storage: Nomination NominationLimit (r:0 w:1)
+	fn set_nomination_limit() -> Weight {
+		(2_835_000 as Weight)
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }
 

--- a/crates/nomination/src/ext.rs
+++ b/crates/nomination/src/ext.rs
@@ -36,13 +36,6 @@ pub(crate) mod vault_registry {
         <vault_registry::Pallet<T>>::is_allowed_to_withdraw_collateral(vault_id, amount)
     }
 
-    pub fn get_max_nominatable_collateral<T: crate::Config>(
-        vault_collateral: &Amount<T>,
-        currency_pair: &DefaultVaultCurrencyPair<T>,
-    ) -> Result<Amount<T>, DispatchError> {
-        <vault_registry::Pallet<T>>::get_max_nominatable_collateral(vault_collateral, currency_pair)
-    }
-
     pub fn try_increase_total_backing_collateral<T: crate::Config>(
         currency_pair: &DefaultVaultCurrencyPair<T>,
         amount: &Amount<T>,

--- a/crates/nomination/src/tests.rs
+++ b/crates/nomination/src/tests.rs
@@ -23,6 +23,11 @@ fn should_deposit_against_valid_vault() {
         ext::vault_registry::get_backing_collateral::<Test>.mock_safe(|_| MockResult::Return(Ok(collateral(10000))));
         ext::vault_registry::compute_collateral::<Test>.mock_safe(|_| MockResult::Return(Ok(collateral(10000))));
         assert_ok!(Nomination::_opt_in_to_nomination(&ALICE));
+        assert_ok!(Nomination::set_nomination_limit(
+            Origin::signed(ALICE.account_id),
+            ALICE.currencies,
+            100
+        ));
         assert_ok!(Nomination::_deposit_collateral(&ALICE, &BOB.account_id, 100));
     })
 }

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -580,7 +580,7 @@ pub mod pallet {
         VaultNotBelowLiquidationThreshold,
         /// Deposit address could not be generated with the given public key.
         InvalidPublicKey,
-        /// The Max Nomination Ratio would be exceeded.
+        /// Deprecated error. TODO: remove when releasing a breaking runtime upgrade
         MaxNominationRatioViolation,
         /// The collateral ceiling would be exceeded for the vault's currency.
         CurrencyCeilingExceeded,
@@ -905,24 +905,7 @@ impl<T: Config> Pallet<T> {
             Self::is_allowed_to_withdraw_collateral(vault_id, amount)?,
             Error::<T>::InsufficientCollateral
         );
-        ensure!(
-            Self::is_max_nomination_ratio_preserved(vault_id, amount)?,
-            Error::<T>::MaxNominationRatioViolation
-        );
         Self::force_withdraw_collateral(vault_id, amount)
-    }
-
-    pub fn is_max_nomination_ratio_preserved(
-        vault_id: &DefaultVaultId<T>,
-        amount: &Amount<T>,
-    ) -> Result<bool, DispatchError> {
-        let vault_collateral = Self::compute_collateral(vault_id)?;
-        let backing_collateral = Self::get_backing_collateral(vault_id)?;
-        let current_nomination = backing_collateral.checked_sub(&vault_collateral)?;
-        let new_vault_collateral = vault_collateral.checked_sub(&amount)?;
-        let max_nomination_after_withdrawal =
-            Self::get_max_nominatable_collateral(&new_vault_collateral, &vault_id.currencies)?;
-        Ok(current_nomination.le(&max_nomination_after_withdrawal)?)
     }
 
     /// Checks if the vault would be above the secure threshold after withdrawing collateral
@@ -1856,30 +1839,6 @@ impl<T: Config> Pallet<T> {
     pub fn compute_collateral(vault_id: &DefaultVaultId<T>) -> Result<Amount<T>, DispatchError> {
         let amount = ext::staking::compute_stake::<T>(vault_id, &vault_id.account_id)?;
         Ok(Amount::new(amount, vault_id.currencies.collateral))
-    }
-
-    pub fn get_max_nomination_ratio(
-        currency_pair: &DefaultVaultCurrencyPair<T>,
-    ) -> Result<UnsignedFixedPoint<T>, DispatchError> {
-        // MaxNominationRatio = (SecureCollateralThreshold / PremiumRedeemThreshold) - 1)
-        // It denotes the maximum amount of collateral that can be nominated to a particular Vault.
-        // Its effect is to minimise the impact on collateralization of nominator withdrawals.
-        let secure_collateral_threshold =
-            Self::secure_collateral_threshold(currency_pair).ok_or(Error::<T>::ThresholdNotSet)?;
-        let premium_redeem_threshold =
-            Self::premium_redeem_threshold(currency_pair).ok_or(Error::<T>::ThresholdNotSet)?;
-        Ok(secure_collateral_threshold
-            .checked_div(&premium_redeem_threshold)
-            .ok_or(ArithmeticError::Underflow)?
-            .checked_sub(&UnsignedFixedPoint::<T>::one())
-            .ok_or(ArithmeticError::Underflow)?)
-    }
-
-    pub fn get_max_nominatable_collateral(
-        vault_collateral: &Amount<T>,
-        currency_pair: &DefaultVaultCurrencyPair<T>,
-    ) -> Result<Amount<T>, DispatchError> {
-        vault_collateral.rounded_mul(Self::get_max_nomination_ratio(currency_pair)?)
     }
 
     /// Private getters and setters

--- a/standalone/runtime/tests/mock/nomination_testing_utils.rs
+++ b/standalone/runtime/tests/mock/nomination_testing_utils.rs
@@ -7,6 +7,7 @@ pub const VAULT: [u8; 32] = BOB;
 
 pub const DEFAULT_BACKING_COLLATERAL: Balance = 1_000_000;
 pub const DEFAULT_NOMINATION: Balance = 20_000;
+pub const DEFAULT_NOMINATION_LIMIT: Balance = 1_000_000;
 
 pub const DEFAULT_VAULT_UNBONDING_PERIOD: u32 = 100;
 pub const DEFAULT_NOMINATOR_UNBONDING_PERIOD: u32 = 50;
@@ -38,6 +39,11 @@ pub fn nomination_opt_in(vault_id: &DefaultVaultId<Runtime>) -> DispatchResultWi
 
 pub fn assert_nomination_opt_in(vault_id: &VaultId) {
     assert_ok!(nomination_opt_in(vault_id));
+    assert_ok!(Call::Nomination(NominationCall::set_nomination_limit {
+        currency_pair: vault_id.currencies.clone(),
+        limit: DEFAULT_NOMINATION_LIMIT
+    })
+    .dispatch(origin_of(vault_id.account_id.clone())));
 }
 
 pub fn nomination_opt_out(vault_id: &DefaultVaultId<Runtime>) -> DispatchResultWithPostInfo {

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -1,7 +1,6 @@
 mod mock;
 
 use currency::Amount;
-use frame_support::assert_err;
 use mock::{assert_eq, issue_testing_utils::*, *};
 
 fn test_with<R>(execute: impl Fn(VaultId) -> R) {

--- a/standalone/runtime/tests/test_nomination.rs
+++ b/standalone/runtime/tests/test_nomination.rs
@@ -2,7 +2,6 @@ mod mock;
 
 use currency::Amount;
 use mock::{assert_eq, nomination_testing_utils::*, *};
-use sp_runtime::traits::{CheckedDiv, CheckedSub};
 
 fn test_with<R>(execute: impl Fn(VaultId) -> R) {
     let test_with = |currency_id, wrapped_id| {
@@ -251,7 +250,7 @@ mod spec_based_tests {
                     amount: 100000000000000000000000
                 })
                 .dispatch(origin_of(account_of(USER))),
-                NominationError::DepositViolatesMaxNominationRatio
+                NominationError::NominationExceedsLimit
             );
             assert_ok!(Call::Nomination(NominationCall::deposit_collateral {
                 vault_id: vault_id.clone(),
@@ -460,16 +459,26 @@ fn integration_test_vaults_cannot_withdraw_nominated_collateral() {
 }
 
 #[test]
-fn integration_test_nominated_collateral_cannot_exceed_max_nomination_ratio() {
+fn integration_test_nominated_collateral_cannot_exceed_nomination_limit() {
     test_with_nomination_enabled_and_vault_opted_in(|vault_id| {
+        assert_ok!(Call::Nomination(NominationCall::deposit_collateral {
+            vault_id: vault_id.clone(),
+            amount: DEFAULT_NOMINATION_LIMIT - 100,
+        })
+        .dispatch(origin_of(account_of(USER))));
         assert_noop!(
-            nominate_collateral(
-                &vault_id,
-                account_of(USER),
-                default_backing_collateral(vault_id.collateral_currency())
-            ),
-            NominationError::DepositViolatesMaxNominationRatio
+            Call::Nomination(NominationCall::deposit_collateral {
+                vault_id: vault_id.clone(),
+                amount: 101,
+            })
+            .dispatch(origin_of(account_of(CAROL))),
+            NominationError::NominationExceedsLimit
         );
+        assert_ok!(Call::Nomination(NominationCall::deposit_collateral {
+            vault_id: vault_id.clone(),
+            amount: 100,
+        })
+        .dispatch(origin_of(account_of(CAROL))));
     });
 }
 
@@ -561,22 +570,6 @@ fn integration_test_nomination_fee_distribution() {
 }
 
 #[test]
-fn integration_test_maximum_nomination_ratio_calculation() {
-    test_with_nomination_enabled_and_vault_opted_in(|vault_id| {
-        let expected_nomination_ratio = FixedU128::checked_from_rational(150, 100)
-            .unwrap()
-            .checked_div(&FixedU128::checked_from_rational(135, 100).unwrap())
-            .unwrap()
-            .checked_sub(&FixedU128::one())
-            .unwrap();
-        assert_eq!(
-            VaultRegistryPallet::get_max_nomination_ratio(&vault_id.currencies).unwrap(),
-            expected_nomination_ratio
-        );
-    })
-}
-
-#[test]
 fn integration_test_vault_opt_out_must_refund_nomination() {
     test_with_nomination_enabled_and_vault_opted_in(|vault_id| {
         assert_nominate_collateral(&vault_id, account_of(USER), default_nomination(&vault_id));
@@ -623,24 +616,6 @@ fn integration_test_liquidating_a_vault_does_not_force_refund() {
         VaultRegistryPallet::liquidate_vault(&vault_id).unwrap();
         let nonce: u32 = VaultStakingPallet::nonce(&vault_id);
         assert_eq!(nonce, 0);
-    })
-}
-
-#[test]
-fn integration_test_vault_withdrawal_cannot_exceed_max_nomination_taio() {
-    test_with_nomination_enabled_and_vault_opted_in(|vault_id| {
-        let max_nomination = VaultRegistryPallet::get_max_nominatable_collateral(
-            &default_backing_collateral(vault_id.collateral_currency()),
-            &vault_id.currencies,
-        )
-        .unwrap();
-        assert_nominate_collateral(&vault_id, account_of(USER), max_nomination);
-
-        // Need to withdraw 10 units to account for rounding errors
-        assert_noop!(
-            withdraw_vault_collateral(&vault_id, Amount::new(10, vault_id.collateral_currency())),
-            VaultRegistryError::MaxNominationRatioViolation
-        );
     })
 }
 


### PR DESCRIPTION
- now that we consider nomination to be fully trusted, we no longer need to enforce a nomination limit per vault for security reasons
- since the vault may still want to limit nominations for of economic reasons, we implement a configurable limit. It's just a configurable amount rather than a ratio, as discussed here https://discord.com/channels/745259537707040778/1028994764042944532/1029007960283815956 