### PR TITLE
[BREAKING] refactor: extend reward pallet to support multiple pools

### DIFF
--- a/crates/reward/Cargo.toml
+++ b/crates/reward/Cargo.toml
@@ -6,6 +6,7 @@ name = "reward"
 version = "1.2.0"
 
 [dependencies]
+log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.130", default-features = false, features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
@@ -35,6 +36,7 @@ primitives = { package = "interbtc-primitives", path = "../../primitives", defau
 [features]
 default = ["std"]
 std = [
+	"log/std",
 	"serde",
 	"codec/std",
 
@@ -55,3 +57,4 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 ]
+try-runtime = ["frame-support/try-runtime"]

--- a/crates/reward/src/migration.rs
+++ b/crates/reward/src/migration.rs
@@ -1,0 +1,151 @@
+use super::*;
+use frame_support::{pallet_prelude::StorageVersion, traits::OnRuntimeUpgrade};
+
+/// The log target.
+const TARGET: &'static str = "runtime::reward::migration";
+
+pub mod v0 {
+    use super::*;
+    use frame_support::pallet_prelude::*;
+
+    #[frame_support::storage_alias]
+    pub(crate) type TotalStake<T: Config<I>, I: 'static> =
+        StorageValue<Pallet<T, I>, SignedFixedPoint<T, I>, ValueQuery>;
+
+    #[frame_support::storage_alias]
+    pub(crate) type RewardPerToken<T: Config<I>, I: 'static> =
+        StorageMap<Pallet<T, I>, Blake2_128Concat, <T as Config<I>>::CurrencyId, SignedFixedPoint<T, I>, ValueQuery>;
+
+    #[frame_support::storage_alias]
+    pub(crate) type Stake<T: Config<I>, I: 'static> =
+        StorageMap<Pallet<T, I>, Blake2_128Concat, <T as Config<I>>::StakeId, SignedFixedPoint<T, I>, ValueQuery>;
+
+    #[frame_support::storage_alias]
+    pub(crate) type RewardTally<T: Config<I>, I: 'static> = StorageDoubleMap<
+        Pallet<T, I>,
+        Blake2_128Concat,
+        <T as Config<I>>::CurrencyId,
+        Blake2_128Concat,
+        <T as Config<I>>::StakeId,
+        SignedFixedPoint<T, I>,
+        ValueQuery,
+    >;
+}
+
+pub mod v1 {
+    use super::*;
+    use frame_support::pallet_prelude::*;
+
+    /// Migrate the reward pallet from V0 to V1.
+    pub struct MigrateToV1<T, I = ()>(sp_std::marker::PhantomData<(T, I)>);
+
+    // we only implement this migration for the "global" pool
+    // i.e. this is only intended to migrate `EscrowRewards`
+    impl<T: Config<I, PoolId = ()>, I: 'static> OnRuntimeUpgrade for MigrateToV1<T, I> {
+        #[cfg(feature = "try-runtime")]
+        fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+            assert_eq!(
+                StorageVersion::get::<Pallet<T, I>>(),
+                0,
+                "Can only upgrade from version 0"
+            );
+
+            Ok(Vec::new())
+        }
+
+        fn on_runtime_upgrade() -> Weight {
+            let version = StorageVersion::get::<Pallet<T, I>>();
+            if version != 0 {
+                log::warn!(
+                    target: TARGET,
+                    "skipping v0 to v1 migration: executed on wrong storage version.\
+				Expected version 0, found {:?}",
+                    version,
+                );
+                return T::DbWeight::get().reads(1);
+            }
+
+            let mut weight = T::DbWeight::get().reads_writes(2, 1);
+
+            // update total stake
+            TotalStake::<T, I>::insert((), v0::TotalStake::<T, I>::get());
+            weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+
+            let reward_per_token_storage_map_v0 = v0::RewardPerToken::<T, I>::drain().collect::<Vec<_>>();
+            weight.saturating_accrue(T::DbWeight::get().reads(reward_per_token_storage_map_v0.len() as u64));
+            for (currency_id, reward_per_token) in reward_per_token_storage_map_v0.into_iter() {
+                RewardPerToken::<T, I>::insert(currency_id, (), reward_per_token);
+                weight.saturating_accrue(T::DbWeight::get().writes(1));
+            }
+
+            let stake_storage_map_v0 = v0::Stake::<T, I>::drain().collect::<Vec<_>>();
+            weight.saturating_accrue(T::DbWeight::get().reads(stake_storage_map_v0.len() as u64));
+            for (stake_id, stake) in stake_storage_map_v0.into_iter() {
+                Stake::<T, I>::insert(((), stake_id), stake);
+                weight.saturating_accrue(T::DbWeight::get().writes(1));
+            }
+
+            let reward_tally_storage_map_v0 = v0::RewardTally::<T, I>::drain().collect::<Vec<_>>();
+            weight.saturating_accrue(T::DbWeight::get().reads(reward_tally_storage_map_v0.len() as u64));
+            for (currency_id, stake_id, reward_tally) in reward_tally_storage_map_v0.into_iter() {
+                RewardTally::<T, I>::insert(currency_id, ((), stake_id), reward_tally);
+                weight.saturating_accrue(T::DbWeight::get().writes(1));
+            }
+
+            StorageVersion::new(1).put::<Pallet<T, I>>();
+            weight.saturating_add(T::DbWeight::get().reads_writes(1, 2))
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
+            assert_eq!(StorageVersion::get::<Pallet<T, I>>(), 1, "Must upgrade");
+
+            // TODO: verify final state
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "try-runtime")]
+mod test {
+    use super::*;
+    use crate::mock::*;
+    use sp_arithmetic::FixedI128;
+
+    #[test]
+    #[allow(deprecated)]
+    fn migration_v0_to_v1_works() {
+        run_test(|| {
+            // assume that we are at v0
+            StorageVersion::new(0).put::<Reward>();
+
+            // first account deposits 50
+            v0::Stake::<Test, ()>::insert(0, FixedI128::from(50));
+            // total stake is updated to 50
+            v0::TotalStake::<Test, ()>::put(FixedI128::from(50));
+            // distribute 100 rewards
+            // reward / total_stake = 100 / 50 = 2
+            v0::RewardPerToken::<Test, ()>::insert(Token(IBTC), FixedI128::from(2));
+            // second account deposits 50
+            v0::Stake::<Test, ()>::insert(1, FixedI128::from(50));
+            // total stake is updated to 100
+            v0::TotalStake::<Test, ()>::put(FixedI128::from(100));
+            // reward_per_token * amount = 2 * 50
+            v0::RewardTally::<Test, ()>::insert(Token(IBTC), 1, FixedI128::from(100));
+
+            let state = v1::MigrateToV1::<Test>::pre_upgrade().unwrap();
+            let _w = v1::MigrateToV1::<Test>::on_runtime_upgrade();
+            v1::MigrateToV1::<Test>::post_upgrade(state).unwrap();
+
+            assert_eq!(Stake::<Test>::get(((), 0)), FixedI128::from(50));
+            assert_eq!(Stake::<Test>::get(((), 1)), FixedI128::from(50));
+            assert_eq!(TotalStake::<Test>::get(()), FixedI128::from(100));
+            assert_eq!(RewardPerToken::<Test>::get(Token(IBTC), ()), FixedI128::from(2));
+            assert_eq!(RewardTally::<Test>::get(Token(IBTC), ((), 0)), FixedI128::from(0));
+            assert_eq!(RewardTally::<Test>::get(Token(IBTC), ((), 1)), FixedI128::from(100));
+
+            assert_eq!(StorageVersion::get::<Reward>(), 1);
+        });
+    }
+}

