### PR TITLE
Collateral Toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5936,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "orml-asset-registry"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "orml-oracle"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5973,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "orml-tokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5988,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -6006,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "orml-unknown-tokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6021,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "orml-utilities"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6035,7 +6035,7 @@ dependencies = [
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6050,7 +6050,7 @@ dependencies = [
 [[package]]
 name = "orml-xcm"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6064,7 +6064,7 @@ dependencies = [
 [[package]]
 name = "orml-xcm-support"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "frame-support",
  "orml-traits",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "orml-xtokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=f4ef99fb108232c4c1fe9ed54d08be3681b77669#f4ef99fb108232c4c1fe9ed54d08be3681b77669"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5936,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "orml-asset-registry"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "orml-oracle"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5973,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "orml-tokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5988,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -6006,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "orml-unknown-tokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6021,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "orml-utilities"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6035,7 +6035,7 @@ dependencies = [
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6050,7 +6050,7 @@ dependencies = [
 [[package]]
 name = "orml-xcm"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6064,7 +6064,7 @@ dependencies = [
 [[package]]
 name = "orml-xcm-support"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "frame-support",
  "orml-traits",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "orml-xtokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=5803a01a44ade05fe5f00dd73b619c89fbf4e701#5803a01a44ade05fe5f00dd73b619c89fbf4e701"
+source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=3fcd3cf9e63fe80fd9671912833a900ba09d1cc0#3fcd3cf9e63fe80fd9671912833a900ba09d1cc0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/crates/currency/Cargo.toml
+++ b/crates/currency/Cargo.toml
@@ -22,8 +22,8 @@ primitives = { package = "interbtc-primitives", path = "../../primitives", defau
 traits = { path = '../traits', default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 # for other pallets wanting to mock functions
 mocktopus = {version = "0.7.0", optional = true }

--- a/crates/currency/Cargo.toml
+++ b/crates/currency/Cargo.toml
@@ -22,8 +22,8 @@ primitives = { package = "interbtc-primitives", path = "../../primitives", defau
 traits = { path = '../traits', default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 # for other pallets wanting to mock functions
 mocktopus = {version = "0.7.0", optional = true }

--- a/crates/currency/src/mock.rs
+++ b/crates/currency/src/mock.rs
@@ -92,16 +92,11 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = ();
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = ();
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 pub struct CurrencyConvert;

--- a/crates/fee/Cargo.toml
+++ b/crates/fee/Cargo.toml
@@ -35,8 +35,8 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "
 currency = { path = "../currency", features = ["testing-utils"] }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 # Parachain dependencies
 primitives = { package = "interbtc-primitives", path = "../../primitives"}

--- a/crates/fee/Cargo.toml
+++ b/crates/fee/Cargo.toml
@@ -35,8 +35,8 @@ pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "
 currency = { path = "../currency", features = ["testing-utils"] }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 # Parachain dependencies
 primitives = { package = "interbtc-primitives", path = "../../primitives"}

--- a/crates/fee/src/mock.rs
+++ b/crates/fee/src/mock.rs
@@ -105,16 +105,11 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = ();
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = ();
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 impl reward::Config for Test {

--- a/crates/issue/Cargo.toml
+++ b/crates/issue/Cargo.toml
@@ -35,8 +35,8 @@ vault-registry = { path = "../vault-registry", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false, optional = true }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false, optional = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
 
 [dev-dependencies]
 mocktopus = "0.7.0"
@@ -47,8 +47,8 @@ reward = { path = "../reward" }
 staking = { path = "../staking" }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
 
 [features]
 default = ["std"]

--- a/crates/issue/Cargo.toml
+++ b/crates/issue/Cargo.toml
@@ -35,8 +35,8 @@ vault-registry = { path = "../vault-registry", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false, optional = true }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false, optional = true }
 
 [dev-dependencies]
 mocktopus = "0.7.0"
@@ -47,8 +47,8 @@ reward = { path = "../reward" }
 staking = { path = "../staking" }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0" }
 
 [features]
 default = ["std"]

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -115,16 +115,11 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = ();
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = ();
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 impl reward::Config for Test {

--- a/crates/loans/Cargo.toml
+++ b/crates/loans/Cargo.toml
@@ -32,9 +32,9 @@ traits = { path = "../traits", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-oracle = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-oracle = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [dev-dependencies]
 mocktopus = "0.7.0"

--- a/crates/loans/Cargo.toml
+++ b/crates/loans/Cargo.toml
@@ -32,9 +32,9 @@ traits = { path = "../traits", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-oracle = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-oracle = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [dev-dependencies]
 mocktopus = "0.7.0"

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -40,7 +40,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 use num_traits::cast::ToPrimitive;
-use orml_traits::MultiCurrency;
+use orml_traits::{MultiCurrency, MultiReservableCurrency};
 pub use pallet::*;
 use primitives::{Balance, CurrencyId, Liquidity, Price, Rate, Ratio, Shortfall, Timestamp};
 use sp_runtime::{
@@ -111,10 +111,9 @@ impl<T: Config> OnSlash<T::AccountId, AssetIdOf<T>, BalanceOf<T>> for OnSlashHoo
     }
 }
 
-pub struct OnDepositHook<T>(marker::PhantomData<T>);
-// TODO: upgrade to use orml-tokens posthooks once merged to master
-impl<T: Config> OnDeposit<T::AccountId, AssetIdOf<T>, BalanceOf<T>> for OnDepositHook<T> {
-    fn on_deposit(currency_id: AssetIdOf<T>, account_id: &T::AccountId, _: BalanceOf<T>) -> DispatchResult {
+pub struct PreDeposit<T>(marker::PhantomData<T>);
+impl<T: Config> OnDeposit<T::AccountId, AssetIdOf<T>, BalanceOf<T>> for PreDeposit<T> {
+    fn on_deposit(currency_id: AssetIdOf<T>, account_id: &T::AccountId, _amount: BalanceOf<T>) -> DispatchResult {
         if currency_id.is_lend_token() {
             let underlying_id = Pallet::<T>::underlying_id(currency_id)?;
             Pallet::<T>::update_reward_supply_index(underlying_id)?;
@@ -124,20 +123,44 @@ impl<T: Config> OnDeposit<T::AccountId, AssetIdOf<T>, BalanceOf<T>> for OnDeposi
     }
 }
 
-pub struct OnTransferHook<T>(marker::PhantomData<T>);
-// TODO: upgrade to use orml-tokens posthooks once merged to master
-impl<T: Config> OnTransfer<T::AccountId, AssetIdOf<T>, BalanceOf<T>> for OnTransferHook<T> {
+pub struct PostDeposit<T>(marker::PhantomData<T>);
+impl<T: Config> OnDeposit<T::AccountId, AssetIdOf<T>, BalanceOf<T>> for PostDeposit<T> {
+    fn on_deposit(currency_id: AssetIdOf<T>, account_id: &T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
+        if currency_id.is_lend_token() {
+            Pallet::<T>::lock_if_account_deposited(account_id, currency_id, amount)?;
+        }
+        Ok(())
+    }
+}
+
+pub struct PreTransfer<T>(marker::PhantomData<T>);
+impl<T: Config> OnTransfer<T::AccountId, AssetIdOf<T>, BalanceOf<T>> for PreTransfer<T> {
     fn on_transfer(
         currency_id: AssetIdOf<T>,
         from: &T::AccountId,
         to: &T::AccountId,
-        _: BalanceOf<T>,
+        _amount: BalanceOf<T>,
     ) -> DispatchResult {
         if currency_id.is_lend_token() {
             let underlying_id = Pallet::<T>::underlying_id(currency_id)?;
             Pallet::<T>::update_reward_supply_index(underlying_id)?;
             Pallet::<T>::distribute_supplier_reward(underlying_id, from)?;
             Pallet::<T>::distribute_supplier_reward(underlying_id, to)?;
+        }
+        Ok(())
+    }
+}
+
+pub struct PostTransfer<T>(marker::PhantomData<T>);
+impl<T: Config> OnTransfer<T::AccountId, AssetIdOf<T>, BalanceOf<T>> for PostTransfer<T> {
+    fn on_transfer(
+        currency_id: AssetIdOf<T>,
+        _from: &T::AccountId,
+        to: &T::AccountId,
+        amount: BalanceOf<T>,
+    ) -> DispatchResult {
+        if currency_id.is_lend_token() {
+            Pallet::<T>::lock_if_account_deposited(to, currency_id, amount)?;
         }
         Ok(())
     }
@@ -242,6 +265,8 @@ pub mod pallet {
         InvalidExchangeRate,
         /// Amount cannot be zero
         InvalidAmount,
+        /// Tokens already locked for a different purpose than borrow collateral
+        TokensAlreadyLocked,
         /// Payer cannot be signer
         PayerIsSigner,
         /// Codec error
@@ -850,6 +875,18 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
             ensure!(!redeem_amount.is_zero(), Error::<T>::InvalidAmount);
+
+            let lend_token_id = Self::lend_token_id(asset_id)?;
+            // if the receiver has collateral locked
+            let deposit = Pallet::<T>::account_deposits(lend_token_id, &who);
+            if deposit > 0 {
+                // Withdraw the `lend_tokens` from the borrow collateral, so they are redeemable.
+                // This assumes that a user cannot have both `free` and `locked` lend tokens at
+                // the same time (for the purposes of lending and borrowing).
+                let amount = Amount::<T>::new(redeem_amount, asset_id);
+                let collateral = Self::recompute_collateral_amount(&amount)?;
+                Self::do_withdraw_collateral(&who, collateral.currency(), collateral.amount())?;
+            }
             Self::do_redeem(&who, asset_id, redeem_amount)?;
 
             Ok(().into())
@@ -861,7 +898,7 @@ pub mod pallet {
         #[pallet::weight(<T as Config>::WeightInfo::redeem_all())]
         #[transactional]
         pub fn redeem_all(origin: OriginFor<T>, asset_id: AssetIdOf<T>) -> DispatchResultWithPostInfo {
-            let who = ensure_signed(origin)?;
+            let who = ensure_signed(origin.clone())?;
             // This function is an almost 1:1 duplicate of the logic in `do_redeem`.
             // It could be refactored to compute the redeemable underlying
             // with `Self::recompute_underlying_amount(&Self::free_lend_tokens(asset_id, &who)?)?`
@@ -881,6 +918,16 @@ pub mod pallet {
             // If there are leftover lend_tokens after a `redeem_all` (because of rounding down), it would make it
             // impossible to enforce "collateral toggle" state transitions.
             Self::ensure_active_market(asset_id)?;
+
+            let lend_token_id = Self::lend_token_id(asset_id)?;
+            // if the receiver has collateral locked
+            let deposit = Pallet::<T>::account_deposits(lend_token_id, &who);
+            if deposit > 0 {
+                // then withdraw all collateral
+                Self::withdraw_all_collateral(origin, asset_id)?;
+            }
+
+            // `do_redeem()` logic duplicate:
             Self::accrue_interest(asset_id)?;
             let exchange_rate = Self::exchange_rate_stored(asset_id)?;
             Self::update_earned_stored(&who, asset_id, exchange_rate)?;
@@ -950,22 +997,13 @@ pub mod pallet {
         #[transactional]
         pub fn deposit_all_collateral(origin: OriginFor<T>, asset_id: AssetIdOf<T>) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
-            let lend_tokens = Self::free_lend_tokens(asset_id, &who)?;
-            ensure!(!lend_tokens.is_zero(), Error::<T>::InvalidAmount);
-            Self::do_deposit_collateral(&who, lend_tokens.currency(), lend_tokens.amount())?;
-            Ok(().into())
-        }
-
-        #[pallet::weight(<T as Config>::WeightInfo::collateral_asset())]
-        #[transactional]
-        pub fn deposit_collateral(
-            origin: OriginFor<T>,
-            asset_id: AssetIdOf<T>,
-            #[pallet::compact] amount: BalanceOf<T>,
-        ) -> DispatchResultWithPostInfo {
-            let who = ensure_signed(origin)?;
-            ensure!(!amount.is_zero(), Error::<T>::InvalidAmount);
-            Self::do_deposit_collateral(&who, asset_id, amount)?;
+            let free_lend_tokens = Self::free_lend_tokens(asset_id, &who)?;
+            ensure!(!free_lend_tokens.is_zero(), Error::<T>::InvalidAmount);
+            let reserved_lend_tokens = Self::reserved_lend_tokens(asset_id, &who)?;
+            // This check could fail if `withdraw_all_collateral()` leaves leftover lend_tokens locked.
+            // However the current implementation is guaranteed to withdraw everything.
+            ensure!(reserved_lend_tokens.is_zero(), Error::<T>::TokensAlreadyLocked);
+            Self::do_deposit_collateral(&who, free_lend_tokens.currency(), free_lend_tokens.amount())?;
             Ok(().into())
         }
 
@@ -978,19 +1016,6 @@ pub mod pallet {
             let collateral = Self::account_deposits(lend_token_id, who.clone());
             ensure!(!collateral.is_zero(), Error::<T>::InvalidAmount);
             Self::do_withdraw_collateral(&who, lend_token_id, collateral)?;
-            Ok(().into())
-        }
-
-        #[pallet::weight(<T as Config>::WeightInfo::collateral_asset())]
-        #[transactional]
-        pub fn withdraw_collateral(
-            origin: OriginFor<T>,
-            asset_id: AssetIdOf<T>,
-            #[pallet::compact] amount: BalanceOf<T>,
-        ) -> DispatchResultWithPostInfo {
-            let who = ensure_signed(origin)?;
-            ensure!(!amount.is_zero(), Error::<T>::InvalidAmount);
-            Self::do_withdraw_collateral(&who, asset_id, amount)?;
             Ok(().into())
         }
 
@@ -1630,6 +1655,21 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
+    pub fn lock_if_account_deposited(
+        account_id: &T::AccountId,
+        lend_token_id: AssetIdOf<T>,
+        incoming_amount: BalanceOf<T>,
+    ) -> DispatchResult {
+        // if the receiver already has their collateral deposited
+        let deposit = Pallet::<T>::account_deposits(lend_token_id, account_id);
+        if deposit > 0 {
+            // then any incoming `lend_tokens` must automatically be deposited as collateral
+            // to enforce the "collateral toggle"
+            Self::do_deposit_collateral(account_id, lend_token_id, incoming_amount)?;
+        }
+        Ok(())
+    }
+
     // Ensures a given `asset_id` is an active market.
     fn ensure_active_market(asset_id: AssetIdOf<T>) -> Result<Market<BalanceOf<T>>, DispatchError> {
         Self::active_markets()
@@ -1743,6 +1783,16 @@ impl<T: Config> Pallet<T> {
         let lend_token_id = Self::lend_token_id(asset_id)?;
         let amount = Amount::new(
             orml_tokens::Pallet::<T>::free_balance(lend_token_id, account_id),
+            lend_token_id,
+        );
+        Ok(amount)
+    }
+
+    /// Reserved lending tokens (lend_tokens) of an account, given the underlying
+    pub fn reserved_lend_tokens(asset_id: AssetIdOf<T>, account_id: &T::AccountId) -> Result<Amount<T>, DispatchError> {
+        let lend_token_id = Self::lend_token_id(asset_id)?;
+        let amount = Amount::new(
+            orml_tokens::Pallet::<T>::reserved_balance(lend_token_id, account_id),
             lend_token_id,
         );
         Ok(amount)

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -265,6 +265,10 @@ pub mod pallet {
         InvalidExchangeRate,
         /// Amount cannot be zero
         InvalidAmount,
+        /// Locking collateral failed. The account has no `free` tokens.
+        DepositAllCollateralFailed,
+        /// Unlocking collateral failed. The account has no `reserved` tokens.
+        WithdrawAllCollateralFailed,
         /// Tokens already locked for a different purpose than borrow collateral
         TokensAlreadyLocked,
         /// Payer cannot be signer
@@ -998,7 +1002,7 @@ pub mod pallet {
         pub fn deposit_all_collateral(origin: OriginFor<T>, asset_id: AssetIdOf<T>) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
             let free_lend_tokens = Self::free_lend_tokens(asset_id, &who)?;
-            ensure!(!free_lend_tokens.is_zero(), Error::<T>::InvalidAmount);
+            ensure!(!free_lend_tokens.is_zero(), Error::<T>::DepositAllCollateralFailed);
             let reserved_lend_tokens = Self::reserved_lend_tokens(asset_id, &who)?;
             // This check could fail if `withdraw_all_collateral()` leaves leftover lend_tokens locked.
             // However the current implementation is guaranteed to withdraw everything.
@@ -1014,7 +1018,7 @@ pub mod pallet {
 
             let lend_token_id = Self::lend_token_id(asset_id)?;
             let collateral = Self::account_deposits(lend_token_id, who.clone());
-            ensure!(!collateral.is_zero(), Error::<T>::InvalidAmount);
+            ensure!(!collateral.is_zero(), Error::<T>::WithdrawAllCollateralFailed);
             Self::do_withdraw_collateral(&who, lend_token_id, collateral)?;
             Ok(().into())
         }

--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -316,11 +316,11 @@ fn zero_amount_extrinsics_fail() {
         );
         assert_noop!(
             Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), DOT),
-            Error::<Test>::InvalidAmount
+            Error::<Test>::DepositAllCollateralFailed
         );
         assert_noop!(
             Loans::withdraw_all_collateral(RuntimeOrigin::signed(ALICE), DOT),
-            Error::<Test>::InvalidAmount
+            Error::<Test>::WithdrawAllCollateralFailed
         );
         assert_noop!(
             Loans::liquidate_borrow(RuntimeOrigin::signed(ALICE), BOB, DOT, unit(0), IBTC),
@@ -1285,7 +1285,7 @@ fn reward_calculation_multi_player_in_one_market_works() {
         // There is no locked collateral left, so withdrawing will fail
         assert_noop!(
             Loans::withdraw_all_collateral(RuntimeOrigin::signed(BOB), DOT),
-            Error::<Test>::InvalidAmount
+            Error::<Test>::WithdrawAllCollateralFailed
         );
         // There is also no free collateral left, so redeeming will fail
         assert_noop!(

--- a/crates/loans/src/tests/interest_rate.rs
+++ b/crates/loans/src/tests/interest_rate.rs
@@ -170,15 +170,6 @@ fn accrue_interest_works_after_redeem() {
         TimestampPallet::set_timestamp(12000);
 
         let amount_to_redeem = unit(10);
-        // First, withdraw the amount to redeem from the deposited collateral
-        let exchange_rate = Loans::exchange_rate_stored(Token(DOT)).unwrap();
-        let lend_token_amount = Loans::calc_collateral_amount(amount_to_redeem, exchange_rate).unwrap();
-        assert_ok!(Loans::withdraw_collateral(
-            RuntimeOrigin::signed(ALICE),
-            Loans::lend_token_id(Token(DOT)).unwrap(),
-            lend_token_amount
-        ));
-        // Then the amount can be redeemed
         assert_ok!(Loans::redeem(
             RuntimeOrigin::signed(ALICE),
             Token(DOT),
@@ -213,6 +204,8 @@ fn accrue_interest_works_after_redeem_all() {
             0,
         );
         assert_eq!(Tokens::balance(Token(DOT), &BOB), 1000000000003608);
+        assert_eq!(Loans::free_lend_tokens(Token(DOT), &BOB).unwrap().is_zero(), true);
+        assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &BOB).unwrap().is_zero(), true);
         assert!(!AccountDeposits::<Test>::contains_key(Token(DOT), &BOB))
     })
 }

--- a/crates/loans/src/tests/lend_tokens.rs
+++ b/crates/loans/src/tests/lend_tokens.rs
@@ -14,6 +14,7 @@ use primitives::{
     KBTC as KBTC_CURRENCY, KINT as KINT_CURRENCY, KSM as KSM_CURRENCY,
 };
 use sp_runtime::{FixedPointNumber, TokenError};
+use traits::LoansApi;
 
 const KINT: CurrencyId = Token(KINT_CURRENCY);
 const KSM: CurrencyId = Token(KSM_CURRENCY);
@@ -195,12 +196,9 @@ fn transfer_lend_tokens_under_collateral_does_not_work() {
             Loans::transfer(LEND_KINT, &DAVE, &ALICE, unit(20) * 50, true),
             Error::<Test>::InsufficientCollateral
         );
-        // First, withdraw some tokens
-        assert_ok!(Loans::withdraw_collateral(
-            RuntimeOrigin::signed(DAVE),
-            LEND_KINT,
-            unit(20) * 50
-        ));
+        // First, withdraw some tokens. Note that directly withdrawing part of the locked
+        // lend_tokens is not possible through extrinsics.
+        assert_ok!(Loans::do_withdraw_collateral(&DAVE, LEND_KINT, unit(20) * 50));
         // Check entries from orml-tokens directly
         assert_eq!(free_balance(LEND_KINT, &DAVE), unit(20) * 50);
         assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(80) * 50);

--- a/crates/nomination/Cargo.toml
+++ b/crates/nomination/Cargo.toml
@@ -33,16 +33,16 @@ staking = { path = "../staking", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false, optional = true }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false, optional = true }
 
 [dev-dependencies]
 mocktopus = "0.7.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/nomination/Cargo.toml
+++ b/crates/nomination/Cargo.toml
@@ -33,16 +33,16 @@ staking = { path = "../staking", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false, optional = true }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false, optional = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
 
 [dev-dependencies]
 mocktopus = "0.7.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/nomination/src/mock.rs
+++ b/crates/nomination/src/mock.rs
@@ -120,16 +120,11 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = ();
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = ();
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 impl reward::Config for Test {

--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -32,8 +32,8 @@ mocktopus = "0.7.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -32,8 +32,8 @@ mocktopus = "0.7.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/oracle/src/mock.rs
+++ b/crates/oracle/src/mock.rs
@@ -103,16 +103,11 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = ();
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = ();
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 pub struct CurrencyConvert;

--- a/crates/redeem/Cargo.toml
+++ b/crates/redeem/Cargo.toml
@@ -33,8 +33,8 @@ vault-registry = { path = "../vault-registry", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false, optional = true }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false, optional = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
 
 [dev-dependencies]
 mocktopus = "0.7.0"
@@ -46,8 +46,8 @@ staking = { path = "../staking" }
 currency = { path = "../currency", features = ["testing-utils"] }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
 
 [features]
 default = ["std"]

--- a/crates/redeem/Cargo.toml
+++ b/crates/redeem/Cargo.toml
@@ -33,8 +33,8 @@ vault-registry = { path = "../vault-registry", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false, optional = true }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false, optional = true }
 
 [dev-dependencies]
 mocktopus = "0.7.0"
@@ -46,8 +46,8 @@ staking = { path = "../staking" }
 currency = { path = "../currency", features = ["testing-utils"] }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0" }
 
 [features]
 default = ["std"]

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -121,16 +121,11 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = ();
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = ();
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 parameter_types! {

--- a/crates/replace/Cargo.toml
+++ b/crates/replace/Cargo.toml
@@ -34,8 +34,8 @@ nomination = { path = "../nomination", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false, optional = true }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false, optional = true }
 
 [dev-dependencies]
 mocktopus = "0.7.0"
@@ -47,8 +47,8 @@ staking = { path = "../staking" }
 currency = { path = "../currency", features = ["testing-utils"] }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0" }
 
 [features]
 default = ["std"]

--- a/crates/replace/Cargo.toml
+++ b/crates/replace/Cargo.toml
@@ -34,8 +34,8 @@ nomination = { path = "../nomination", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false, optional = true }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false, optional = true }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false, optional = true }
 
 [dev-dependencies]
 mocktopus = "0.7.0"
@@ -47,8 +47,8 @@ staking = { path = "../staking" }
 currency = { path = "../currency", features = ["testing-utils"] }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669" }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701" }
 
 [features]
 default = ["std"]

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -116,16 +116,11 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = ();
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = ();
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 impl reward::Config for Test {

--- a/crates/staking/Cargo.toml
+++ b/crates/staking/Cargo.toml
@@ -25,8 +25,8 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false, optional = true }
 
 # note: can be remove after removal of migration
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [dev-dependencies]
 mocktopus = "0.7.0"

--- a/crates/staking/Cargo.toml
+++ b/crates/staking/Cargo.toml
@@ -25,8 +25,8 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false, optional = true }
 
 # note: can be remove after removal of migration
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [dev-dependencies]
 mocktopus = "0.7.0"

--- a/crates/staking/src/mock.rs
+++ b/crates/staking/src/mock.rs
@@ -97,16 +97,11 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = ();
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = ();
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 pub type TestError = Error<Test>;

--- a/crates/vault-registry/Cargo.toml
+++ b/crates/vault-registry/Cargo.toml
@@ -37,8 +37,8 @@ staking = { path = "../staking", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [dev-dependencies]
 mocktopus = "0.7.0"

--- a/crates/vault-registry/Cargo.toml
+++ b/crates/vault-registry/Cargo.toml
@@ -37,8 +37,8 @@ staking = { path = "../staking", default-features = false }
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [dev-dependencies]
 mocktopus = "0.7.0"

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -117,16 +117,11 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = ();
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = ();
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 impl reward::Config for Test {

--- a/parachain/runtime/interlay/Cargo.toml
+++ b/parachain/runtime/interlay/Cargo.toml
@@ -109,14 +109,14 @@ module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-a
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/interlay/Cargo.toml
+++ b/parachain/runtime/interlay/Cargo.toml
@@ -109,14 +109,14 @@ module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-a
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -25,7 +25,7 @@ use frame_system::{
 };
 pub use orml_asset_registry::AssetMetadata;
 use orml_asset_registry::SequentialId;
-use orml_traits::parameter_type_with_key;
+use orml_traits::{currency::MutationHooks, parameter_type_with_key};
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, H256};
@@ -669,6 +669,21 @@ parameter_type_with_key! {
     };
 }
 
+pub struct CurrencyHooks<T>(PhantomData<T>);
+impl<T: orml_tokens::Config> MutationHooks<T::AccountId, T::CurrencyId, T::Balance> for CurrencyHooks<T>
+where
+    T::AccountId: From<sp_runtime::AccountId32>,
+{
+    type OnDust = orml_tokens::TransferDust<T, FeeAccount>;
+    type OnSlash = ();
+    type PreDeposit = ();
+    type PostDeposit = ();
+    type PreTransfer = ();
+    type PostTransfer = ();
+    type OnNewTokenAccount = ();
+    type OnKilledTokenAccount = ();
+}
+
 impl orml_tokens::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Balance = Balance;
@@ -676,16 +691,11 @@ impl orml_tokens::Config for Runtime {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = orml_tokens::TransferDust<Runtime, FeeAccount>;
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = CurrencyHooks<Runtime>;
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = DustRemovalWhitelist;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 pub struct AssetAuthority;

--- a/parachain/runtime/kintsugi/Cargo.toml
+++ b/parachain/runtime/kintsugi/Cargo.toml
@@ -109,14 +109,14 @@ module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-a
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/kintsugi/Cargo.toml
+++ b/parachain/runtime/kintsugi/Cargo.toml
@@ -109,14 +109,14 @@ module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-a
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -24,7 +24,7 @@ use frame_system::{
     EnsureRoot, EnsureRootWithSuccess, RawOrigin,
 };
 use orml_asset_registry::SequentialId;
-use orml_traits::parameter_type_with_key;
+use orml_traits::{currency::MutationHooks, parameter_type_with_key};
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, H256};
@@ -669,6 +669,21 @@ parameter_type_with_key! {
     };
 }
 
+pub struct CurrencyHooks<T>(PhantomData<T>);
+impl<T: orml_tokens::Config> MutationHooks<T::AccountId, T::CurrencyId, T::Balance> for CurrencyHooks<T>
+where
+    T::AccountId: From<sp_runtime::AccountId32>,
+{
+    type OnDust = orml_tokens::TransferDust<T, FeeAccount>;
+    type OnSlash = ();
+    type PreDeposit = ();
+    type PostDeposit = ();
+    type PreTransfer = ();
+    type PostTransfer = ();
+    type OnNewTokenAccount = ();
+    type OnKilledTokenAccount = ();
+}
+
 impl orml_tokens::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Balance = Balance;
@@ -676,16 +691,11 @@ impl orml_tokens::Config for Runtime {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = orml_tokens::TransferDust<Runtime, FeeAccount>;
-    type OnSlash = ();
-    type OnDeposit = ();
-    type OnTransfer = ();
+    type CurrencyHooks = CurrencyHooks<Runtime>;
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = DustRemovalWhitelist;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 pub struct AssetAuthority;

--- a/parachain/runtime/runtime-tests/Cargo.toml
+++ b/parachain/runtime/runtime-tests/Cargo.toml
@@ -114,14 +114,14 @@ module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api
 module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/runtime-tests/Cargo.toml
+++ b/parachain/runtime/runtime-tests/Cargo.toml
@@ -114,14 +114,14 @@ module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api
 module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-xcm = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/testnet-interlay/Cargo.toml
+++ b/parachain/runtime/testnet-interlay/Cargo.toml
@@ -111,14 +111,14 @@ module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-a
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/testnet-interlay/Cargo.toml
+++ b/parachain/runtime/testnet-interlay/Cargo.toml
@@ -111,14 +111,14 @@ module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-a
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -24,9 +24,9 @@ use frame_system::{
     limits::{BlockLength, BlockWeights},
     EnsureRoot, EnsureRootWithSuccess, EnsureSigned,
 };
-use loans::{OnDepositHook, OnSlashHook, OnTransferHook};
+use loans::{OnSlashHook, PostDeposit, PostTransfer, PreDeposit, PreTransfer};
 use orml_asset_registry::SequentialId;
-use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key, MultiCurrency};
+use orml_traits::{currency::MutationHooks, location::AbsoluteReserveProvider, parameter_type_with_key, MultiCurrency};
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use primitives::PriceDetail;
 use sp_api::impl_runtime_apis;
@@ -646,6 +646,22 @@ parameter_type_with_key! {
     };
 }
 
+pub struct CurrencyHooks<T>(PhantomData<T>);
+impl<T: orml_tokens::Config + loans::Config>
+    MutationHooks<T::AccountId, T::CurrencyId, <T as currency::Config>::Balance> for CurrencyHooks<T>
+where
+    T::AccountId: From<sp_runtime::AccountId32>,
+{
+    type OnDust = orml_tokens::TransferDust<T, FeeAccount>;
+    type OnSlash = OnSlashHook<T>;
+    type PreDeposit = PreDeposit<T>;
+    type PostDeposit = PostDeposit<T>;
+    type PreTransfer = PreTransfer<T>;
+    type PostTransfer = PostTransfer<T>;
+    type OnNewTokenAccount = ();
+    type OnKilledTokenAccount = ();
+}
+
 impl orml_tokens::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Balance = Balance;
@@ -653,16 +669,11 @@ impl orml_tokens::Config for Runtime {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = orml_tokens::TransferDust<Runtime, FeeAccount>;
-    type OnSlash = OnSlashHook<Runtime>;
-    type OnDeposit = OnDepositHook<Runtime>;
-    type OnTransfer = OnTransferHook<Runtime>;
+    type CurrencyHooks = CurrencyHooks<Runtime>;
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = DustRemovalWhitelist;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 pub struct AssetAuthority;

--- a/parachain/runtime/testnet-interlay/src/xcm_config.rs
+++ b/parachain/runtime/testnet-interlay/src/xcm_config.rs
@@ -7,7 +7,10 @@ use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use primitives::{Balance, CurrencyId, CurrencyId::ForeignAsset};
 use sp_runtime::WeakBoundedVec;
-use xcm::latest::{prelude::*, Weight};
+use xcm::latest::{
+    prelude::{AccountId32, *},
+    Weight,
+};
 use xcm_builder::{
     AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom,
     EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, LocationInverter, NativeAsset, ParentIsPreset,

--- a/parachain/runtime/testnet-interlay/src/xcm_config.rs
+++ b/parachain/runtime/testnet-interlay/src/xcm_config.rs
@@ -334,7 +334,7 @@ parameter_types! {
 
 parameter_type_with_key! {
     // Only used for transferring parachain tokens to other parachains using DOT/KSM as fee currency. Currently we do not support this, hence return MAX.
-    // See: https://github.com/interlay/open-runtime-module-library/blob/cadcc9fb10b8212f92668138fc8f83dc0c53acf5/xtokens/README.md#transfer-multiple-currencies
+    // See: https://github.com/open-web3-stack/open-runtime-module-library/blob/cadcc9fb10b8212f92668138fc8f83dc0c53acf5/xtokens/README.md#transfer-multiple-currencies
     pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
         #[allow(clippy::match_ref_pats)] // false positive
         match (location.parents, location.first_interior()) {

--- a/parachain/runtime/testnet-kintsugi/Cargo.toml
+++ b/parachain/runtime/testnet-kintsugi/Cargo.toml
@@ -111,14 +111,14 @@ module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-a
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/testnet-kintsugi/Cargo.toml
+++ b/parachain/runtime/testnet-kintsugi/Cargo.toml
@@ -111,14 +111,14 @@ module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-a
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
-orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-unknown-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-asset-registry= { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 [dev-dependencies]
 hex = '0.4.2'

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -24,9 +24,9 @@ use frame_system::{
     limits::{BlockLength, BlockWeights},
     EnsureRoot, EnsureRootWithSuccess, EnsureSigned,
 };
-use loans::{OnDepositHook, OnSlashHook, OnTransferHook};
+use loans::{OnSlashHook, PostDeposit, PostTransfer, PreDeposit, PreTransfer};
 use orml_asset_registry::SequentialId;
-use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key, MultiCurrency};
+use orml_traits::{currency::MutationHooks, location::AbsoluteReserveProvider, parameter_type_with_key, MultiCurrency};
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use primitives::PriceDetail;
 use sp_api::impl_runtime_apis;
@@ -646,6 +646,22 @@ parameter_type_with_key! {
     };
 }
 
+pub struct CurrencyHooks<T>(PhantomData<T>);
+impl<T: orml_tokens::Config + loans::Config>
+    MutationHooks<T::AccountId, T::CurrencyId, <T as currency::Config>::Balance> for CurrencyHooks<T>
+where
+    T::AccountId: From<sp_runtime::AccountId32>,
+{
+    type OnDust = orml_tokens::TransferDust<T, FeeAccount>;
+    type OnSlash = OnSlashHook<T>;
+    type PreDeposit = PreDeposit<T>;
+    type PostDeposit = PostDeposit<T>;
+    type PreTransfer = PreTransfer<T>;
+    type PostTransfer = PostTransfer<T>;
+    type OnNewTokenAccount = ();
+    type OnKilledTokenAccount = ();
+}
+
 impl orml_tokens::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Balance = Balance;
@@ -653,16 +669,11 @@ impl orml_tokens::Config for Runtime {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
-    type OnDust = orml_tokens::TransferDust<Runtime, FeeAccount>;
-    type OnSlash = OnSlashHook<Runtime>;
-    type OnDeposit = OnDepositHook<Runtime>;
-    type OnTransfer = OnTransferHook<Runtime>;
+    type CurrencyHooks = CurrencyHooks<Runtime>;
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = DustRemovalWhitelist;
     type MaxReserves = ConstU32<0>; // we don't use named reserves
     type ReserveIdentifier = (); // we don't use named reserves
-    type OnNewTokenAccount = ();
-    type OnKilledTokenAccount = ();
 }
 
 pub struct AssetAuthority;

--- a/parachain/runtime/testnet-kintsugi/src/xcm_config.rs
+++ b/parachain/runtime/testnet-kintsugi/src/xcm_config.rs
@@ -331,7 +331,7 @@ parameter_types! {
 
 parameter_type_with_key! {
     // Only used for transferring parachain tokens to other parachains using DOT/KSM as fee currency. Currently we do not support this, hence return MAX.
-    // See: https://github.com/interlay/open-runtime-module-library/blob/cadcc9fb10b8212f92668138fc8f83dc0c53acf5/xtokens/README.md#transfer-multiple-currencies
+    // See: https://github.com/open-web3-stack/open-runtime-module-library/blob/cadcc9fb10b8212f92668138fc8f83dc0c53acf5/xtokens/README.md#transfer-multiple-currencies
     pub ParachainMinFee: |location: MultiLocation| -> Option<u128> {
         #[allow(clippy::match_ref_pats)] // false positive
         match (location.parents, location.first_interior()) {

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -90,10 +90,10 @@ module-replace-rpc-runtime-api = { path = "../../crates/replace/rpc/runtime-api"
 loans-rpc-runtime-api = { path = "../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
-orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
 
 xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.31", default-features = false }
 

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -90,10 +90,10 @@ module-replace-rpc-runtime-api = { path = "../../crates/replace/rpc/runtime-api"
 loans-rpc-runtime-api = { path = "../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
-orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
-orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "5803a01a44ade05fe5f00dd73b619c89fbf4e701", default-features = false }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-vesting = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
+orml-asset-registry = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "3fcd3cf9e63fe80fd9671912833a900ba09d1cc0", default-features = false }
 
 xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.31", default-features = false }
 


### PR DESCRIPTION
- Auto-deposits incoming lend tokens from minting and transfers, if the user already enabled the toggle
    - Implemented using `orml-tokens` post-hooks for OnDeposit and OnTransfer
    - The `deposit_collateral(...)` extrinsic can now be removed 
- `redeem(...)` implicitly calls  `withdraw(...)` if the user locked funds (the collateral toggle is enabled). 
    - Thanks to this, the `withdraw_collateral(...)` extrinsic is now removed.
- Forbids enabling the lend tokens as collateral unless the entire balance of the user is `free`

Closes https://github.com/interlay/interbtc/issues/743

TODO:
- [x] upgrade to ORML to https://github.com/open-web3-stack/open-runtime-module-library/commit/5803a01a44ade05fe5f00dd73b619c89fbf4e701