### PR TITLE
fix(loans): oracle integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9398,7 +9398,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "interbtc-primitives",
- "log",
  "mocktopus",
  "pallet-timestamp",
  "parity-scale-codec",

--- a/crates/currency/src/amount.rs
+++ b/crates/currency/src/amount.rs
@@ -62,6 +62,22 @@ mod conversions {
             Ok(signed_fixed_point)
         }
 
+        pub fn from_unsigned_fixed_point(
+            amount: UnsignedFixedPoint<T>,
+            currency_id: CurrencyId<T>,
+        ) -> Result<Self, DispatchError> {
+            let amount = amount
+                .into_inner()
+                .try_into()
+                .map_err(|_| Error::<T>::TryIntoIntError)?;
+            Ok(Self::new(amount, currency_id))
+        }
+
+        pub fn to_unsigned_fixed_point(&self) -> Result<UnsignedFixedPoint<T>, DispatchError> {
+            let unsigned_fixed_point = <T as pallet::Config>::UnsignedFixedPoint::from_inner(self.amount);
+            Ok(unsigned_fixed_point)
+        }
+
         pub fn convert_to(&self, currency_id: CurrencyId<T>) -> Result<Self, DispatchError> {
             T::CurrencyConversion::convert(self, currency_id)
         }

--- a/crates/loans/src/lend_token.rs
+++ b/crates/loans/src/lend_token.rs
@@ -135,16 +135,12 @@ impl<T: Config> Pallet<T> {
 
         // Formula
         // reducible_underlying_amount = liquidity / collateral_factor / price
-        let price = Self::get_price(underlying_id)?;
-
         let reducible_supply_value = liquidity
             .checked_div(&market.collateral_factor.into())
             .ok_or(ArithmeticError::Overflow)?;
-
-        let reducible_underlying_amount = reducible_supply_value
-            .checked_div(&price)
-            .ok_or(ArithmeticError::Underflow)?
-            .into_inner();
+        let reducible_supply_amount =
+            Amount::<T>::from_unsigned_fixed_point(reducible_supply_value, T::ReferenceAssetId::get())?;
+        let reducible_underlying_amount = reducible_supply_amount.convert_to(underlying_id)?.amount();
 
         let exchange_rate = Self::exchange_rate(underlying_id);
         let amount = Self::calc_collateral_amount(reducible_underlying_amount, exchange_rate)?;

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -1162,6 +1162,7 @@ impl<T: Config> Pallet<T> {
         T::PalletId::get().into_account_truncating()
     }
 
+    // TODO: return `Amount<T>`s instead of `FixedU128`
     pub fn get_account_liquidity(account: &T::AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
         let total_borrow_value = Self::total_borrowed_value(account)?;
         let total_collateral_value = Self::total_collateral_value(account)?;

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -42,7 +42,7 @@ use frame_system::pallet_prelude::*;
 use num_traits::cast::ToPrimitive;
 use orml_traits::{MultiCurrency, MultiReservableCurrency};
 pub use pallet::*;
-use primitives::{Balance, CurrencyId, Liquidity, Price, Rate, Ratio, Shortfall, Timestamp};
+use primitives::{Balance, CurrencyId, Liquidity, Rate, Ratio, Shortfall, Timestamp};
 use sp_runtime::{
     traits::{
         AccountIdConversion, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, One, SaturatedConversion, Saturating,
@@ -51,9 +51,7 @@ use sp_runtime::{
     ArithmeticError, FixedPointNumber, FixedU128,
 };
 use sp_std::{marker, result::Result};
-use traits::{
-    ConvertToBigUint, LoansApi as LoansTrait, LoansMarketDataProvider, MarketInfo, MarketStatus, PriceFeeder,
-};
+use traits::{ConvertToBigUint, LoansApi as LoansTrait, LoansMarketDataProvider, MarketInfo, MarketStatus};
 
 pub use orml_traits::currency::{OnDeposit, OnSlash, OnTransfer};
 use sp_io::hashing::blake2_256;
@@ -178,11 +176,10 @@ pub mod pallet {
     use super::*;
 
     #[pallet::config]
-    pub trait Config: frame_system::Config + currency::Config<Balance = BalanceOf<Self>> {
+    pub trait Config:
+        frame_system::Config + currency::Config<Balance = BalanceOf<Self>, UnsignedFixedPoint = FixedU128>
+    {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
-        /// The oracle price feeder
-        type PriceFeeder: PriceFeeder;
 
         /// The loan's module id, keep all collaterals of CDPs.
         #[pallet::constant]
@@ -209,6 +206,10 @@ pub mod pallet {
         /// Reward asset id.
         #[pallet::constant]
         type RewardAssetId: Get<AssetIdOf<Self>>;
+
+        /// Reference currency for expressing asset prices. Example: USD, IBTC.
+        #[pallet::constant]
+        type ReferenceAssetId: Get<AssetIdOf<Self>>;
     }
 
     #[pallet::error]
@@ -1537,19 +1538,9 @@ impl<T: Config> Pallet<T> {
         }
 
         // Calculate the collateral will get
-        //
-        // amount: 1 Unit = 10^12 pico
-        // price is for 1 pico: 1$ = FixedU128::saturating_from_rational(1, 10^12)
-        // if price is N($) and amount is M(Unit):
-        // liquidate_value = price * amount = (N / 10^12) * (M * 10^12) = N * M
-        // if liquidate_value >= 340282366920938463463.374607431768211455,
-        // FixedU128::saturating_from_integer(liquidate_value) will overflow, so we use from_inner
-        // instead of saturating_from_integer, and after calculation use into_inner to get final value.
-        let collateral_token_price = Self::get_price(collateral_asset_id)?;
-        let real_collateral_underlying_amount = liquidate_value
-            .checked_div(&collateral_token_price)
-            .ok_or(ArithmeticError::Underflow)?
-            .into_inner();
+        let liquidate_value_amount =
+            Amount::<T>::from_unsigned_fixed_point(liquidate_value, T::ReferenceAssetId::get())?;
+        let real_collateral_underlying_amount = liquidate_value_amount.convert_to(collateral_asset_id)?.amount();
 
         //inside transfer token
         Self::liquidated_transfer(
@@ -1802,37 +1793,12 @@ impl<T: Config> Pallet<T> {
         Ok(amount)
     }
 
-    // Returns the uniform format price.
-    // Formula: `price = oracle_price * 10.pow(18 - asset_decimal)`
-    // This particular price makes it easy to calculate the value ,
-    // because we don't have to consider decimal for each asset. ref: get_asset_value
-    //
-    // Returns `Err` if the oracle price not ready
-    pub fn get_price(asset_id: AssetIdOf<T>) -> Result<Price, DispatchError> {
-        let (price, _) = T::PriceFeeder::get_price(&asset_id).ok_or(Error::<T>::PriceOracleNotReady)?;
-        if price.is_zero() {
-            return Err(Error::<T>::PriceIsZero.into());
-        }
-        log::trace!(
-            target: "loans::get_price", "price: {:?}", price.into_inner()
-        );
-
-        Ok(price)
-    }
-
-    // Returns the value of the asset, in dollars.
-    // Formula: `value = oracle_price * balance / 1e18(oracle_price_decimal) / asset_decimal`
-    // As the price is a result of `oracle_price * 10.pow(18 - asset_decimal)`,
-    // then `value = price * balance / 1e18`.
-    // We use FixedU128::from_inner(balance) instead of `balance / 1e18`.
-    //
+    // Returns the value of the asset, in the reference currency.
     // Returns `Err` if oracle price not ready or arithmetic error.
     pub fn get_asset_value(asset_id: AssetIdOf<T>, amount: BalanceOf<T>) -> Result<FixedU128, DispatchError> {
-        let value = Self::get_price(asset_id)?
-            .checked_mul(&FixedU128::from_inner(amount))
-            .ok_or(ArithmeticError::Overflow)?;
-
-        Ok(value)
+        let asset_amount = Amount::<T>::new(amount, asset_id);
+        let reference_amount = asset_amount.convert_to(T::ReferenceAssetId::get())?;
+        reference_amount.to_unsigned_fixed_point()
     }
 
     // Returns a stored Market.

--- a/crates/loans/src/tests/interest_rate.rs
+++ b/crates/loans/src/tests/interest_rate.rs
@@ -1,6 +1,7 @@
 use crate::{mock::*, tests::Loans, Markets};
-use currency::Amount;
+use currency::{Amount, CurrencyConversion};
 use frame_support::assert_ok;
+use mocktopus::mocking::Mockable;
 use primitives::{CurrencyId::Token, Rate, Ratio, DOT, KSM, SECONDS_PER_YEAR};
 use sp_runtime::{
     traits::{CheckedDiv, One, Saturating},
@@ -256,7 +257,7 @@ fn accrue_interest_works_after_liquidate_borrow() {
         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
         TimestampPallet::set_timestamp(12000);
         // Adjust KSM price to make shortfall
-        MockPriceFeeder::set_price(Token(KSM), 2.into());
+        CurrencyConvert::convert.mock_safe(with_price(Some((Token(KSM), 2.into()))));
         // BOB repay the KSM loan and get DOT callateral from ALICE
         assert_ok!(Loans::liquidate_borrow(
             RuntimeOrigin::signed(BOB),

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -3,14 +3,8 @@
 use frame_support::dispatch::DispatchError;
 use num_bigint::{BigUint, ToBigUint};
 
-use primitives::{CurrencyId, PriceDetail};
-
 pub mod loans;
 pub use loans::*;
-
-pub trait PriceFeeder {
-    fn get_price(asset_id: &CurrencyId) -> Option<PriceDetail>;
-}
 
 pub trait ConvertToBigUint {
     fn get_big_uint(&self) -> BigUint;

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -28,7 +28,6 @@ use loans::{OnSlashHook, PostDeposit, PostTransfer, PreDeposit, PreTransfer};
 use orml_asset_registry::SequentialId;
 use orml_traits::{currency::MutationHooks, location::AbsoluteReserveProvider, parameter_type_with_key, MultiCurrency};
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
-use primitives::PriceDetail;
 use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, H256};
 use sp_runtime::{
@@ -41,7 +40,6 @@ use sp_std::{marker::PhantomData, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use traits::OracleApi;
 use xcm_executor::{traits::WeightTrader, Assets};
 
 // A few exports that help ease life for downstream crates.
@@ -1014,42 +1012,16 @@ impl clients_info::Config for Runtime {
     type WeightInfo = ();
 }
 
-// TODO: Remove this once `get_price()` is replaced with `amount.convert()`
-pub struct PriceFeed;
-impl traits::PriceFeeder for PriceFeed {
-    fn get_price(asset_id: &CurrencyId) -> Option<PriceDetail> {
-        let one = match asset_id {
-            Token(t) => t.one(),
-            ForeignAsset(f) => {
-                // TODO: Either add `one` to the AssetRegistry or require this as an associated type in the config trait
-                if let Some(metadata) = AssetRegistry::metadata(f) {
-                    10u128.pow(metadata.decimals)
-                } else {
-                    return None;
-                }
-            }
-            // Returning `None` here means there is no price for this asset.
-            // This is fine since LendTokens may not be used as underlying currency
-            // in the loans pallet.
-            LendToken(_) => return None,
-        };
-        let amount = Amount::<Runtime>::new(one, asset_id.clone());
-        Oracle::convert(&amount, WRAPPED_CURRENCY_ID)
-            .ok()
-            .map(|price| (price.amount().into(), Timestamp::now()))
-    }
-}
-
 impl loans::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type PalletId = LoansPalletId;
-    type PriceFeeder = PriceFeed;
     type ReserveOrigin = EnsureRoot<AccountId>;
     type UpdateOrigin = EnsureRoot<AccountId>;
     type WeightInfo = ();
     type UnixTime = Timestamp;
     type Assets = Tokens;
     type RewardAssetId = GetNativeCurrencyId;
+    type ReferenceAssetId = GetWrappedCurrencyId;
 }
 
 construct_runtime! {

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -28,7 +28,6 @@ use loans::{OnSlashHook, PostDeposit, PostTransfer, PreDeposit, PreTransfer};
 use orml_asset_registry::SequentialId;
 use orml_traits::{currency::MutationHooks, location::AbsoluteReserveProvider, parameter_type_with_key, MultiCurrency};
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
-use primitives::PriceDetail;
 use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, H256};
 use sp_runtime::{
@@ -41,7 +40,6 @@ use sp_std::{marker::PhantomData, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use traits::OracleApi;
 use xcm_executor::{traits::WeightTrader, Assets};
 
 // A few exports that help ease life for downstream crates.
@@ -1014,42 +1012,16 @@ impl clients_info::Config for Runtime {
     type WeightInfo = ();
 }
 
-// TODO: Remove this once `get_price()` is replaced with `amount.convert()`
-pub struct PriceFeed;
-impl traits::PriceFeeder for PriceFeed {
-    fn get_price(asset_id: &CurrencyId) -> Option<PriceDetail> {
-        let one = match asset_id {
-            Token(t) => t.one(),
-            ForeignAsset(f) => {
-                // TODO: Either add `one` to the AssetRegistry or require this as an associated type in the config trait
-                if let Some(metadata) = AssetRegistry::metadata(f) {
-                    10u128.pow(metadata.decimals)
-                } else {
-                    return None;
-                }
-            }
-            // Returning `None` here means there is no price for this asset.
-            // This is fine since LendTokens may not be used as underlying currency
-            // in the loans pallet.
-            LendToken(_) => return None,
-        };
-        let amount = Amount::<Runtime>::new(one, asset_id.clone());
-        Oracle::convert(&amount, WRAPPED_CURRENCY_ID)
-            .ok()
-            .map(|price| (price.amount().into(), Timestamp::now()))
-    }
-}
-
 impl loans::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type PalletId = LoansPalletId;
-    type PriceFeeder = PriceFeed;
     type ReserveOrigin = EnsureRoot<AccountId>;
     type UpdateOrigin = EnsureRoot<AccountId>;
     type WeightInfo = ();
     type UnixTime = Timestamp;
     type Assets = Tokens;
     type RewardAssetId = GetNativeCurrencyId;
+    type ReferenceAssetId = GetWrappedCurrencyId;
 }
 
 construct_runtime! {

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -1571,3 +1571,13 @@ pub const fn wrapped(amount: Balance) -> Amount<Runtime> {
 pub const fn griefing(amount: Balance) -> Amount<Runtime> {
     Amount::new(amount, DEFAULT_GRIEFING_CURRENCY)
 }
+
+pub fn set_balance(who: AccountId, currency_id: CurrencyId, new_free: Balance) {
+    assert_ok!(RuntimeCall::Tokens(TokensCall::set_balance {
+        who,
+        currency_id,
+        new_free,
+        new_reserved: 0,
+    })
+    .dispatch(root()));
+}

--- a/standalone/runtime/tests/test_multisig.rs
+++ b/standalone/runtime/tests/test_multisig.rs
@@ -9,16 +9,6 @@ use sp_std::str::FromStr;
 
 type VestingCall = orml_vesting::Call<Runtime>;
 
-fn set_balance(who: AccountId, currency_id: CurrencyId, new_free: Balance) {
-    assert_ok!(RuntimeCall::Tokens(TokensCall::set_balance {
-        who,
-        currency_id,
-        new_free,
-        new_reserved: 0,
-    })
-    .dispatch(root()));
-}
-
 #[test]
 fn integration_test_transfer_from_multisig_to_vested() {
     ExtBuilder::build().execute_with(|| {


### PR DESCRIPTION
Replaces the incorrect `get_price` integration with the conversion approach from the `currency` crate. The `PriceFeeder` associated type is replaced by `ReferenceAssetId`, which is the currency that prices are expressed in by the oracle. In our runtimes, that currency is `GetWrappedCurrencyId`. 

In some tests, `KINT` and `KBTC` are replaced with `INTR` and `IBTC`, because runtime currencies have been harmonized for these pairs: governance_currency / loan_reward_currency, and wrapped_currency / reference_currency.

Closes https://github.com/interlay/interbtc/issues/744