### PR TITLE
fix(loans): Set min and max exchange rates on runtime upgrade

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           command: check
           args: --release --workspace
+      - name: try-runtime build
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --release --workspace --features try-runtime
       - name: test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           command: check
           args: --release --workspace
-      - name: try-runtime build
+      - name: try-runtime check
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3631,6 +3631,7 @@ dependencies = [
  "issue-rpc-runtime-api",
  "jsonrpsee",
  "kintsugi-runtime-parachain",
+ "loans",
  "loans-rpc-runtime-api",
  "log",
  "oracle-rpc-runtime-api",

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -77,6 +77,9 @@ pub mod weights;
 pub const REWARD_ACCOUNT_PREFIX: &[u8; 13] = b"loans/farming";
 pub const INCENTIVE_ACCOUNT_PREFIX: &[u8; 15] = b"loans/incentive";
 
+pub const DEFAULT_MAX_EXCHANGE_RATE: u128 = 1_000_000_000_000_000_000; // 1
+pub const DEFAULT_MIN_EXCHANGE_RATE: u128 = 20_000_000_000_000_000; // 0.02
+
 type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 type AssetIdOf<T> = <<T as Config>::Assets as Inspect<<T as frame_system::Config>::AccountId>>::AssetId;
 type BalanceOf<T> = <<T as Config>::Assets as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
@@ -343,6 +346,40 @@ pub mod pallet {
         IncentiveReservesReduced(T::AccountId, AssetIdOf<T>, BalanceOf<T>),
     }
 
+    #[pallet::hooks]
+    impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
+        fn on_runtime_upgrade() -> frame_support::weights::Weight {
+            let max_exchange_rate = crate::MaxExchangeRate::<T>::get();
+            if max_exchange_rate.is_zero() {
+                crate::MaxExchangeRate::<T>::put(Rate::from_inner(DEFAULT_MAX_EXCHANGE_RATE));
+            }
+            let min_exchange_rate = crate::MinExchangeRate::<T>::get();
+            if min_exchange_rate.is_zero() {
+                crate::MinExchangeRate::<T>::put(Rate::from_inner(DEFAULT_MIN_EXCHANGE_RATE));
+            }
+            T::DbWeight::get().reads_writes(0, 2)
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade(_pre_upgrade_state: Vec<u8>) -> Result<(), &'static str> {
+            let max_exchange_rate = crate::MaxExchangeRate::<T>::get();
+            let min_exchange_rate = crate::MinExchangeRate::<T>::get();
+            ensure!(
+                !min_exchange_rate.is_zero(),
+                "Minimum lending exchange rate must be greater than zero"
+            );
+            ensure!(
+                !max_exchange_rate.is_zero(),
+                "Minimum lending exchange rate must be greater than zero"
+            );
+            ensure!(
+                min_exchange_rate.lt(&max_exchange_rate),
+                "Minimum lending exchange rate must be greater than the maximum exchange rate"
+            );
+            Ok(())
+        }
+    }
+
     /// The timestamp of the last calculation of accrued interest
     #[pallet::storage]
     #[pallet::getter(fn last_accrued_interest_time)]
@@ -500,8 +537,8 @@ pub mod pallet {
     impl Default for GenesisConfig {
         fn default() -> Self {
             Self {
-                max_exchange_rate: Default::default(),
-                min_exchange_rate: Default::default(),
+                max_exchange_rate: Rate::from_inner(DEFAULT_MAX_EXCHANGE_RATE),
+                min_exchange_rate: Rate::from_inner(DEFAULT_MIN_EXCHANGE_RATE),
             }
         }
     }

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -50,7 +50,7 @@ use sp_runtime::{
     },
     ArithmeticError, FixedPointNumber, FixedU128,
 };
-use sp_std::{marker, result::Result};
+use sp_std::{marker, result::Result, vec::Vec};
 use traits::{ConvertToBigUint, LoansApi as LoansTrait, LoansMarketDataProvider, MarketInfo, MarketStatus};
 
 pub use orml_traits::currency::{OnDeposit, OnSlash, OnTransfer};
