### PR TITLE
fix: disable timestamp hook in testnet s.t. instant seal works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9398,7 +9398,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "interbtc-primitives",
- "log",
  "mocktopus",
  "pallet-timestamp",
  "parity-scale-codec",

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -308,7 +308,7 @@ parameter_types! {
 impl pallet_timestamp::Config for Runtime {
     /// A timestamp: milliseconds since the unix epoch.
     type Moment = Moment;
-    type OnTimestampSet = Aura;
+    type OnTimestampSet = (); // no hook set - it would break instant seal
     type MinimumPeriod = MinimumPeriod;
     type WeightInfo = ();
 }


### PR DESCRIPTION
https://github.com/interlay/interbtc/pull/777 configured the OnTimestampSet hook because of a reported security vulneribility: 
![image](https://user-images.githubusercontent.com/2421693/203344074-b85e9405-4509-4369-9b04-5b8ce900837e.png)

However, with this change, we run into https://github.com/paritytech/subport/issues/94 when we use instant-seal. This PR disables the hook for testnet-kintsugi, since that is the one we use in the integration tests. This should be safe as I don't think we have external collators for testnet anyway.