--- a/crates/reward/src/tests.rs
+++ b/crates/reward/src/tests.rs
@@ -21,83 +21,83 @@ fn reproduce_live_state() {
         let currency = Token(INTR);
 
         // state for a3eFe9M2HbAgrQrShEDH2CEvXACtzLhSf4JGkwuT9SQ1EV4ti at block 0xb47ed0e773e25c81da2cc606495ab6f716c3c2024f9beb361605860912fee652
-        crate::RewardPerToken::<Test>::insert(currency, f(1_699_249_738_518_636_122_154_288_694));
-        crate::RewardTally::<Test>::insert(currency, ALICE, f(164_605_943_476_265_834_062_592_062_507_811_208));
-        crate::Stake::<Test>::insert(ALICE, f(97_679_889_000_000_000_000_000_000));
+        crate::RewardPerToken::<Test>::insert(currency, (), f(1_699_249_738_518_636_122_154_288_694));
+        crate::RewardTally::<Test>::insert(currency, ((), ALICE), f(164_605_943_476_265_834_062_592_062_507_811_208));
+        crate::Stake::<Test>::insert(((), ALICE), f(97_679_889_000_000_000_000_000_000));
         crate::TotalRewards::<Test>::insert(currency, f(8_763_982_459_262_268_000_000_000_000_000_000));
-        crate::TotalStake::<Test>::put(f(2_253_803_217_000_000_000_000_000_000));
+        crate::TotalStake::<Test>::insert((), f(2_253_803_217_000_000_000_000_000_000));
 
-        assert_ok!(Reward::compute_reward(&ALICE, currency), 1376582365513566);
+        assert_ok!(Reward::compute_reward(&(), &ALICE, currency), 1376582365513566);
     })
 }
 
 #[test]
 fn should_distribute_rewards_equally() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(50)));