@@ -357,7 +357,7 @@ pub mod pallet {
             if min_exchange_rate.is_zero() {
                 crate::MinExchangeRate::<T>::put(Rate::from_inner(DEFAULT_MIN_EXCHANGE_RATE));
             }
-            T::DbWeight::get().reads_writes(0, 2)
+            T::DbWeight::get().reads_writes(2, 2)
         }
 
         #[cfg(feature = "try-runtime")]

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -32,6 +32,7 @@ testnet-kintsugi-runtime = { package = "testnet-kintsugi-runtime-parachain", pat
 testnet-interlay-runtime = { package = "testnet-interlay-runtime-parachain", path = "./runtime/testnet-interlay" }
 interbtc-rpc = { path = "../rpc" }
 bitcoin = { path = "../crates/bitcoin" }
+loans = { path = "../crates/loans" }
 primitives = { package = "interbtc-primitives", path = "../primitives" }
 
 btc-relay-rpc-runtime-api = { path = "../crates/btc-relay/rpc/runtime-api" }

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -1123,19 +1123,8 @@ pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, RuntimeCall, 
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
 /// Executive: handles dispatch to the various modules.
-pub type Executive = frame_executive::Executive<
-    Runtime,
-    Block,
-    frame_system::ChainContext<Runtime>,
-    Runtime,
-    AllPalletsWithSystem,
-    (
-        // "Bound uses of call" <https://github.com/paritytech/substrate/pull/11649>
-        pallet_preimage::migration::v1::Migration<Runtime>,
-        pallet_scheduler::migration::v3::MigrateToV4<Runtime>,
-        pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
-    ),
->;
+pub type Executive =
+    frame_executive::Executive<Runtime, Block, frame_system::ChainContext<Runtime>, Runtime, AllPalletsWithSystem>;
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -1123,19 +1123,8 @@ pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, RuntimeCall, 
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
 /// Executive: handles dispatch to the various modules.
-pub type Executive = frame_executive::Executive<
-    Runtime,
-    Block,
-    frame_system::ChainContext<Runtime>,
-    Runtime,
-    AllPalletsWithSystem,
-    (
-        // "Bound uses of call" <https://github.com/paritytech/substrate/pull/11649>
-        pallet_preimage::migration::v1::Migration<Runtime>,
-        pallet_scheduler::migration::v3::MigrateToV4<Runtime>,
-        pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
-    ),
->;
+pub type Executive =
+    frame_executive::Executive<Runtime, Block, frame_system::ChainContext<Runtime>, Runtime, AllPalletsWithSystem>;
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {

--- a/parachain/src/chain_spec/mod.rs
+++ b/parachain/src/chain_spec/mod.rs
@@ -95,9 +95,6 @@ const DEFAULT_DUST_VALUE: Balance = 1000;
 const DEFAULT_BITCOIN_CONFIRMATIONS: u32 = 1;
 const SECURE_BITCOIN_CONFIRMATIONS: u32 = 6;
 
-pub const DEFAULT_MAX_EXCHANGE_RATE: u128 = 1_000_000_000_000_000_000; // 1
-pub const DEFAULT_MIN_EXCHANGE_RATE: u128 = 20_000_000_000_000_000; // 0.02
-
 fn expected_transaction_size() -> u32 {
     virtual_transaction_size(
         TransactionInputMetadata {

--- a/parachain/src/chain_spec/testnet_interlay.rs
+++ b/parachain/src/chain_spec/testnet_interlay.rs
@@ -271,8 +271,8 @@ fn testnet_genesis(
             safe_xcm_version: Some(2),
         },
         loans: LoansConfig {
-            max_exchange_rate: Rate::from_inner(DEFAULT_MAX_EXCHANGE_RATE),
-            min_exchange_rate: Rate::from_inner(DEFAULT_MIN_EXCHANGE_RATE),
+            max_exchange_rate: Rate::from_inner(loans::DEFAULT_MAX_EXCHANGE_RATE),
+            min_exchange_rate: Rate::from_inner(loans::DEFAULT_MIN_EXCHANGE_RATE),
         },
     }
 }

--- a/parachain/src/chain_spec/testnet_kintsugi.rs
+++ b/parachain/src/chain_spec/testnet_kintsugi.rs
@@ -468,8 +468,8 @@ fn testnet_genesis(
             safe_xcm_version: Some(2),
         },
         loans: LoansConfig {
-            max_exchange_rate: Rate::from_inner(DEFAULT_MAX_EXCHANGE_RATE),
-            min_exchange_rate: Rate::from_inner(DEFAULT_MIN_EXCHANGE_RATE),
+            max_exchange_rate: Rate::from_inner(loans::DEFAULT_MAX_EXCHANGE_RATE),
+            min_exchange_rate: Rate::from_inner(loans::DEFAULT_MIN_EXCHANGE_RATE),
         },
     }
 }


### PR DESCRIPTION
Adds a migration to set the `min` and `max` exchange rates, if these are zero.

Closes https://github.com/interlay/interbtc/issues/791