### PR TITLE
chore: update max block weight comment

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -128,7 +128,7 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-/// We allow for 2 seconds of compute with a 12 second average block time.
+/// We allow for 0.5 seconds of compute with a 12 second average block time.
 pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
     .saturating_div(2)
     .set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -128,7 +128,7 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-/// We allow for 2 seconds of compute with a 12 second average block time.
+/// We allow for 0.5 seconds of compute with a 12 second average block time.
 pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
     .saturating_div(2)
     .set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -133,7 +133,7 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-/// We allow for 2 seconds of compute with a 12 second average block time.
+/// We allow for 0.5 seconds of compute with a 12 second average block time.
 pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
     .saturating_div(2)
     .set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -133,7 +133,7 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-/// We allow for 2 seconds of compute with a 12 second average block time.
+/// We allow for 0.5 seconds of compute with a 12 second average block time.
 pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
     .saturating_div(2)
     .set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

I found the following definition on the maximum block weight [here](https://substrate.stackexchange.com/questions/269/maximum-weight-in-a-block):

**Maximum Block Weight**

> The maximum block weight should be equivalent to one-third of the target block time, allocating one third for block construction, one third for network propagation, and one third for import and verification.

We can see that polkadot does allow for 2 seconds of compute time [here](https://github.com/paritytech/polkadot/blob/b984c40cc5217eda68f630e329320dc26578a0bc/runtime/common/src/lib.rs#L73-L74):

```
MAXIMUM_BLOCK_WEIGHT = WEIGHT_PER_SECOND * 2
```

However, it would seem most parachains (including statemine & statemint) are limited to 0.5 seconds of compute time ([for example](https://github.com/paritytech/cumulus/pull/501)). The only reference I can find to this limitation is the "asynchronous backing" [tracking issue](https://github.com/paritytech/polkadot/issues/3779):

> This implicitly creates a requirement for a parachain block to be authored, submitted to relay-chain validators, executed, and backed all within a 6-second window. Practically, this leaves only around 0.5 seconds for the collator to author a block, which is not enough time to include a meaningful amount of transactions.