### PR TITLE
fix: testnet-kintsugi build

### DIFF
--- a/parachain/runtime/testnet-kintsugi/Cargo.toml
+++ b/parachain/runtime/testnet-kintsugi/Cargo.toml
@@ -228,6 +228,7 @@ std = [
   "issue-rpc-runtime-api/std",
   "redeem-rpc-runtime-api/std",
   "replace-rpc-runtime-api/std",
+  "loans-rpc-runtime-api/std",
 
   "orml-tokens/std",
   "orml-traits/std",


### PR DESCRIPTION
The build is [failing](https://github.com/interlay/interbtc/actions/runs/3533270582/jobs/5943688368) because of a missing rpc dependency in the std feature.