### PR TITLE
fix: add migration for kintsugi slot duration

### DIFF
--- a/crates/collator-selection/Cargo.toml
+++ b/crates/collator-selection/Cargo.toml
@@ -26,7 +26,6 @@ frame-support = { default-features = false, git = "https://github.com/paritytech
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 pallet-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-pallet-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-consensus-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
@@ -39,6 +38,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 
 [features]
 default = ["std"]
@@ -60,7 +60,6 @@ std = [
 	"frame-benchmarking/std",
 	"pallet-authorship/std",
 	"pallet-session/std",
-	"pallet-aura/std",
 	"sp-consensus-aura/std",
 ]
 

--- a/crates/collator-selection/Cargo.toml
+++ b/crates/collator-selection/Cargo.toml
@@ -26,6 +26,8 @@ frame-support = { default-features = false, git = "https://github.com/paritytech
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 pallet-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+pallet-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+sp-consensus-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 
@@ -37,7 +39,6 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
-pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 
 [features]
 default = ["std"]
@@ -59,6 +60,8 @@ std = [
 	"frame-benchmarking/std",
 	"pallet-authorship/std",
 	"pallet-session/std",
+	"pallet-aura/std",
+	"sp-consensus-aura/std",
 ]
 
 try-runtime = [ "frame-support/try-runtime" ]

--- a/crates/collator-selection/src/lib.rs
+++ b/crates/collator-selection/src/lib.rs
@@ -273,7 +273,7 @@ pub mod pallet {
     #[pallet::hooks]
     impl<T: Config> Hooks<u32> for Pallet<T> {
         fn on_initialize(n: u32) -> Weight {
-            if n != 1983993 {
+            if n != 1983994 {
                 // only run for this block on kintsugi
                 // remove once complete
                 return Weight::zero();

--- a/crates/collator-selection/src/lib.rs
+++ b/crates/collator-selection/src/lib.rs
@@ -66,7 +66,7 @@ pub mod pallet {
         inherent::Vec,
         pallet_prelude::*,
         sp_runtime::{
-            traits::{AccountIdConversion, CheckedSub, Zero},
+            traits::{AccountIdConversion, CheckedSub, Saturating, Zero},
             RuntimeDebug,
         },
         traits::{Currency, EnsureOrigin, ExistenceRequirement::KeepAlive, ReservableCurrency, ValidatorRegistration},
@@ -88,10 +88,9 @@ pub mod pallet {
         }
     }
 
-    // TODO: revert explicit block number
     /// Configure the pallet by specifying the parameters and types on which it depends.
     #[pallet::config]
-    pub trait Config: frame_system::Config<BlockNumber = u32> {
+    pub trait Config: frame_system::Config {
         /// Overarching event type.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
@@ -271,9 +270,9 @@ pub mod pallet {
     }
 
     #[pallet::hooks]
-    impl<T: Config> Hooks<u32> for Pallet<T> {
-        fn on_initialize(n: u32) -> Weight {
-            if n != 1983994 {
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+        fn on_initialize(n: BlockNumberFor<T>) -> Weight {
+            if n != 1983994u32.into() {
                 // only run for this block on kintsugi
                 // remove once complete
                 return Weight::zero();

--- a/crates/collator-selection/src/mock.rs
+++ b/crates/collator-selection/src/mock.rs
@@ -24,10 +24,13 @@ use frame_system as system;
 use frame_system::EnsureSignedBy;
 use sp_core::H256;
 use sp_runtime::{
-    testing::{Header, UintAuthorityId},
+    generic::Header as GenericHeader,
+    testing::UintAuthorityId,
     traits::{BlakeTwo256, IdentityLookup, OpaqueKeys},
     RuntimeAppPublic,
 };
+
+type Header = GenericHeader<BlockNumber, BlakeTwo256>;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -49,8 +52,14 @@ frame_support::construct_runtime!(
     }
 );
 
+pub type AccountId = u64;
+pub type Balance = u128;
+pub type BlockNumber = u32;
+pub type Index = u64;
+pub type Moment = u32;
+
 parameter_types! {
-    pub const BlockHashCount: u64 = 250;
+    pub const BlockHashCount: u32 = 250;
     pub const SS58Prefix: u8 = 42;
 }
 
@@ -61,18 +70,18 @@ impl system::Config for Test {
     type DbWeight = ();
     type RuntimeOrigin = RuntimeOrigin;
     type RuntimeCall = RuntimeCall;
-    type Index = u64;
-    type BlockNumber = u64;
+    type Index = Index;
+    type BlockNumber = BlockNumber;
     type Hash = H256;
     type Hashing = BlakeTwo256;
-    type AccountId = u64;
+    type AccountId = AccountId;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
     type RuntimeEvent = RuntimeEvent;
     type BlockHashCount = BlockHashCount;
     type Version = ();
     type PalletInfo = PalletInfo;
-    type AccountData = pallet_balances::AccountData<u64>;
+    type AccountData = pallet_balances::AccountData<Balance>;
     type OnNewAccount = ();
     type OnKilledAccount = ();
     type SystemWeightInfo = ();
@@ -87,7 +96,7 @@ parameter_types! {
 }
 
 impl pallet_balances::Config for Test {
-    type Balance = u64;
+    type Balance = Balance;
     type RuntimeEvent = RuntimeEvent;
     type DustRemoval = ();
     type ExistentialDeposit = ExistentialDeposit;
@@ -116,11 +125,11 @@ impl pallet_authorship::Config for Test {
 }
 
 parameter_types! {
-    pub const MinimumPeriod: u64 = 1;
+    pub const MinimumPeriod: Moment = 1;
 }
 
 impl pallet_timestamp::Config for Test {
-    type Moment = u64;
+    type Moment = Moment;
     type OnTimestampSet = Aura;
     type MinimumPeriod = MinimumPeriod;
     type WeightInfo = ();
@@ -147,7 +156,7 @@ impl From<UintAuthorityId> for MockSessionKeys {
 
 parameter_types! {
     pub static SessionHandlerCollators: Vec<u64> = Vec::new();
-    pub static SessionChangeBlock: u64 = 0;
+    pub static SessionChangeBlock: BlockNumber = 0;
 }
 
 pub struct TestSessionHandler;
@@ -166,8 +175,8 @@ impl pallet_session::SessionHandler<u64> for TestSessionHandler {
 }
 
 parameter_types! {
-    pub const Offset: u64 = 0;
-    pub const Period: u64 = 10;
+    pub const Offset: BlockNumber = 0;
+    pub const Period: BlockNumber = 10;
 }
 
 impl pallet_session::Config for Test {
@@ -256,9 +265,9 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     t.into()
 }
 
-pub fn initialize_to_block(n: u64) {
+pub fn initialize_to_block(n: BlockNumber) {
     for i in System::block_number() + 1..=n {
         System::set_block_number(i);
-        <AllPalletsWithSystem as frame_support::traits::OnInitialize<u64>>::on_initialize(i);
+        <AllPalletsWithSystem as frame_support::traits::OnInitialize<BlockNumber>>::on_initialize(i);
     }
 }

--- a/crates/collator-selection/src/mock.rs
+++ b/crates/collator-selection/src/mock.rs
@@ -54,9 +54,9 @@ frame_support::construct_runtime!(
 
 pub type AccountId = u64;
 pub type Balance = u128;
-pub type BlockNumber = u32;
+pub type BlockNumber = u64;
 pub type Index = u64;
-pub type Moment = u32;
+pub type Moment = u64;
 
 parameter_types! {
     pub const BlockHashCount: u32 = 250;
@@ -125,7 +125,8 @@ impl pallet_authorship::Config for Test {
 }
 
 parameter_types! {
-    pub const MinimumPeriod: Moment = 1;
+    // NOTE: updated to match kintsugi runtime
+    pub const MinimumPeriod: u64 = 12000 / 2;
 }
 
 impl pallet_timestamp::Config for Test {

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1114,36 +1114,6 @@ construct_runtime! {
     }
 }
 
-// https://hackmd.io/@XuVYQ1rUQjGv8uRzzsdzuw/HkduIX4y5
-pub struct SlotDurationMigration;
-
-impl frame_support::traits::OnRuntimeUpgrade for SlotDurationMigration {
-    fn on_runtime_upgrade() -> Weight {
-        if VERSION.spec_version != 1020000 {
-            // only run for this runtime version
-            // remove once complete
-            return Weight::zero();
-        }
-
-        let old_slot_duration: u64 = 6000; // ms
-        let new_slot_duration: u64 = 12000; // ms
-
-        let current_slot = Aura::current_slot();
-        // slot = timestamp / slot_duration
-        // timestamp = slot * slot_duration
-        let timestamp: u64 = Into::<u64>::into(current_slot) * old_slot_duration;
-        let new_slot = timestamp / new_slot_duration;
-        frame_support::migration::put_storage_value(
-            b"Aura",
-            b"CurrentSlot",
-            &[],
-            sp_consensus_aura::Slot::from(new_slot),
-        );
-
-        Weight::zero()
-    }
-}
-
 /// The address format for describing accounts.
 pub type Address = AccountId;
 /// Block header type as expected by this runtime.
@@ -1176,8 +1146,6 @@ pub type Executive = frame_executive::Executive<
     Runtime,
     AllPalletsWithSystem,
     (
-        // Timestamp fix
-        SlotDurationMigration,
         // "Bound uses of call" <https://github.com/paritytech/substrate/pull/11649>
         pallet_preimage::migration::v1::Migration<Runtime>,
         pallet_scheduler::migration::v3::MigrateToV4<Runtime>,

--- a/parachain/src/service.rs
+++ b/parachain/src/service.rs
@@ -237,11 +237,8 @@ where
                 create_inherent_data_providers: move |parent: sp_core::H256, _| {
                     let client_clone = client_clone.clone();
                     async move {
-                        let slot_ms = match client_clone.clone().runtime_version_at(&BlockId::Hash(parent.clone())) {
-                            Ok(x) if x.spec_name.starts_with("kintsugi") => 6000,
-                            _ => 12000,
-                        };
-                        let slot_duration = sp_consensus_aura::SlotDuration::from_millis(slot_ms);
+                        // let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
+                        let slot_duration = sp_consensus_aura::SlotDuration::from_millis(12000);
 
                         let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 
@@ -471,11 +468,6 @@ where
     RuntimeApi::RuntimeApi: sp_consensus_aura::AuraApi<Block, AuraId>,
     Executor: sc_executor::NativeExecutionDispatch + 'static,
 {
-    let slot_ms = if parachain_config.chain_spec.id() == "kusama" {
-        6000
-    } else {
-        12000
-    };
     start_node_impl(
         parachain_config,
         polkadot_config,
@@ -491,7 +483,8 @@ where
          sync_oracle,
          keystore,
          force_authoring| {
-            let slot_duration = sp_consensus_aura::SlotDuration::from_millis(slot_ms);
+            // let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
+            let slot_duration = sp_consensus_aura::SlotDuration::from_millis(12000);
 
             let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
                 task_manager.spawn_handle(),


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Implements the slot duration migration described [here](https://hackmd.io/@XuVYQ1rUQjGv8uRzzsdzuw/HkduIX4y5). Note that the service already has the necessary changes: https://github.com/interlay/interbtc/blob/63b485b2e8105eeaf20d960ed0a89443d2567d2a/parachain/src/service.rs#L474-L478