-        assert_ok!(Reward::deposit_stake(&BOB, fixed!(50)));
-        assert_ok!(Reward::distribute_reward(Token(IBTC), fixed!(100)));
-        assert_ok!(Reward::compute_reward(&ALICE, Token(IBTC)), 50);
-        assert_ok!(Reward::compute_reward(&BOB, Token(IBTC)), 50);
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(50)));
+        assert_ok!(Reward::deposit_stake(&(), &BOB, fixed!(50)));
+        assert_ok!(Reward::distribute_reward(&(), Token(IBTC), fixed!(100)));
+        assert_ok!(Reward::compute_reward(&(), &ALICE, Token(IBTC)), 50);
+        assert_ok!(Reward::compute_reward(&(), &BOB, Token(IBTC)), 50);
     })
 }
 
 #[test]
 fn should_distribute_uneven_rewards_equally() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(50)));
-        assert_ok!(Reward::deposit_stake(&BOB, fixed!(50)));
-        assert_ok!(Reward::distribute_reward(Token(IBTC), fixed!(451)));
-        assert_ok!(Reward::compute_reward(&ALICE, Token(IBTC)), 225);
-        assert_ok!(Reward::compute_reward(&BOB, Token(IBTC)), 225);
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(50)));
+        assert_ok!(Reward::deposit_stake(&(), &BOB, fixed!(50)));
+        assert_ok!(Reward::distribute_reward(&(), Token(IBTC), fixed!(451)));
+        assert_ok!(Reward::compute_reward(&(), &ALICE, Token(IBTC)), 225);
+        assert_ok!(Reward::compute_reward(&(), &BOB, Token(IBTC)), 225);
     })
 }
 
 #[test]
 fn should_not_update_previous_rewards() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(40)));
-        assert_ok!(Reward::distribute_reward(Token(IBTC), fixed!(1000)));
-        assert_ok!(Reward::compute_reward(&ALICE, Token(IBTC)), 1000);
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(40)));
+        assert_ok!(Reward::distribute_reward(&(), Token(IBTC), fixed!(1000)));
+        assert_ok!(Reward::compute_reward(&(), &ALICE, Token(IBTC)), 1000);
 
-        assert_ok!(Reward::deposit_stake(&BOB, fixed!(20)));
-        assert_ok!(Reward::compute_reward(&ALICE, Token(IBTC)), 1000);
-        assert_ok!(Reward::compute_reward(&BOB, Token(IBTC)), 0);
+        assert_ok!(Reward::deposit_stake(&(), &BOB, fixed!(20)));
+        assert_ok!(Reward::compute_reward(&(), &ALICE, Token(IBTC)), 1000);
+        assert_ok!(Reward::compute_reward(&(), &BOB, Token(IBTC)), 0);
     })
 }
 
 #[test]
 fn should_withdraw_reward() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(45)));
-        assert_ok!(Reward::deposit_stake(&BOB, fixed!(55)));
-        assert_ok!(Reward::distribute_reward(Token(IBTC), fixed!(2344)));
-        assert_ok!(Reward::compute_reward(&BOB, Token(IBTC)), 1289);
-        assert_ok!(Reward::withdraw_reward(&ALICE, Token(IBTC)), 1054);
-        assert_ok!(Reward::compute_reward(&BOB, Token(IBTC)), 1289);
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(45)));
+        assert_ok!(Reward::deposit_stake(&(), &BOB, fixed!(55)));
+        assert_ok!(Reward::distribute_reward(&(), Token(IBTC), fixed!(2344)));
+        assert_ok!(Reward::compute_reward(&(), &BOB, Token(IBTC)), 1289);
+        assert_ok!(Reward::withdraw_reward(&(), &ALICE, Token(IBTC)), 1054);
+        assert_ok!(Reward::compute_reward(&(), &BOB, Token(IBTC)), 1289);
     })
 }
 
 #[test]
 fn should_withdraw_stake() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(1312)));
-        assert_ok!(Reward::distribute_reward(Token(IBTC), fixed!(4242)));
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(1312)));
+        assert_ok!(Reward::distribute_reward(&(), Token(IBTC), fixed!(4242)));
         // rounding in `CheckedDiv` loses some precision
