### PR TITLE
refactor: remove module prefix from rpc pallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "btc-relay-rpc"
+version = "1.2.0"
+dependencies = [
+ "btc-relay-rpc-runtime-api",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "btc-relay-rpc-runtime-api"
+version = "1.2.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-std",
+]
+
+[[package]]
 name = "build-helper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.23"
+version = "4.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb41c13df48950b20eb4cd0eefa618819469df1bffc49d11e8487c4ba0037e5"
+checksum = "60494cedb60cb47462c0ff7be53de32c0e42a6fc2c772184554fa12bd9489c03"
 dependencies = [
  "atty",
  "bitflags",
@@ -2405,6 +2427,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "escrow-rpc"
+version = "0.3.0"
+dependencies = [
+ "escrow-rpc-runtime-api",
+ "jsonrpsee",
+ "oracle-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "escrow-rpc-runtime-api"
+version = "0.3.0"
+dependencies = [
+ "oracle-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,6 +3610,7 @@ name = "interbtc-parachain"
 version = "1.2.0"
 dependencies = [
  "bitcoin",
+ "btc-relay-rpc-runtime-api",
  "clap",
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -3582,6 +3627,7 @@ dependencies = [
  "cumulus-relay-chain-minimal-node",
  "cumulus-relay-chain-rpc-interface",
  "cumulus-test-relay-sproof-builder",
+ "escrow-rpc-runtime-api",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",
@@ -3590,25 +3636,22 @@ dependencies = [
  "interbtc-primitives",
  "interbtc-rpc",
  "interlay-runtime-parachain",
+ "issue-rpc-runtime-api",
  "jsonrpsee",
  "kintsugi-runtime-parachain",
  "loans-rpc-runtime-api",
  "log",
- "module-btc-relay-rpc-runtime-api",
- "module-escrow-rpc-runtime-api",
- "module-issue-rpc-runtime-api",
- "module-oracle-rpc-runtime-api",
- "module-redeem-rpc-runtime-api",
- "module-replace-rpc-runtime-api",
- "module-reward-rpc-runtime-api",
- "module-vault-registry-rpc-runtime-api",
+ "oracle-rpc-runtime-api",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
  "polkadot-cli",
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-service",
+ "redeem-rpc-runtime-api",
  "regex",
+ "replace-rpc-runtime-api",
+ "reward-rpc-runtime-api",
  "sc-basic-authorship",
  "sc-chain-spec",
  "sc-cli",
@@ -3643,6 +3686,7 @@ dependencies = [
  "testnet-interlay-runtime-parachain",
  "testnet-kintsugi-runtime-parachain",
  "try-runtime-cli",
+ "vault-registry-rpc-runtime-api",
 ]
 
 [[package]]
@@ -3664,19 +3708,18 @@ dependencies = [
 name = "interbtc-rpc"
 version = "1.2.0"
 dependencies = [
+ "btc-relay-rpc",
+ "escrow-rpc",
  "futures",
  "interbtc-primitives",
+ "issue-rpc",
  "jsonrpsee",
  "loans-rpc",
- "module-btc-relay-rpc",
- "module-escrow-rpc",
- "module-issue-rpc",
- "module-oracle-rpc",
- "module-redeem-rpc",
- "module-replace-rpc",
- "module-reward-rpc",
- "module-vault-registry-rpc",
+ "oracle-rpc",
  "pallet-transaction-payment-rpc",
+ "redeem-rpc",
+ "replace-rpc",
+ "reward-rpc",
  "sc-consensus-manual-seal",
  "sc-rpc",
  "sc-rpc-api",
@@ -3688,6 +3731,7 @@ dependencies = [
  "sp-core",
  "substrate-frame-rpc-system",
  "vault-registry",
+ "vault-registry-rpc",
 ]
 
 [[package]]
@@ -3697,10 +3741,12 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "btc-relay-rpc-runtime-api",
  "clients-info",
  "currency",
  "democracy",
  "escrow",
+ "escrow-rpc-runtime-api",
  "fee",
  "flate2",
  "frame-benchmarking",
@@ -3712,20 +3758,14 @@ dependencies = [
  "hex-literal 0.3.4",
  "interbtc-primitives",
  "issue",
+ "issue-rpc-runtime-api",
  "itertools",
  "loans",
  "loans-rpc-runtime-api",
  "mocktopus",
- "module-btc-relay-rpc-runtime-api",
- "module-escrow-rpc-runtime-api",
- "module-issue-rpc-runtime-api",
- "module-oracle-rpc-runtime-api",
- "module-redeem-rpc-runtime-api",
- "module-replace-rpc-runtime-api",
- "module-reward-rpc-runtime-api",
- "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "oracle-rpc-runtime-api",
  "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
@@ -3750,8 +3790,11 @@ dependencies = [
  "parity-scale-codec",
  "pretty_assertions",
  "redeem",
+ "redeem-rpc-runtime-api",
  "replace",
+ "replace-rpc-runtime-api",
  "reward",
+ "reward-rpc-runtime-api",
  "scale-info",
  "security",
  "serde",
@@ -3774,6 +3817,7 @@ dependencies = [
  "supply",
  "traits",
  "vault-registry",
+ "vault-registry-rpc-runtime-api",
  "xcm-builder",
 ]
 
@@ -3829,6 +3873,7 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "btc-relay-rpc-runtime-api",
  "clients-info",
  "collator-selection",
  "cumulus-pallet-aura-ext",
@@ -3842,6 +3887,7 @@ dependencies = [
  "currency",
  "democracy",
  "escrow",
+ "escrow-rpc-runtime-api",
  "fee",
  "frame-benchmarking",
  "frame-executive",
@@ -3853,18 +3899,12 @@ dependencies = [
  "hex-literal 0.3.4",
  "interbtc-primitives",
  "issue",
+ "issue-rpc-runtime-api",
  "loans-rpc-runtime-api",
  "mocktopus",
- "module-btc-relay-rpc-runtime-api",
- "module-escrow-rpc-runtime-api",
- "module-issue-rpc-runtime-api",
- "module-oracle-rpc-runtime-api",
- "module-redeem-rpc-runtime-api",
- "module-replace-rpc-runtime-api",
- "module-reward-rpc-runtime-api",
- "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "oracle-rpc-runtime-api",
  "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
@@ -3894,8 +3934,11 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain",
  "redeem",
+ "redeem-rpc-runtime-api",
  "replace",
+ "replace-rpc-runtime-api",
  "reward",
+ "reward-rpc-runtime-api",
  "scale-info",
  "security",
  "serde",
@@ -3918,6 +3961,7 @@ dependencies = [
  "supply",
  "traits",
  "vault-registry",
+ "vault-registry-rpc-runtime-api",
  "xcm",
  "xcm-builder",
  "xcm-executor",
@@ -3993,6 +4037,28 @@ dependencies = [
  "sp-std",
  "staking",
  "vault-registry",
+]
+
+[[package]]
+name = "issue-rpc"
+version = "1.2.0"
+dependencies = [
+ "issue-rpc-runtime-api",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "issue-rpc-runtime-api"
+version = "1.2.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-std",
 ]
 
 [[package]]
@@ -4186,9 +4252,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kintsugi-runtime-parachain"
@@ -4197,6 +4266,7 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "btc-relay-rpc-runtime-api",
  "clients-info",
  "collator-selection",
  "cumulus-pallet-aura-ext",
@@ -4210,6 +4280,7 @@ dependencies = [
  "currency",
  "democracy",
  "escrow",
+ "escrow-rpc-runtime-api",
  "fee",
  "frame-benchmarking",
  "frame-executive",
@@ -4221,19 +4292,13 @@ dependencies = [
  "hex-literal 0.3.4",
  "interbtc-primitives",
  "issue",
+ "issue-rpc-runtime-api",
  "loans-rpc-runtime-api",
  "log",
  "mocktopus",
- "module-btc-relay-rpc-runtime-api",
- "module-escrow-rpc-runtime-api",
- "module-issue-rpc-runtime-api",
- "module-oracle-rpc-runtime-api",
- "module-redeem-rpc-runtime-api",
- "module-replace-rpc-runtime-api",
- "module-reward-rpc-runtime-api",
- "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "oracle-rpc-runtime-api",
  "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
@@ -4262,8 +4327,11 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain",
  "redeem",
+ "redeem-rpc-runtime-api",
  "replace",
+ "replace-rpc-runtime-api",
  "reward",
+ "reward-rpc-runtime-api",
  "scale-info",
  "security",
  "serde",
@@ -4286,6 +4354,7 @@ dependencies = [
  "supply",
  "traits",
  "vault-registry",
+ "vault-registry-rpc-runtime-api",
  "xcm",
  "xcm-builder",
  "xcm-executor",
@@ -5299,186 +5368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "module-btc-relay-rpc"
-version = "1.2.0"
-dependencies = [
- "jsonrpsee",
- "module-btc-relay-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
-]
-
-[[package]]
-name = "module-btc-relay-rpc-runtime-api"
-version = "1.2.0"
-dependencies = [
- "frame-support",
- "parity-scale-codec",
- "sp-api",
- "sp-std",
-]
-
-[[package]]
-name = "module-escrow-rpc"
-version = "0.3.0"
-dependencies = [
- "jsonrpsee",
- "module-escrow-rpc-runtime-api",
- "module-oracle-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
-]
-
-[[package]]
-name = "module-escrow-rpc-runtime-api"
-version = "0.3.0"
-dependencies = [
- "module-oracle-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
-]
-
-[[package]]
-name = "module-issue-rpc"
-version = "1.2.0"
-dependencies = [
- "jsonrpsee",
- "module-issue-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
-]
-
-[[package]]
-name = "module-issue-rpc-runtime-api"
-version = "1.2.0"
-dependencies = [
- "frame-support",
- "parity-scale-codec",
- "sp-api",
- "sp-std",
-]
-
-[[package]]
-name = "module-oracle-rpc"
-version = "1.2.0"
-dependencies = [
- "jsonrpsee",
- "module-oracle-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
-]
-
-[[package]]
-name = "module-oracle-rpc-runtime-api"
-version = "1.2.0"
-dependencies = [
- "frame-support",
- "parity-scale-codec",
- "serde",
- "sp-api",
- "sp-std",
-]
-
-[[package]]
-name = "module-redeem-rpc"
-version = "1.2.0"
-dependencies = [
- "jsonrpsee",
- "module-redeem-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
-]
-
-[[package]]
-name = "module-redeem-rpc-runtime-api"
-version = "1.2.0"
-dependencies = [
- "frame-support",
- "parity-scale-codec",
- "sp-api",
- "sp-std",
-]
-
-[[package]]
-name = "module-replace-rpc"
-version = "1.2.0"
-dependencies = [
- "jsonrpsee",
- "module-replace-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
-]
-
-[[package]]
-name = "module-replace-rpc-runtime-api"
-version = "1.2.0"
-dependencies = [
- "frame-support",
- "parity-scale-codec",
- "sp-api",
- "sp-std",
-]
-
-[[package]]
-name = "module-reward-rpc"
-version = "0.3.0"
-dependencies = [
- "jsonrpsee",
- "module-oracle-rpc-runtime-api",
- "module-reward-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
-]
-
-[[package]]
-name = "module-reward-rpc-runtime-api"
-version = "0.3.0"
-dependencies = [
- "frame-support",
- "module-oracle-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
-]
-
-[[package]]
-name = "module-vault-registry-rpc"
-version = "0.3.0"
-dependencies = [
- "jsonrpsee",
- "module-oracle-rpc-runtime-api",
- "module-vault-registry-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-blockchain",
- "sp-runtime",
-]
-
-[[package]]
-name = "module-vault-registry-rpc-runtime-api"
-version = "0.3.0"
-dependencies = [
- "frame-support",
- "module-oracle-rpc-runtime-api",
- "parity-scale-codec",
- "sp-api",
- "sp-std",
-]
-
-[[package]]
 name = "multiaddr"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5890,6 +5779,29 @@ dependencies = [
  "sp-std",
  "staking",
  "traits",
+]
+
+[[package]]
+name = "oracle-rpc"
+version = "1.2.0"
+dependencies = [
+ "jsonrpsee",
+ "oracle-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "oracle-rpc-runtime-api"
+version = "1.2.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "serde",
+ "sp-api",
+ "sp-std",
 ]
 
 [[package]]
@@ -7068,6 +6980,7 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "btc-relay-rpc-runtime-api",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -7093,18 +7006,14 @@ dependencies = [
  "interbtc-primitives",
  "interlay-runtime-parachain",
  "issue",
+ "issue-rpc-runtime-api",
  "kintsugi-runtime-parachain",
  "kusama-runtime",
  "libsecp256k1 0.6.0",
  "mocktopus",
- "module-btc-relay-rpc-runtime-api",
- "module-issue-rpc-runtime-api",
- "module-oracle-rpc-runtime-api",
- "module-redeem-rpc-runtime-api",
- "module-replace-rpc-runtime-api",
- "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "oracle-rpc-runtime-api",
  "orml-tokens",
  "orml-traits",
  "orml-unknown-tokens",
@@ -7134,7 +7043,9 @@ dependencies = [
  "polkadot-runtime",
  "polkadot-runtime-parachains",
  "redeem",
+ "redeem-rpc-runtime-api",
  "replace",
+ "replace-rpc-runtime-api",
  "reward",
  "scale-info",
  "security",
@@ -7158,6 +7069,7 @@ dependencies = [
  "testnet-interlay-runtime-parachain",
  "testnet-kintsugi-runtime-parachain",
  "vault-registry",
+ "vault-registry-rpc-runtime-api",
  "xcm",
  "xcm-builder",
  "xcm-emulator",
@@ -9273,6 +9185,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "redeem-rpc"
+version = "1.2.0"
+dependencies = [
+ "jsonrpsee",
+ "parity-scale-codec",
+ "redeem-rpc-runtime-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "redeem-rpc-runtime-api"
+version = "1.2.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-std",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9422,6 +9356,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "replace-rpc"
+version = "1.2.0"
+dependencies = [
+ "jsonrpsee",
+ "parity-scale-codec",
+ "replace-rpc-runtime-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "replace-rpc-runtime-api"
+version = "1.2.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-std",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9450,6 +9406,29 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+]
+
+[[package]]
+name = "reward-rpc"
+version = "0.3.0"
+dependencies = [
+ "jsonrpsee",
+ "oracle-rpc-runtime-api",
+ "parity-scale-codec",
+ "reward-rpc-runtime-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "reward-rpc-runtime-api"
+version = "0.3.0"
+dependencies = [
+ "frame-support",
+ "oracle-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
 ]
 
 [[package]]
@@ -12474,6 +12453,7 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "btc-relay-rpc-runtime-api",
  "clients-info",
  "collator-selection",
  "cumulus-pallet-aura-ext",
@@ -12487,6 +12467,7 @@ dependencies = [
  "currency",
  "democracy",
  "escrow",
+ "escrow-rpc-runtime-api",
  "fee",
  "frame-benchmarking",
  "frame-executive",
@@ -12498,20 +12479,14 @@ dependencies = [
  "hex-literal 0.3.4",
  "interbtc-primitives",
  "issue",
+ "issue-rpc-runtime-api",
  "loans",
  "loans-rpc-runtime-api",
  "log",
  "mocktopus",
- "module-btc-relay-rpc-runtime-api",
- "module-escrow-rpc-runtime-api",
- "module-issue-rpc-runtime-api",
- "module-oracle-rpc-runtime-api",
- "module-redeem-rpc-runtime-api",
- "module-replace-rpc-runtime-api",
- "module-reward-rpc-runtime-api",
- "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "oracle-rpc-runtime-api",
  "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
@@ -12541,8 +12516,11 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain",
  "redeem",
+ "redeem-rpc-runtime-api",
  "replace",
+ "replace-rpc-runtime-api",
  "reward",
+ "reward-rpc-runtime-api",
  "scale-info",
  "security",
  "serde",
@@ -12565,6 +12543,7 @@ dependencies = [
  "supply",
  "traits",
  "vault-registry",
+ "vault-registry-rpc-runtime-api",
  "xcm",
  "xcm-builder",
  "xcm-executor",
@@ -12577,6 +12556,7 @@ dependencies = [
  "annuity",
  "bitcoin",
  "btc-relay",
+ "btc-relay-rpc-runtime-api",
  "clients-info",
  "collator-selection",
  "cumulus-pallet-aura-ext",
@@ -12590,6 +12570,7 @@ dependencies = [
  "currency",
  "democracy",
  "escrow",
+ "escrow-rpc-runtime-api",
  "fee",
  "frame-benchmarking",
  "frame-executive",
@@ -12601,20 +12582,14 @@ dependencies = [
  "hex-literal 0.3.4",
  "interbtc-primitives",
  "issue",
+ "issue-rpc-runtime-api",
  "loans",
  "loans-rpc-runtime-api",
  "log",
  "mocktopus",
- "module-btc-relay-rpc-runtime-api",
- "module-escrow-rpc-runtime-api",
- "module-issue-rpc-runtime-api",
- "module-oracle-rpc-runtime-api",
- "module-redeem-rpc-runtime-api",
- "module-replace-rpc-runtime-api",
- "module-reward-rpc-runtime-api",
- "module-vault-registry-rpc-runtime-api",
  "nomination",
  "oracle",
+ "oracle-rpc-runtime-api",
  "orml-asset-registry",
  "orml-tokens",
  "orml-traits",
@@ -12644,8 +12619,11 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain",
  "redeem",
+ "redeem-rpc-runtime-api",
  "replace",
+ "replace-rpc-runtime-api",
  "reward",
+ "reward-rpc-runtime-api",
  "scale-info",
  "security",
  "serde",
@@ -12668,6 +12646,7 @@ dependencies = [
  "supply",
  "traits",
  "vault-registry",
+ "vault-registry-rpc-runtime-api",
  "xcm",
  "xcm-builder",
  "xcm-executor",
@@ -13290,6 +13269,30 @@ dependencies = [
  "staking",
  "traits",
  "visibility",
+]
+
+[[package]]
+name = "vault-registry-rpc"
+version = "0.3.0"
+dependencies = [
+ "jsonrpsee",
+ "oracle-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+ "vault-registry-rpc-runtime-api",
+]
+
+[[package]]
+name = "vault-registry-rpc-runtime-api"
+version = "0.3.0"
+dependencies = [
+ "frame-support",
+ "oracle-rpc-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-std",
 ]
 
 [[package]]

--- a/crates/btc-relay/rpc/Cargo.toml
+++ b/crates/btc-relay/rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-btc-relay-rpc"
+name = "btc-relay-rpc"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"
@@ -10,4 +10,4 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-module-btc-relay-rpc-runtime-api = { path = "runtime-api" }
+btc-relay-rpc-runtime-api = { path = "runtime-api" }

--- a/crates/btc-relay/rpc/runtime-api/Cargo.toml
+++ b/crates/btc-relay/rpc/runtime-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-btc-relay-rpc-runtime-api"
+name = "btc-relay-rpc-runtime-api"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"

--- a/crates/btc-relay/rpc/src/lib.rs
+++ b/crates/btc-relay/rpc/src/lib.rs
@@ -11,7 +11,7 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT, DispatchError};
 use std::sync::Arc;
 
-pub use module_btc_relay_rpc_runtime_api::BtcRelayApi as BtcRelayRuntimeApi;
+pub use btc_relay_rpc_runtime_api::BtcRelayApi as BtcRelayRuntimeApi;
 
 #[rpc(client, server)]
 pub trait BtcRelayApi<BlockHash, H256Le> {

--- a/crates/escrow/rpc/Cargo.toml
+++ b/crates/escrow/rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Interlay Ltd"]
 edition = "2021"
-name = "module-escrow-rpc"
+name = "escrow-rpc"
 version = '0.3.0'
 
 [dependencies]
@@ -10,7 +10,7 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-module-escrow-rpc-runtime-api = { path = "runtime-api" }
+escrow-rpc-runtime-api = { path = "runtime-api" }
 
-[dependencies.module-oracle-rpc-runtime-api]
+[dependencies.oracle-rpc-runtime-api]
 path = '../../oracle/rpc/runtime-api'

--- a/crates/escrow/rpc/runtime-api/Cargo.toml
+++ b/crates/escrow/rpc/runtime-api/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 authors = ["Interlay Ltd"]
 edition = "2021"
-name = "module-escrow-rpc-runtime-api"
+name = "escrow-rpc-runtime-api"
 version = '0.3.0'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"] }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
-[dependencies.module-oracle-rpc-runtime-api]
+[dependencies.oracle-rpc-runtime-api]
 default-features = false
 path = '../../../oracle/rpc/runtime-api'
 
@@ -17,5 +17,5 @@ default = ["std"]
 std = [
   "codec/std",
   "sp-api/std",
-  "module-oracle-rpc-runtime-api/std",
+  "oracle-rpc-runtime-api/std",
 ]

--- a/crates/escrow/rpc/runtime-api/src/lib.rs
+++ b/crates/escrow/rpc/runtime-api/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::Codec;
-use module_oracle_rpc_runtime_api::BalanceWrapper;
+use oracle_rpc_runtime_api::BalanceWrapper;
 
 sp_api::decl_runtime_apis! {
     pub trait EscrowApi<AccountId, BlockNumber, Balance> where

--- a/crates/escrow/rpc/src/lib.rs
+++ b/crates/escrow/rpc/src/lib.rs
@@ -6,7 +6,7 @@ use jsonrpsee::{
     proc_macros::rpc,
     types::error::{CallError, ErrorCode, ErrorObject},
 };
-use module_oracle_rpc_runtime_api::BalanceWrapper;
+use oracle_rpc_runtime_api::BalanceWrapper;
 use sp_api::{ApiError, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{
@@ -15,7 +15,7 @@ use sp_runtime::{
 };
 use std::sync::Arc;
 
-pub use module_escrow_rpc_runtime_api::EscrowApi as EscrowRuntimeApi;
+pub use escrow_rpc_runtime_api::EscrowApi as EscrowRuntimeApi;
 
 #[rpc(client, server)]
 pub trait EscrowApi<BlockHash, AccountId, BlockNumber, Balance>

--- a/crates/issue/rpc/Cargo.toml
+++ b/crates/issue/rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-issue-rpc"
+name = "issue-rpc"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"
@@ -10,4 +10,4 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-module-issue-rpc-runtime-api = { path = "runtime-api" }
+issue-rpc-runtime-api = { path = "runtime-api" }

--- a/crates/issue/rpc/runtime-api/Cargo.toml
+++ b/crates/issue/rpc/runtime-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-issue-rpc-runtime-api"
+name = "issue-rpc-runtime-api"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"

--- a/crates/issue/rpc/src/lib.rs
+++ b/crates/issue/rpc/src/lib.rs
@@ -11,7 +11,7 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
 
-pub use module_issue_rpc_runtime_api::IssueApi as IssueRuntimeApi;
+pub use issue_rpc_runtime_api::IssueApi as IssueRuntimeApi;
 
 #[rpc(client, server)]
 pub trait IssueApi<BlockHash, AccountId, H256, IssueRequest> {

--- a/crates/oracle/rpc/Cargo.toml
+++ b/crates/oracle/rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-oracle-rpc"
+name = "oracle-rpc"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"
@@ -10,4 +10,4 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-module-oracle-rpc-runtime-api = { path = "runtime-api" }
+oracle-rpc-runtime-api = { path = "runtime-api" }

--- a/crates/oracle/rpc/runtime-api/Cargo.toml
+++ b/crates/oracle/rpc/runtime-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-oracle-rpc-runtime-api"
+name = "oracle-rpc-runtime-api"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"

--- a/crates/oracle/rpc/src/lib.rs
+++ b/crates/oracle/rpc/src/lib.rs
@@ -15,7 +15,7 @@ use sp_runtime::{
 };
 use std::sync::Arc;
 
-pub use module_oracle_rpc_runtime_api::{BalanceWrapper, OracleApi as OracleRuntimeApi};
+pub use oracle_rpc_runtime_api::{BalanceWrapper, OracleApi as OracleRuntimeApi};
 
 #[rpc(client, server)]
 pub trait OracleApi<BlockHash, Balance, CurrencyId>

--- a/crates/redeem/rpc/Cargo.toml
+++ b/crates/redeem/rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-redeem-rpc"
+name = "redeem-rpc"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"
@@ -10,4 +10,4 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-module-redeem-rpc-runtime-api = { path = "runtime-api" }
+redeem-rpc-runtime-api = { path = "runtime-api" }

--- a/crates/redeem/rpc/runtime-api/Cargo.toml
+++ b/crates/redeem/rpc/runtime-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-redeem-rpc-runtime-api"
+name = "redeem-rpc-runtime-api"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"

--- a/crates/redeem/rpc/src/lib.rs
+++ b/crates/redeem/rpc/src/lib.rs
@@ -11,7 +11,7 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
 
-pub use module_redeem_rpc_runtime_api::RedeemApi as RedeemRuntimeApi;
+pub use redeem_rpc_runtime_api::RedeemApi as RedeemRuntimeApi;
 
 #[rpc(client, server)]
 pub trait RedeemApi<BlockHash, AccountId, H256, RedeemRequest> {

--- a/crates/replace/rpc/Cargo.toml
+++ b/crates/replace/rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-replace-rpc"
+name = "replace-rpc"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"
@@ -10,4 +10,4 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-module-replace-rpc-runtime-api = { path = "runtime-api" }
+replace-rpc-runtime-api = { path = "runtime-api" }

--- a/crates/replace/rpc/runtime-api/Cargo.toml
+++ b/crates/replace/rpc/runtime-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "module-replace-rpc-runtime-api"
+name = "replace-rpc-runtime-api"
 version = "1.2.0"
 authors = ["Interlay Ltd"]
 edition = "2021"

--- a/crates/replace/rpc/src/lib.rs
+++ b/crates/replace/rpc/src/lib.rs
@@ -11,7 +11,7 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
 
-pub use module_replace_rpc_runtime_api::ReplaceApi as ReplaceRuntimeApi;
+pub use replace_rpc_runtime_api::ReplaceApi as ReplaceRuntimeApi;
 
 #[rpc(client, server)]
 pub trait ReplaceApi<BlockHash, AccountId, H256, ReplaceRequest> {

--- a/crates/reward/rpc/Cargo.toml
+++ b/crates/reward/rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Interlay Ltd"]
 edition = "2021"
-name = "module-reward-rpc"
+name = "reward-rpc"
 version = '0.3.0'
 
 [dependencies]
@@ -10,7 +10,7 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-module-reward-rpc-runtime-api = { path = "runtime-api" }
+reward-rpc-runtime-api = { path = "runtime-api" }
 
-[dependencies.module-oracle-rpc-runtime-api]
+[dependencies.oracle-rpc-runtime-api]
 path = '../../oracle/rpc/runtime-api'

--- a/crates/reward/rpc/runtime-api/Cargo.toml
+++ b/crates/reward/rpc/runtime-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Interlay Ltd"]
 edition = "2021"
-name = "module-reward-rpc-runtime-api"
+name = "reward-rpc-runtime-api"
 version = '0.3.0'
 
 [dependencies]
@@ -9,7 +9,7 @@ codec = { package = "parity-scale-codec", version = "3.1.5", default-features = 
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
-[dependencies.module-oracle-rpc-runtime-api]
+[dependencies.oracle-rpc-runtime-api]
 default-features = false
 path = '../../../oracle/rpc/runtime-api'
 
@@ -19,5 +19,5 @@ std = [
   "codec/std",
   "frame-support/std",
   "sp-api/std",
-  "module-oracle-rpc-runtime-api/std",
+  "oracle-rpc-runtime-api/std",
 ]

--- a/crates/reward/rpc/runtime-api/src/lib.rs
+++ b/crates/reward/rpc/runtime-api/src/lib.rs
@@ -4,7 +4,7 @@
 
 use codec::Codec;
 use frame_support::dispatch::DispatchError;
-use module_oracle_rpc_runtime_api::BalanceWrapper;
+use oracle_rpc_runtime_api::BalanceWrapper;
 
 sp_api::decl_runtime_apis! {
     pub trait RewardApi<AccountId, VaultId, CurrencyId, Balance> where

--- a/crates/reward/rpc/src/lib.rs
+++ b/crates/reward/rpc/src/lib.rs
@@ -6,7 +6,7 @@ use jsonrpsee::{
     proc_macros::rpc,
     types::error::{CallError, ErrorCode, ErrorObject},
 };
-use module_oracle_rpc_runtime_api::BalanceWrapper;
+use oracle_rpc_runtime_api::BalanceWrapper;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{
@@ -16,7 +16,7 @@ use sp_runtime::{
 };
 use std::sync::Arc;
 
-pub use module_reward_rpc_runtime_api::RewardApi as RewardRuntimeApi;
+pub use reward_rpc_runtime_api::RewardApi as RewardRuntimeApi;
 
 #[rpc(client, server)]
 pub trait RewardApi<BlockHash, AccountId, VaultId, CurrencyId, Balance>

--- a/crates/vault-registry/rpc/Cargo.toml
+++ b/crates/vault-registry/rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Interlay Ltd"]
 edition = "2021"
-name = "module-vault-registry-rpc"
+name = "vault-registry-rpc"
 version = '0.3.0'
 
 [dependencies]
@@ -10,7 +10,7 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-module-vault-registry-rpc-runtime-api = { path = "runtime-api" }
+vault-registry-rpc-runtime-api = { path = "runtime-api" }
 
-[dependencies.module-oracle-rpc-runtime-api]
+[dependencies.oracle-rpc-runtime-api]
 path = '../../oracle/rpc/runtime-api'

--- a/crates/vault-registry/rpc/runtime-api/Cargo.toml
+++ b/crates/vault-registry/rpc/runtime-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Interlay Ltd"]
 edition = "2021"
-name = "module-vault-registry-rpc-runtime-api"
+name = "vault-registry-rpc-runtime-api"
 version = '0.3.0'
 
 [dependencies]
@@ -10,7 +10,7 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
-[dependencies.module-oracle-rpc-runtime-api]
+[dependencies.oracle-rpc-runtime-api]
 default-features = false
 path = '../../../oracle/rpc/runtime-api'
 
@@ -21,5 +21,5 @@ std = [
   "frame-support/std",
   "sp-api/std",
   "sp-std/std",
-  "module-oracle-rpc-runtime-api/std",
+  "oracle-rpc-runtime-api/std",
 ]

--- a/crates/vault-registry/rpc/runtime-api/src/lib.rs
+++ b/crates/vault-registry/rpc/runtime-api/src/lib.rs
@@ -4,7 +4,7 @@
 
 use codec::Codec;
 use frame_support::dispatch::DispatchError;
-use module_oracle_rpc_runtime_api::BalanceWrapper;
+use oracle_rpc_runtime_api::BalanceWrapper;
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {

--- a/crates/vault-registry/rpc/src/lib.rs
+++ b/crates/vault-registry/rpc/src/lib.rs
@@ -6,7 +6,7 @@ use jsonrpsee::{
     proc_macros::rpc,
     types::error::{CallError, ErrorCode, ErrorObject},
 };
-use module_oracle_rpc_runtime_api::BalanceWrapper;
+use oracle_rpc_runtime_api::BalanceWrapper;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{
@@ -16,7 +16,7 @@ use sp_runtime::{
 };
 use std::sync::Arc;
 
-pub use module_vault_registry_rpc_runtime_api::VaultRegistryApi as VaultRegistryRuntimeApi;
+pub use vault_registry_rpc_runtime_api::VaultRegistryApi as VaultRegistryRuntimeApi;
 
 #[rpc(client, server)]
 pub trait VaultRegistryApi<BlockHash, VaultId, Balance, UnsignedFixedPoint, CurrencyId, AccountId>

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -34,14 +34,14 @@ interbtc-rpc = { path = "../rpc" }
 bitcoin = { path = "../crates/bitcoin" }
 primitives = { package = "interbtc-primitives", path = "../primitives" }
 
-module-btc-relay-rpc-runtime-api = { path = "../crates/btc-relay/rpc/runtime-api" }
-module-oracle-rpc-runtime-api = { path = "../crates/oracle/rpc/runtime-api" }
-module-vault-registry-rpc-runtime-api = { path = "../crates/vault-registry/rpc/runtime-api" }
-module-escrow-rpc-runtime-api = { path = "../crates/escrow/rpc/runtime-api" }
-module-reward-rpc-runtime-api = { path = "../crates/reward/rpc/runtime-api" }
-module-issue-rpc-runtime-api = { path = "../crates/issue/rpc/runtime-api" }
-module-redeem-rpc-runtime-api = { path = "../crates/redeem/rpc/runtime-api" }
-module-replace-rpc-runtime-api = { path = "../crates/replace/rpc/runtime-api" }
+btc-relay-rpc-runtime-api = { path = "../crates/btc-relay/rpc/runtime-api" }
+oracle-rpc-runtime-api = { path = "../crates/oracle/rpc/runtime-api" }
+vault-registry-rpc-runtime-api = { path = "../crates/vault-registry/rpc/runtime-api" }
+escrow-rpc-runtime-api = { path = "../crates/escrow/rpc/runtime-api" }
+reward-rpc-runtime-api = { path = "../crates/reward/rpc/runtime-api" }
+issue-rpc-runtime-api = { path = "../crates/issue/rpc/runtime-api" }
+redeem-rpc-runtime-api = { path = "../crates/redeem/rpc/runtime-api" }
+replace-rpc-runtime-api = { path = "../crates/replace/rpc/runtime-api" }
 loans-rpc-runtime-api = { path = "../crates/loans/rpc/runtime-api" }
 
 # Substrate dependencies

--- a/parachain/runtime/interlay/Cargo.toml
+++ b/parachain/runtime/interlay/Cargo.toml
@@ -98,14 +98,14 @@ traits = { path = "../../../crates/traits", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../../primitives", default-features = false }
 
-module-btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
-module-oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
-module-vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
-module-escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
-module-reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
-module-issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
-module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
-module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
+btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
+oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
+vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
+escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
+reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
+issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
+redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
+replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
@@ -213,14 +213,14 @@ std = [
 
   "parachain-info/std",
 
-  "module-btc-relay-rpc-runtime-api/std",
-  "module-oracle-rpc-runtime-api/std",
-  "module-vault-registry-rpc-runtime-api/std",
-  "module-escrow-rpc-runtime-api/std",
-  "module-reward-rpc-runtime-api/std",
-  "module-issue-rpc-runtime-api/std",
-  "module-redeem-rpc-runtime-api/std",
-  "module-replace-rpc-runtime-api/std",
+  "btc-relay-rpc-runtime-api/std",
+  "oracle-rpc-runtime-api/std",
+  "vault-registry-rpc-runtime-api/std",
+  "escrow-rpc-runtime-api/std",
+  "reward-rpc-runtime-api/std",
+  "issue-rpc-runtime-api/std",
+  "redeem-rpc-runtime-api/std",
+  "replace-rpc-runtime-api/std",
   "loans-rpc-runtime-api/std",
 
   "orml-tokens/std",

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -62,7 +62,7 @@ pub use sp_runtime::{FixedU128, Perbill, Permill};
 // interBTC exports
 pub use btc_relay::{bitcoin, Call as BtcRelayCall, TARGET_SPACING};
 pub use constants::{currency::*, time::*};
-pub use module_oracle_rpc_runtime_api::BalanceWrapper;
+pub use oracle_rpc_runtime_api::BalanceWrapper;
 pub use security::StatusCode;
 
 pub use primitives::{
@@ -1325,7 +1325,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_btc_relay_rpc_runtime_api::BtcRelayApi<
+    impl btc_relay_rpc_runtime_api::BtcRelayApi<
         Block,
         H256Le,
     > for Runtime {
@@ -1334,7 +1334,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_oracle_rpc_runtime_api::OracleApi<
+    impl oracle_rpc_runtime_api::OracleApi<
         Block,
         Balance,
         CurrencyId
@@ -1350,7 +1350,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_vault_registry_rpc_runtime_api::VaultRegistryApi<
+    impl vault_registry_rpc_runtime_api::VaultRegistryApi<
         Block,
         VaultId,
         Balance,
@@ -1413,7 +1413,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_escrow_rpc_runtime_api::EscrowApi<
+    impl escrow_rpc_runtime_api::EscrowApi<
         Block,
         AccountId,
         BlockNumber,
@@ -1428,7 +1428,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_reward_rpc_runtime_api::RewardApi<
+    impl reward_rpc_runtime_api::RewardApi<
         Block,
         AccountId,
         VaultId,
@@ -1448,7 +1448,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_issue_rpc_runtime_api::IssueApi<
+    impl issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,
         H256,
@@ -1463,7 +1463,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_redeem_rpc_runtime_api::RedeemApi<
+    impl redeem_rpc_runtime_api::RedeemApi<
         Block,
         AccountId,
         H256,
@@ -1478,7 +1478,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_replace_rpc_runtime_api::ReplaceApi<
+    impl replace_rpc_runtime_api::ReplaceApi<
         Block,
         AccountId,
         H256,

--- a/parachain/runtime/kintsugi/Cargo.toml
+++ b/parachain/runtime/kintsugi/Cargo.toml
@@ -98,14 +98,14 @@ traits = { path = "../../../crates/traits", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../../primitives", default-features = false }
 
-module-btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
-module-oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
-module-vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
-module-escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
-module-reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
-module-issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
-module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
-module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
+btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
+oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
+vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
+escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
+reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
+issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
+redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
+replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
@@ -217,14 +217,14 @@ std = [
 
   "parachain-info/std",
 
-  "module-btc-relay-rpc-runtime-api/std",
-  "module-oracle-rpc-runtime-api/std",
-  "module-vault-registry-rpc-runtime-api/std",
-  "module-escrow-rpc-runtime-api/std",
-  "module-reward-rpc-runtime-api/std",
-  "module-issue-rpc-runtime-api/std",
-  "module-redeem-rpc-runtime-api/std",
-  "module-replace-rpc-runtime-api/std",
+  "btc-relay-rpc-runtime-api/std",
+  "oracle-rpc-runtime-api/std",
+  "vault-registry-rpc-runtime-api/std",
+  "escrow-rpc-runtime-api/std",
+  "reward-rpc-runtime-api/std",
+  "issue-rpc-runtime-api/std",
+  "redeem-rpc-runtime-api/std",
+  "replace-rpc-runtime-api/std",
   "loans-rpc-runtime-api/std",
 
   "orml-tokens/std",

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -61,7 +61,7 @@ pub use sp_runtime::{FixedU128, Perbill, Permill};
 // interBTC exports
 pub use btc_relay::{bitcoin, Call as BtcRelayCall, TARGET_SPACING};
 pub use constants::{currency::*, time::*};
-pub use module_oracle_rpc_runtime_api::BalanceWrapper;
+pub use oracle_rpc_runtime_api::BalanceWrapper;
 pub use orml_asset_registry::AssetMetadata;
 pub use security::StatusCode;
 
@@ -1306,7 +1306,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_btc_relay_rpc_runtime_api::BtcRelayApi<
+    impl btc_relay_rpc_runtime_api::BtcRelayApi<
         Block,
         H256Le,
     > for Runtime {
@@ -1315,7 +1315,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_oracle_rpc_runtime_api::OracleApi<
+    impl oracle_rpc_runtime_api::OracleApi<
         Block,
         Balance,
         CurrencyId
@@ -1331,7 +1331,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_vault_registry_rpc_runtime_api::VaultRegistryApi<
+    impl vault_registry_rpc_runtime_api::VaultRegistryApi<
         Block,
         VaultId,
         Balance,
@@ -1394,7 +1394,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_escrow_rpc_runtime_api::EscrowApi<
+    impl escrow_rpc_runtime_api::EscrowApi<
         Block,
         AccountId,
         BlockNumber,
@@ -1409,7 +1409,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_reward_rpc_runtime_api::RewardApi<
+    impl reward_rpc_runtime_api::RewardApi<
         Block,
         AccountId,
         VaultId,
@@ -1429,7 +1429,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_issue_rpc_runtime_api::IssueApi<
+    impl issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,
         H256,
@@ -1444,7 +1444,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_redeem_rpc_runtime_api::RedeemApi<
+    impl redeem_rpc_runtime_api::RedeemApi<
         Block,
         AccountId,
         H256,
@@ -1459,7 +1459,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_replace_rpc_runtime_api::ReplaceApi<
+    impl replace_rpc_runtime_api::ReplaceApi<
         Block,
         AccountId,
         H256,

--- a/parachain/runtime/runtime-tests/Cargo.toml
+++ b/parachain/runtime/runtime-tests/Cargo.toml
@@ -106,12 +106,12 @@ testnet-interlay-runtime-parachain = { path = "../testnet-interlay", default-fea
 
 primitives = { package = "interbtc-primitives", path = "../../../primitives", default-features = false }
 
-module-btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
-module-oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
-module-vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
-module-issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
-module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
-module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
+btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
+oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
+vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
+issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
+redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
+replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f4ef99fb108232c4c1fe9ed54d08be3681b77669", default-features = false }
@@ -221,12 +221,12 @@ std = [
 
   "parachain-info/std",
 
-  "module-btc-relay-rpc-runtime-api/std",
-  "module-oracle-rpc-runtime-api/std",
-  "module-vault-registry-rpc-runtime-api/std",
-  "module-issue-rpc-runtime-api/std",
-  "module-redeem-rpc-runtime-api/std",
-  "module-replace-rpc-runtime-api/std",
+  "btc-relay-rpc-runtime-api/std",
+  "oracle-rpc-runtime-api/std",
+  "vault-registry-rpc-runtime-api/std",
+  "issue-rpc-runtime-api/std",
+  "redeem-rpc-runtime-api/std",
+  "replace-rpc-runtime-api/std",
 
   "orml-tokens/std",
   "orml-traits/std",

--- a/parachain/runtime/testnet-interlay/Cargo.toml
+++ b/parachain/runtime/testnet-interlay/Cargo.toml
@@ -100,14 +100,14 @@ traits = { path = "../../../crates/traits", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../../primitives", default-features = false }
 
-module-btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
-module-oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
-module-vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
-module-escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
-module-reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
-module-issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
-module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
-module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
+btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
+oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
+vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
+escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
+reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
+issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
+redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
+replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
@@ -220,14 +220,14 @@ std = [
 
   "parachain-info/std",
 
-  "module-btc-relay-rpc-runtime-api/std",
-  "module-oracle-rpc-runtime-api/std",
-  "module-vault-registry-rpc-runtime-api/std",
-  "module-escrow-rpc-runtime-api/std",
-  "module-reward-rpc-runtime-api/std",
-  "module-issue-rpc-runtime-api/std",
-  "module-redeem-rpc-runtime-api/std",
-  "module-replace-rpc-runtime-api/std",
+  "btc-relay-rpc-runtime-api/std",
+  "oracle-rpc-runtime-api/std",
+  "vault-registry-rpc-runtime-api/std",
+  "escrow-rpc-runtime-api/std",
+  "reward-rpc-runtime-api/std",
+  "issue-rpc-runtime-api/std",
+  "redeem-rpc-runtime-api/std",
+  "replace-rpc-runtime-api/std",
   "loans-rpc-runtime-api/std",
 
   "orml-tokens/std",

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -65,7 +65,7 @@ pub use sp_runtime::{FixedU128, Perbill, Permill};
 // interBTC exports
 pub use btc_relay::{bitcoin, Call as BtcRelayCall, TARGET_SPACING};
 pub use constants::{currency::*, time::*};
-pub use module_oracle_rpc_runtime_api::BalanceWrapper;
+pub use oracle_rpc_runtime_api::BalanceWrapper;
 pub use security::StatusCode;
 
 pub use primitives::{
@@ -1316,7 +1316,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_btc_relay_rpc_runtime_api::BtcRelayApi<
+    impl btc_relay_rpc_runtime_api::BtcRelayApi<
         Block,
         H256Le,
     > for Runtime {
@@ -1325,7 +1325,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_oracle_rpc_runtime_api::OracleApi<
+    impl oracle_rpc_runtime_api::OracleApi<
         Block,
         Balance,
         CurrencyId
@@ -1341,7 +1341,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_vault_registry_rpc_runtime_api::VaultRegistryApi<
+    impl vault_registry_rpc_runtime_api::VaultRegistryApi<
         Block,
         VaultId,
         Balance,
@@ -1404,7 +1404,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_escrow_rpc_runtime_api::EscrowApi<
+    impl escrow_rpc_runtime_api::EscrowApi<
         Block,
         AccountId,
         BlockNumber,
@@ -1419,7 +1419,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_reward_rpc_runtime_api::RewardApi<
+    impl reward_rpc_runtime_api::RewardApi<
         Block,
         AccountId,
         VaultId,
@@ -1440,7 +1440,7 @@ impl_runtime_apis! {
     }
 
 
-    impl module_issue_rpc_runtime_api::IssueApi<
+    impl issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,
         H256,
@@ -1455,7 +1455,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_redeem_rpc_runtime_api::RedeemApi<
+    impl redeem_rpc_runtime_api::RedeemApi<
         Block,
         AccountId,
         H256,
@@ -1470,7 +1470,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_replace_rpc_runtime_api::ReplaceApi<
+    impl replace_rpc_runtime_api::ReplaceApi<
         Block,
         AccountId,
         H256,

--- a/parachain/runtime/testnet-kintsugi/Cargo.toml
+++ b/parachain/runtime/testnet-kintsugi/Cargo.toml
@@ -100,14 +100,14 @@ traits = { path = "../../../crates/traits", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../../primitives", default-features = false }
 
-module-btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
-module-oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
-module-vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
-module-escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
-module-reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
-module-issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
-module-redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
-module-replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
+btc-relay-rpc-runtime-api = { path = "../../../crates/btc-relay/rpc/runtime-api", default-features = false }
+oracle-rpc-runtime-api = { path = "../../../crates/oracle/rpc/runtime-api", default-features = false }
+vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/runtime-api", default-features = false }
+escrow-rpc-runtime-api = { path = "../../../crates/escrow/rpc/runtime-api", default-features = false }
+reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api", default-features = false }
+issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api", default-features = false }
+redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api", default-features = false }
+replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api", default-features = false }
 loans-rpc-runtime-api = { path = "../../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
@@ -220,14 +220,14 @@ std = [
 
   "parachain-info/std",
 
-  "module-btc-relay-rpc-runtime-api/std",
-  "module-oracle-rpc-runtime-api/std",
-  "module-vault-registry-rpc-runtime-api/std",
-  "module-escrow-rpc-runtime-api/std",
-  "module-reward-rpc-runtime-api/std",
-  "module-issue-rpc-runtime-api/std",
-  "module-redeem-rpc-runtime-api/std",
-  "module-replace-rpc-runtime-api/std",
+  "btc-relay-rpc-runtime-api/std",
+  "oracle-rpc-runtime-api/std",
+  "vault-registry-rpc-runtime-api/std",
+  "escrow-rpc-runtime-api/std",
+  "reward-rpc-runtime-api/std",
+  "issue-rpc-runtime-api/std",
+  "redeem-rpc-runtime-api/std",
+  "replace-rpc-runtime-api/std",
 
   "orml-tokens/std",
   "orml-traits/std",

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -65,7 +65,7 @@ pub use sp_runtime::{FixedU128, Perbill, Permill};
 // interBTC exports
 pub use btc_relay::{bitcoin, Call as BtcRelayCall, TARGET_SPACING};
 pub use constants::{currency::*, time::*};
-pub use module_oracle_rpc_runtime_api::BalanceWrapper;
+pub use oracle_rpc_runtime_api::BalanceWrapper;
 pub use security::StatusCode;
 
 pub use primitives::{
@@ -1316,7 +1316,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_btc_relay_rpc_runtime_api::BtcRelayApi<
+    impl btc_relay_rpc_runtime_api::BtcRelayApi<
         Block,
         H256Le,
     > for Runtime {
@@ -1325,7 +1325,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_oracle_rpc_runtime_api::OracleApi<
+    impl oracle_rpc_runtime_api::OracleApi<
         Block,
         Balance,
         CurrencyId
@@ -1341,7 +1341,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_vault_registry_rpc_runtime_api::VaultRegistryApi<
+    impl vault_registry_rpc_runtime_api::VaultRegistryApi<
         Block,
         VaultId,
         Balance,
@@ -1404,7 +1404,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_escrow_rpc_runtime_api::EscrowApi<
+    impl escrow_rpc_runtime_api::EscrowApi<
         Block,
         AccountId,
         BlockNumber,
@@ -1419,7 +1419,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_reward_rpc_runtime_api::RewardApi<
+    impl reward_rpc_runtime_api::RewardApi<
         Block,
         AccountId,
         VaultId,
@@ -1439,7 +1439,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_issue_rpc_runtime_api::IssueApi<
+    impl issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,
         H256,
@@ -1454,7 +1454,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_redeem_rpc_runtime_api::RedeemApi<
+    impl redeem_rpc_runtime_api::RedeemApi<
         Block,
         AccountId,
         H256,
@@ -1469,7 +1469,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_replace_rpc_runtime_api::ReplaceApi<
+    impl replace_rpc_runtime_api::ReplaceApi<
         Block,
         AccountId,
         H256,

--- a/parachain/src/service.rs
+++ b/parachain/src/service.rs
@@ -68,32 +68,32 @@ pub trait RuntimeApiCollection:
     + substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
     + pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
     + cumulus_primitives_core::CollectCollationInfo<Block>
-    + module_btc_relay_rpc_runtime_api::BtcRelayApi<Block, H256Le>
-    + module_oracle_rpc_runtime_api::OracleApi<Block, Balance, CurrencyId>
-    + module_vault_registry_rpc_runtime_api::VaultRegistryApi<
+    + btc_relay_rpc_runtime_api::BtcRelayApi<Block, H256Le>
+    + oracle_rpc_runtime_api::OracleApi<Block, Balance, CurrencyId>
+    + vault_registry_rpc_runtime_api::VaultRegistryApi<
         Block,
         VaultId<AccountId, CurrencyId>,
         Balance,
         UnsignedFixedPoint,
         CurrencyId,
         AccountId,
-    > + module_escrow_rpc_runtime_api::EscrowApi<Block, AccountId, BlockNumber, Balance>
-    + module_issue_rpc_runtime_api::IssueApi<
+    > + escrow_rpc_runtime_api::EscrowApi<Block, AccountId, BlockNumber, Balance>
+    + issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,
         H256,
         issue::IssueRequest<AccountId, BlockNumber, Balance, CurrencyId>,
-    > + module_redeem_rpc_runtime_api::RedeemApi<
+    > + redeem_rpc_runtime_api::RedeemApi<
         Block,
         AccountId,
         H256,
         redeem::RedeemRequest<AccountId, BlockNumber, Balance, CurrencyId>,
-    > + module_replace_rpc_runtime_api::ReplaceApi<
+    > + replace_rpc_runtime_api::ReplaceApi<
         Block,
         AccountId,
         H256,
         replace::ReplaceRequest<AccountId, BlockNumber, Balance, CurrencyId>,
-    > + module_reward_rpc_runtime_api::RewardApi<Block, AccountId, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>
+    > + reward_rpc_runtime_api::RewardApi<Block, AccountId, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>
     + loans_rpc_runtime_api::LoansApi<Block, AccountId, Balance>
 where
     <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
@@ -111,32 +111,32 @@ where
         + substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
         + pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
         + cumulus_primitives_core::CollectCollationInfo<Block>
-        + module_btc_relay_rpc_runtime_api::BtcRelayApi<Block, H256Le>
-        + module_oracle_rpc_runtime_api::OracleApi<Block, Balance, CurrencyId>
-        + module_vault_registry_rpc_runtime_api::VaultRegistryApi<
+        + btc_relay_rpc_runtime_api::BtcRelayApi<Block, H256Le>
+        + oracle_rpc_runtime_api::OracleApi<Block, Balance, CurrencyId>
+        + vault_registry_rpc_runtime_api::VaultRegistryApi<
             Block,
             VaultId<AccountId, CurrencyId>,
             Balance,
             UnsignedFixedPoint,
             CurrencyId,
             AccountId,
-        > + module_escrow_rpc_runtime_api::EscrowApi<Block, AccountId, BlockNumber, Balance>
-        + module_issue_rpc_runtime_api::IssueApi<
+        > + escrow_rpc_runtime_api::EscrowApi<Block, AccountId, BlockNumber, Balance>
+        + issue_rpc_runtime_api::IssueApi<
             Block,
             AccountId,
             H256,
             issue::IssueRequest<AccountId, BlockNumber, Balance, CurrencyId>,
-        > + module_redeem_rpc_runtime_api::RedeemApi<
+        > + redeem_rpc_runtime_api::RedeemApi<
             Block,
             AccountId,
             H256,
             redeem::RedeemRequest<AccountId, BlockNumber, Balance, CurrencyId>,
-        > + module_replace_rpc_runtime_api::ReplaceApi<
+        > + replace_rpc_runtime_api::ReplaceApi<
             Block,
             AccountId,
             H256,
             replace::ReplaceRequest<AccountId, BlockNumber, Balance, CurrencyId>,
-        > + module_reward_rpc_runtime_api::RewardApi<Block, AccountId, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>
+        > + reward_rpc_runtime_api::RewardApi<Block, AccountId, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>
         + loans_rpc_runtime_api::LoansApi<Block, AccountId, Balance>,
     <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -9,14 +9,14 @@ futures = "0.3.21"
 jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 
 # Parachain dependencies
-module-btc-relay-rpc = { path = "../crates/btc-relay/rpc" }
-module-oracle-rpc = { path = "../crates/oracle/rpc" }
-module-vault-registry-rpc = { path = "../crates/vault-registry/rpc" }
-module-issue-rpc = { path = "../crates/issue/rpc" }
-module-redeem-rpc = { path = "../crates/redeem/rpc" }
-module-replace-rpc = { path = "../crates/replace/rpc" }
-module-escrow-rpc = { path = "../crates/escrow/rpc" }
-module-reward-rpc = { path = "../crates/reward/rpc" }
+btc-relay-rpc = { path = "../crates/btc-relay/rpc" }
+oracle-rpc = { path = "../crates/oracle/rpc" }
+vault-registry-rpc = { path = "../crates/vault-registry/rpc" }
+issue-rpc = { path = "../crates/issue/rpc" }
+redeem-rpc = { path = "../crates/redeem/rpc" }
+replace-rpc = { path = "../crates/replace/rpc" }
+escrow-rpc = { path = "../crates/escrow/rpc" }
+reward-rpc = { path = "../crates/reward/rpc" }
 loans-rpc = { path = "../crates/loans/rpc" }
 
 vault-registry = { path = "../crates/vault-registry" }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -44,9 +44,9 @@ where
     C: Send + Sync + 'static,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
     C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
-    C::Api: module_btc_relay_rpc::BtcRelayRuntimeApi<Block, H256Le>,
-    C::Api: module_oracle_rpc::OracleRuntimeApi<Block, Balance, CurrencyId>,
-    C::Api: module_vault_registry_rpc::VaultRegistryRuntimeApi<
+    C::Api: btc_relay_rpc::BtcRelayRuntimeApi<Block, H256Le>,
+    C::Api: oracle_rpc::OracleRuntimeApi<Block, Balance, CurrencyId>,
+    C::Api: vault_registry_rpc::VaultRegistryRuntimeApi<
         Block,
         VaultId<AccountId, CurrencyId>,
         Balance,
@@ -54,41 +54,37 @@ where
         CurrencyId,
         AccountId,
     >,
-    C::Api: module_issue_rpc::IssueRuntimeApi<
-        Block,
-        AccountId,
-        H256,
-        IssueRequest<AccountId, BlockNumber, Balance, CurrencyId>,
-    >,
-    C::Api: module_redeem_rpc::RedeemRuntimeApi<
+    C::Api:
+        issue_rpc::IssueRuntimeApi<Block, AccountId, H256, IssueRequest<AccountId, BlockNumber, Balance, CurrencyId>>,
+    C::Api: redeem_rpc::RedeemRuntimeApi<
         Block,
         AccountId,
         H256,
         RedeemRequest<AccountId, BlockNumber, Balance, CurrencyId>,
     >,
-    C::Api: module_replace_rpc::ReplaceRuntimeApi<
+    C::Api: replace_rpc::ReplaceRuntimeApi<
         Block,
         AccountId,
         H256,
         ReplaceRequest<AccountId, BlockNumber, Balance, CurrencyId>,
     >,
-    C::Api: module_escrow_rpc::EscrowRuntimeApi<Block, AccountId, BlockNumber, Balance>,
-    C::Api: module_reward_rpc::RewardRuntimeApi<Block, AccountId, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>,
+    C::Api: escrow_rpc::EscrowRuntimeApi<Block, AccountId, BlockNumber, Balance>,
+    C::Api: reward_rpc::RewardRuntimeApi<Block, AccountId, VaultId<AccountId, CurrencyId>, CurrencyId, Balance>,
     C::Api: loans_rpc::LoansRuntimeApi<Block, AccountId, Balance>,
     C::Api: BlockBuilder<Block>,
     P: TransactionPool + 'static,
 {
+    use btc_relay_rpc::{BtcRelay, BtcRelayApiServer};
+    use escrow_rpc::{Escrow, EscrowApiServer};
+    use issue_rpc::{Issue, IssueApiServer};
     use loans_rpc::{Loans, LoansApiServer};
-    use module_btc_relay_rpc::{BtcRelay, BtcRelayApiServer};
-    use module_escrow_rpc::{Escrow, EscrowApiServer};
-    use module_issue_rpc::{Issue, IssueApiServer};
-    use module_oracle_rpc::{Oracle, OracleApiServer};
-    use module_redeem_rpc::{Redeem, RedeemApiServer};
-    use module_replace_rpc::{Replace, ReplaceApiServer};
-    use module_reward_rpc::{Reward, RewardApiServer};
-    use module_vault_registry_rpc::{VaultRegistry, VaultRegistryApiServer};
+    use oracle_rpc::{Oracle, OracleApiServer};
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
+    use redeem_rpc::{Redeem, RedeemApiServer};
+    use replace_rpc::{Replace, ReplaceApiServer};
+    use reward_rpc::{Reward, RewardApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};
+    use vault_registry_rpc::{VaultRegistry, VaultRegistryApiServer};
 
     let mut module = RpcExtension::new(());
     let FullDeps {

--- a/standalone/runtime/Cargo.toml
+++ b/standalone/runtime/Cargo.toml
@@ -79,14 +79,14 @@ traits = { path = "../../crates/traits", default-features = false }
 
 primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
-module-btc-relay-rpc-runtime-api = { path = "../../crates/btc-relay/rpc/runtime-api", default-features = false }
-module-oracle-rpc-runtime-api = { path = "../../crates/oracle/rpc/runtime-api", default-features = false }
-module-vault-registry-rpc-runtime-api = { path = "../../crates/vault-registry/rpc/runtime-api", default-features = false }
-module-escrow-rpc-runtime-api = { path = "../../crates/escrow/rpc/runtime-api", default-features = false }
-module-reward-rpc-runtime-api = { path = "../../crates/reward/rpc/runtime-api", default-features = false }
-module-issue-rpc-runtime-api = { path = "../../crates/issue/rpc/runtime-api", default-features = false }
-module-redeem-rpc-runtime-api = { path = "../../crates/redeem/rpc/runtime-api", default-features = false }
-module-replace-rpc-runtime-api = { path = "../../crates/replace/rpc/runtime-api", default-features = false }
+btc-relay-rpc-runtime-api = { path = "../../crates/btc-relay/rpc/runtime-api", default-features = false }
+oracle-rpc-runtime-api = { path = "../../crates/oracle/rpc/runtime-api", default-features = false }
+vault-registry-rpc-runtime-api = { path = "../../crates/vault-registry/rpc/runtime-api", default-features = false }
+escrow-rpc-runtime-api = { path = "../../crates/escrow/rpc/runtime-api", default-features = false }
+reward-rpc-runtime-api = { path = "../../crates/reward/rpc/runtime-api", default-features = false }
+issue-rpc-runtime-api = { path = "../../crates/issue/rpc/runtime-api", default-features = false }
+redeem-rpc-runtime-api = { path = "../../crates/redeem/rpc/runtime-api", default-features = false }
+replace-rpc-runtime-api = { path = "../../crates/replace/rpc/runtime-api", default-features = false }
 loans-rpc-runtime-api = { path = "../../crates/loans/rpc/runtime-api", default-features = false }
 
 # Orml dependencies
@@ -179,14 +179,14 @@ std = [
 
   "primitives/std",
 
-  "module-btc-relay-rpc-runtime-api/std",
-  "module-oracle-rpc-runtime-api/std",
-  "module-vault-registry-rpc-runtime-api/std",
-  "module-escrow-rpc-runtime-api/std",
-  "module-reward-rpc-runtime-api/std",
-  "module-issue-rpc-runtime-api/std",
-  "module-redeem-rpc-runtime-api/std",
-  "module-replace-rpc-runtime-api/std",
+  "btc-relay-rpc-runtime-api/std",
+  "oracle-rpc-runtime-api/std",
+  "vault-registry-rpc-runtime-api/std",
+  "escrow-rpc-runtime-api/std",
+  "reward-rpc-runtime-api/std",
+  "issue-rpc-runtime-api/std",
+  "redeem-rpc-runtime-api/std",
+  "replace-rpc-runtime-api/std",
   "loans-rpc-runtime-api/std",
 
   "orml-asset-registry/std",

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -64,7 +64,7 @@ pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 
 // interBTC exports
 pub use btc_relay::{bitcoin, Call as BtcRelayCall, TARGET_SPACING};
-pub use module_oracle_rpc_runtime_api::BalanceWrapper;
+pub use oracle_rpc_runtime_api::BalanceWrapper;
 pub use security::StatusCode;
 
 pub use primitives::{
@@ -1275,7 +1275,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_btc_relay_rpc_runtime_api::BtcRelayApi<
+    impl btc_relay_rpc_runtime_api::BtcRelayApi<
         Block,
         H256Le,
     > for Runtime {
@@ -1284,7 +1284,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_oracle_rpc_runtime_api::OracleApi<
+    impl oracle_rpc_runtime_api::OracleApi<
         Block,
         Balance,
         CurrencyId
@@ -1300,7 +1300,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_vault_registry_rpc_runtime_api::VaultRegistryApi<
+    impl vault_registry_rpc_runtime_api::VaultRegistryApi<
         Block,
         VaultId,
         Balance,
@@ -1363,7 +1363,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_escrow_rpc_runtime_api::EscrowApi<
+    impl escrow_rpc_runtime_api::EscrowApi<
         Block,
         AccountId,
         BlockNumber,
@@ -1378,7 +1378,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_reward_rpc_runtime_api::RewardApi<
+    impl reward_rpc_runtime_api::RewardApi<
         Block,
         AccountId,
         VaultId,
@@ -1398,7 +1398,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_issue_rpc_runtime_api::IssueApi<
+    impl issue_rpc_runtime_api::IssueApi<
         Block,
         AccountId,
         H256,
@@ -1413,7 +1413,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_redeem_rpc_runtime_api::RedeemApi<
+    impl redeem_rpc_runtime_api::RedeemApi<
         Block,
         AccountId,
         H256,
@@ -1428,7 +1428,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl module_replace_rpc_runtime_api::ReplaceApi<
+    impl replace_rpc_runtime_api::ReplaceApi<
         Block,
         AccountId,
         H256,


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Harmonizes the rpc pallet names similar to https://github.com/interlay/interbtc/pull/764.