### PR TITLE
chore: reduce democracy periods on kintsugi & testnet

### DIFF
--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -478,13 +478,13 @@ type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
 
 parameter_types! {
     pub const LaunchPeriod: BlockNumber = 7 * DAYS;
-    pub const VotingPeriod: BlockNumber = 7 * DAYS;
+    pub const VotingPeriod: BlockNumber = 2 * DAYS;
     pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
     // Require 5 vKINT to make a proposal. Given the crowdloan airdrop, this qualifies about 3500
     // accounts to make a governance proposal. Only 2300 can do two proposals,
     // and 700 accounts can do ten or more proposals.
     pub MinimumDeposit: Balance = 5 * UNITS;
-    pub const EnactmentPeriod: BlockNumber = DAYS;
+    pub const EnactmentPeriod: BlockNumber = 6 * HOURS;
     pub PreimageByteDeposit: Balance = 10 * MILLICENTS;
     pub const MaxVotes: u32 = 100;
     pub const MaxProposals: u32 = 100;

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -448,13 +448,13 @@ type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
 
 parameter_types! {
     pub const LaunchPeriod: BlockNumber = 7 * DAYS;
-    pub const VotingPeriod: BlockNumber = 7 * DAYS;
+    pub const VotingPeriod: BlockNumber = 2 * DAYS;
     pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
     // Require 5 vKINT to make a proposal. Given the crowdloan airdrop, this qualifies about 3500
     // accounts to make a governance proposal. Only 2300 can do two proposals,
     // and 700 accounts can do ten or more proposals.
     pub MinimumDeposit: Balance = 5 * UNITS;
-    pub const EnactmentPeriod: BlockNumber = DAYS;
+    pub const EnactmentPeriod: BlockNumber = 6 * HOURS;
     pub PreimageByteDeposit: Balance = 10 * MILLICENTS;
     pub const MaxVotes: u32 = 100;
     pub const MaxProposals: u32 = 100;


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

* Public proposal escalated to referendum every 7 days (same as before)
* Voting period is 2 days (reduced from 7 days)
* Fast-track voting period is 3 hours (same as before)
* Default enactment period is now 6 hours (reduced from 1 day) - for anything not fast-tracked