-        assert_ok!(Reward::compute_reward(&ALICE, Token(IBTC)), 4241);
-        assert_ok!(Reward::withdraw_stake(&ALICE, fixed!(1312)));
-        assert_ok!(Reward::compute_reward(&ALICE, Token(IBTC)), 4241);
+        assert_ok!(Reward::compute_reward(&(), &ALICE, Token(IBTC)), 4241);
+        assert_ok!(Reward::withdraw_stake(&(), &ALICE, fixed!(1312)));
+        assert_ok!(Reward::compute_reward(&(), &ALICE, Token(IBTC)), 4241);
     })
 }
 
 #[test]
 fn should_not_withdraw_stake_if_balance_insufficient() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(100)));
-        assert_ok!(Reward::distribute_reward(Token(IBTC), fixed!(2000)));
-        assert_ok!(Reward::compute_reward(&ALICE, Token(IBTC)), 2000);
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(100)));
+        assert_ok!(Reward::distribute_reward(&(), Token(IBTC), fixed!(2000)));
+        assert_ok!(Reward::compute_reward(&(), &ALICE, Token(IBTC)), 2000);
         assert_err!(
-            Reward::withdraw_stake(&ALICE, fixed!(200)),
+            Reward::withdraw_stake(&(), &ALICE, fixed!(200)),
             TestError::InsufficientFunds
         );
     })
@@ -106,12 +106,12 @@ fn should_not_withdraw_stake_if_balance_insufficient() {
 #[test]
 fn should_deposit_stake() {
     run_test(|| {
-        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(25)));
-        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(25)));
-        assert_eq!(Reward::stake(&ALICE), fixed!(50));
-        assert_ok!(Reward::deposit_stake(&BOB, fixed!(50)));
-        assert_ok!(Reward::distribute_reward(Token(IBTC), fixed!(1000)));
-        assert_ok!(Reward::compute_reward(&ALICE, Token(IBTC)), 500);
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(25)));
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(25)));
+        assert_eq!(Reward::stake(&(), &ALICE), fixed!(50));
+        assert_ok!(Reward::deposit_stake(&(), &BOB, fixed!(50)));
+        assert_ok!(Reward::distribute_reward(&(), Token(IBTC), fixed!(1000)));
+        assert_ok!(Reward::compute_reward(&(), &ALICE, Token(IBTC)), 500);
     })
 }
 
@@ -119,7 +119,7 @@ fn should_deposit_stake() {
 fn should_not_distribute_rewards_without_stake() {
     run_test(|| {
         assert_err!(
-            Reward::distribute_reward(Token(IBTC), fixed!(1000)),
+            Reward::distribute_reward(&(), Token(IBTC), fixed!(1000)),
             TestError::ZeroTotalStake
         );
         assert_eq!(Reward::total_rewards(Token(IBTC)), fixed!(0));
@@ -131,15 +131,19 @@ fn should_distribute_with_many_rewards() {
     // test that reward tally doesn't overflow
     run_test(|| {
         let mut rng = rand::thread_rng();
-        assert_ok!(Reward::deposit_stake(&ALICE, fixed!(9230404)));
-        assert_ok!(Reward::deposit_stake(&BOB, fixed!(234234444)));
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(9230404)));
+        assert_ok!(Reward::deposit_stake(&(), &BOB, fixed!(234234444)));
         for _ in 0..30 {
             // NOTE: this will overflow compute_reward with > u32
-            assert_ok!(Reward::distribute_reward(Token(IBTC), fixed!(rng.gen::<u32>() as i128)));
+            assert_ok!(Reward::distribute_reward(
+                &(),
+                Token(IBTC),
+                fixed!(rng.gen::<u32>() as i128)
+            ));
         }
-        let alice_reward = Reward::compute_reward(&ALICE, Token(IBTC)).unwrap();
-        assert_ok!(Reward::withdraw_reward(&ALICE, Token(IBTC)), alice_reward);
-        let bob_reward = Reward::compute_reward(&BOB, Token(IBTC)).unwrap();
-        assert_ok!(Reward::withdraw_reward(&BOB, Token(IBTC)), bob_reward);
+        let alice_reward = Reward::compute_reward(&(), &ALICE, Token(IBTC)).unwrap();
+        assert_ok!(Reward::withdraw_reward(&(), &ALICE, Token(IBTC)), alice_reward);
+        let bob_reward = Reward::compute_reward(&(), &BOB, Token(IBTC)).unwrap();
+        assert_ok!(Reward::withdraw_reward(&(), &BOB, Token(IBTC)), bob_reward);
     })
 }


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

First **breaking change** toward implementing #769, uses the `PoolId` introduced in #779 to allow the reward pallet to operate over multiple pools. Note that `type PoolId = ()` emulates the current behavior with a single reward pool since the key does not vary. We will use this for the topmost (unimplemented) `CapacityRewards` and the (implemented) `EscrowRewards` instance.