### PR TITLE
feat(loans): use Amount<T> instead of FixedU128

### DIFF
--- a/crates/currency/src/amount.rs
+++ b/crates/currency/src/amount.rs
@@ -73,9 +73,8 @@ mod conversions {
             Ok(Self::new(amount, currency_id))
         }
 
-        pub fn to_unsigned_fixed_point(&self) -> Result<UnsignedFixedPoint<T>, DispatchError> {
-            let unsigned_fixed_point = <T as pallet::Config>::UnsignedFixedPoint::from_inner(self.amount);
-            Ok(unsigned_fixed_point)
+        pub fn to_unsigned_fixed_point(&self) -> UnsignedFixedPoint<T> {
+            <T as pallet::Config>::UnsignedFixedPoint::from_inner(self.amount)
         }
 
         pub fn convert_to(&self, currency_id: CurrencyId<T>) -> Result<Self, DispatchError> {

--- a/crates/currency/src/tests.rs
+++ b/crates/currency/src/tests.rs
@@ -83,3 +83,30 @@ fn test_checked_fixed_point_mul_rounded_up() {
         }
     })
 }
+
+#[test]
+fn test_amount_to_and_from_fixed_point() {
+    run_test(|| {
+        let currency = Token(DOT);
+        let tests: Vec<Amount<Test>> = vec![
+            Amount::new(133, currency),
+            Amount::new(1, currency),
+            Amount::new(0, currency),
+            Amount::new(2, currency),
+        ];
+
+        for amount in tests {
+            let unsigned_fixed_point = amount.to_unsigned_fixed_point().unwrap();
+            assert_eq!(
+                amount,
+                Amount::from_unsigned_fixed_point(unsigned_fixed_point, currency).unwrap()
+            );
+
+            let signed_fixed_point = amount.to_signed_fixed_point().unwrap();
+            assert_eq!(
+                amount,
+                Amount::from_signed_fixed_point(signed_fixed_point, currency).unwrap()
+            );
+        }
+    })
+}

--- a/crates/currency/src/types.rs
+++ b/crates/currency/src/types.rs
@@ -1,4 +1,5 @@
 use frame_support::dispatch::DispatchError;
+use sp_runtime::FixedPointNumber;
 
 use crate::Config;
 
@@ -11,6 +12,9 @@ pub(crate) type SignedFixedPoint<T> = <T as Config>::SignedFixedPoint;
 pub(crate) type UnsignedFixedPoint<T> = <T as Config>::UnsignedFixedPoint;
 
 pub(crate) type SignedInner<T> = <T as Config>::SignedInner;
+
+pub(crate) type UnsignedInner<T> = <<T as Config>::UnsignedFixedPoint as FixedPointNumber>::Inner;
+
 pub trait CurrencyConversion<Amount, CurrencyId> {
     fn convert(amount: &Amount, to: CurrencyId) -> Result<Amount, DispatchError>;
 }

--- a/crates/loans/src/interest.rs
+++ b/crates/loans/src/interest.rs
@@ -71,7 +71,9 @@ impl<T: Config> Pallet<T> {
         let now = T::UnixTime::now().as_secs();
         let last_accrued_interest_time = Self::last_accrued_interest_time(asset_id);
         if now > last_accrued_interest_time {
-            let delta_time = now - last_accrued_interest_time;
+            let delta_time = now
+                .checked_sub(last_accrued_interest_time)
+                .ok_or(ArithmeticError::Underflow)?;
             let interest_accumulated =
                 Self::accrued_interest(borrow_rate, total_borrows, delta_time).ok_or(ArithmeticError::Overflow)?;
             total_borrows = interest_accumulated

--- a/crates/loans/src/lend_token.rs
+++ b/crates/loans/src/lend_token.rs
@@ -127,7 +127,8 @@ impl<T: Config> Pallet<T> {
         let collateral_value = Self::collateral_asset_value(who, underlying_id)?;
 
         // liquidity of all assets
-        let AccountLiquidity { liquidity, .. } = Self::get_account_liquidity(who)?;
+        let account_liquidity = Self::get_account_liquidity(who)?;
+        let liquidity = account_liquidity.liquidity();
 
         if liquidity.ge(&collateral_value)? {
             return Ok(voucher_balance);

--- a/crates/loans/src/lend_token.rs
+++ b/crates/loans/src/lend_token.rs
@@ -67,6 +67,7 @@ impl<T: Config> Pallet<T> {
             return DepositConsequence::UnknownAsset;
         }
 
+        // Not using checked arithmetic here is fine because this is a testing utility
         if Self::balance(lend_token_id, who) + amount < Self::minimum_balance(lend_token_id) {
             return DepositConsequence::BelowMinimum;
         }

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -26,6 +26,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use crate::rate_model::*;
+use crate::types::AccountLiquidity;
 
 use currency::Amount;
 use frame_support::{
@@ -42,7 +43,7 @@ use frame_system::pallet_prelude::*;
 use num_traits::cast::ToPrimitive;
 use orml_traits::{MultiCurrency, MultiReservableCurrency};
 pub use pallet::*;
-use primitives::{Balance, CurrencyId, Liquidity, Rate, Ratio, Shortfall, Timestamp};
+use primitives::{Balance, CurrencyId, Rate, Ratio, Timestamp};
 use sp_runtime::{
     traits::{
         AccountIdConversion, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, One, SaturatedConversion, Saturating,
@@ -1162,8 +1163,7 @@ impl<T: Config> Pallet<T> {
         T::PalletId::get().into_account_truncating()
     }
 
-    // TODO: return `Amount<T>`s instead of `FixedU128`
-    pub fn get_account_liquidity(account: &T::AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
+    pub fn get_account_liquidity(account: &T::AccountId) -> Result<AccountLiquidity<T>, DispatchError> {
         let total_borrow_value = Self::total_borrowed_value(account)?;
         let total_collateral_value = Self::total_collateral_value(account)?;
 
@@ -1171,29 +1171,26 @@ impl<T: Config> Pallet<T> {
             target: "loans::get_account_liquidity",
             "account: {:?}, total_borrow_value: {:?}, total_collateral_value: {:?}",
             account,
-            total_borrow_value.into_inner(),
-            total_collateral_value.into_inner(),
+            total_borrow_value.amount(),
+            total_collateral_value.amount(),
         );
-        if total_collateral_value > total_borrow_value {
-            Ok((
-                total_collateral_value
-                    .checked_sub(&total_borrow_value)
-                    .ok_or(ArithmeticError::Underflow)?,
-                FixedU128::zero(),
-            ))
+        let zero = Amount::<T>::zero(T::ReferenceAssetId::get());
+        if total_collateral_value.gt(&total_borrow_value)? {
+            Ok(AccountLiquidity {
+                liquidity: total_collateral_value.checked_sub(&total_borrow_value)?,
+                shortfall: zero,
+            })
         } else {
-            Ok((
-                FixedU128::zero(),
-                total_borrow_value
-                    .checked_sub(&total_collateral_value)
-                    .ok_or(ArithmeticError::Underflow)?,
-            ))
+            Ok(AccountLiquidity {
+                liquidity: zero,
+                shortfall: total_borrow_value.checked_sub(&total_collateral_value)?,
+            })
         }
     }
 
     pub fn get_account_liquidation_threshold_liquidity(
         account: &T::AccountId,
-    ) -> Result<(Liquidity, Shortfall), DispatchError> {
+    ) -> Result<AccountLiquidity<T>, DispatchError> {
         let total_borrow_value = Self::total_borrowed_value(account)?;
         let total_collateral_value = Self::total_liquidation_threshold_value(account)?;
 
@@ -1201,26 +1198,32 @@ impl<T: Config> Pallet<T> {
             target: "loans::get_account_liquidation_threshold_liquidity",
             "account: {:?}, total_borrow_value: {:?}, total_collateral_value: {:?}",
             account,
-            total_borrow_value.into_inner(),
-            total_collateral_value.into_inner(),
+            total_borrow_value.amount(),
+            total_collateral_value.amount(),
         );
-        if total_collateral_value > total_borrow_value {
-            Ok((total_collateral_value - total_borrow_value, FixedU128::zero()))
+        let zero = Amount::<T>::zero(T::ReferenceAssetId::get());
+        if total_collateral_value.gt(&total_borrow_value)? {
+            Ok(AccountLiquidity {
+                liquidity: total_collateral_value.checked_sub(&total_borrow_value)?,
+                shortfall: zero,
+            })
         } else {
-            Ok((FixedU128::zero(), total_borrow_value - total_collateral_value))
+            Ok(AccountLiquidity {
+                liquidity: zero,
+                shortfall: total_borrow_value.checked_sub(&total_collateral_value)?,
+            })
         }
     }
 
-    fn total_borrowed_value(borrower: &T::AccountId) -> Result<FixedU128, DispatchError> {
-        let mut total_borrow_value: FixedU128 = FixedU128::zero();
+    fn total_borrowed_value(borrower: &T::AccountId) -> Result<Amount<T>, DispatchError> {
+        let mut total_borrow_value = Amount::<T>::zero(T::ReferenceAssetId::get());
         for (asset_id, _) in Self::active_markets() {
             let currency_borrow_amount = Self::current_borrow_balance(borrower, asset_id)?;
             if currency_borrow_amount.is_zero() {
                 continue;
             }
-            total_borrow_value = Self::get_asset_value(asset_id, currency_borrow_amount)?
-                .checked_add(&total_borrow_value)
-                .ok_or(ArithmeticError::Overflow)?;
+            total_borrow_value =
+                Self::get_asset_value(asset_id, currency_borrow_amount)?.checked_add(&total_borrow_value)?;
         }
 
         Ok(total_borrow_value)
@@ -1241,19 +1244,20 @@ impl<T: Config> Pallet<T> {
     fn collateral_amount_value(
         asset_id: AssetIdOf<T>,
         lend_token_amount: BalanceOf<T>,
-    ) -> Result<FixedU128, DispatchError> {
+    ) -> Result<Amount<T>, DispatchError> {
         let effects_amount = Self::collateral_balance(asset_id, lend_token_amount)?;
         Self::get_asset_value(asset_id, effects_amount)
     }
 
-    fn collateral_asset_value(supplier: &T::AccountId, asset_id: AssetIdOf<T>) -> Result<FixedU128, DispatchError> {
+    fn collateral_asset_value(supplier: &T::AccountId, asset_id: AssetIdOf<T>) -> Result<Amount<T>, DispatchError> {
         let lend_token_id = Self::lend_token_id(asset_id)?;
+        let zero = Amount::<T>::zero(T::ReferenceAssetId::get());
         if !AccountDeposits::<T>::contains_key(lend_token_id, supplier) {
-            return Ok(FixedU128::zero());
+            return Ok(zero);
         }
         let deposits = Self::account_deposits(lend_token_id, supplier);
         if deposits.is_zero() {
-            return Ok(FixedU128::zero());
+            return Ok(zero);
         }
         Self::collateral_amount_value(asset_id, deposits)
     }
@@ -1261,14 +1265,15 @@ impl<T: Config> Pallet<T> {
     fn liquidation_threshold_asset_value(
         borrower: &T::AccountId,
         asset_id: AssetIdOf<T>,
-    ) -> Result<FixedU128, DispatchError> {
+    ) -> Result<Amount<T>, DispatchError> {
         let lend_token_id = Self::lend_token_id(asset_id)?;
+        let zero = Amount::<T>::zero(T::ReferenceAssetId::get());
         if !AccountDeposits::<T>::contains_key(lend_token_id, borrower) {
-            return Ok(FixedU128::zero());
+            return Ok(zero);
         }
         let deposits = Self::account_deposits(lend_token_id, borrower);
         if deposits.is_zero() {
-            return Ok(FixedU128::zero());
+            return Ok(zero);
         }
         let exchange_rate = Self::exchange_rate_stored(asset_id)?;
         let underlying_amount = Self::calc_underlying_amount(deposits, exchange_rate)?;
@@ -1278,23 +1283,20 @@ impl<T: Config> Pallet<T> {
         Self::get_asset_value(asset_id, effects_amount)
     }
 
-    fn total_collateral_value(supplier: &T::AccountId) -> Result<FixedU128, DispatchError> {
-        let mut total_asset_value: FixedU128 = FixedU128::zero();
+    fn total_collateral_value(supplier: &T::AccountId) -> Result<Amount<T>, DispatchError> {
+        let mut total_asset_value = Amount::<T>::zero(T::ReferenceAssetId::get());
         for (asset_id, _market) in Self::active_markets() {
-            total_asset_value = total_asset_value
-                .checked_add(&Self::collateral_asset_value(supplier, asset_id)?)
-                .ok_or(ArithmeticError::Overflow)?;
+            total_asset_value = total_asset_value.checked_add(&Self::collateral_asset_value(supplier, asset_id)?)?;
         }
 
         Ok(total_asset_value)
     }
 
-    fn total_liquidation_threshold_value(borrower: &T::AccountId) -> Result<FixedU128, DispatchError> {
-        let mut total_asset_value: FixedU128 = FixedU128::zero();
+    fn total_liquidation_threshold_value(borrower: &T::AccountId) -> Result<Amount<T>, DispatchError> {
+        let mut total_asset_value = Amount::<T>::zero(T::ReferenceAssetId::get());
         for (asset_id, _market) in Self::active_markets() {
-            total_asset_value = total_asset_value
-                .checked_add(&Self::liquidation_threshold_asset_value(borrower, asset_id)?)
-                .ok_or(ArithmeticError::Overflow)?;
+            total_asset_value =
+                total_asset_value.checked_add(&Self::liquidation_threshold_asset_value(borrower, asset_id)?)?;
         }
 
         Ok(total_asset_value)
@@ -1330,7 +1332,7 @@ impl<T: Config> Pallet<T> {
             target: "loans::redeem_allowed",
             "redeem_amount: {:?}, redeem_effects_value: {:?}",
             redeem_amount,
-            redeem_effects_value.into_inner(),
+            redeem_effects_value.amount(),
         );
 
         Self::ensure_liquidity(redeemer, redeem_effects_value)?;
@@ -1471,7 +1473,7 @@ impl<T: Config> Pallet<T> {
             repay_amount,
             market
         );
-        let (_, shortfall) = Self::get_account_liquidation_threshold_liquidity(borrower)?;
+        let AccountLiquidity { shortfall, .. } = Self::get_account_liquidation_threshold_liquidity(borrower)?;
 
         // C_other >= B_other + B_dot_over
         // C_other >= B_other
@@ -1484,10 +1486,10 @@ impl<T: Config> Pallet<T> {
 
         // The liquidator may not repay more than 50%(close_factor) of the borrower's borrow balance.
         let account_borrows = Self::current_borrow_balance(borrower, liquidation_asset_id)?;
-        let account_borrows_value = Self::get_asset_value(liquidation_asset_id, account_borrows)?;
-        let repay_value = Self::get_asset_value(liquidation_asset_id, repay_amount)?;
+        let account_borrows_value = Self::get_asset_value(liquidation_asset_id, account_borrows)?.amount();
+        let repay_value = Self::get_asset_value(liquidation_asset_id, repay_amount)?.amount();
 
-        if market.close_factor.mul_ceil(account_borrows_value.into_inner()) < repay_value.into_inner() {
+        if market.close_factor.mul_ceil(account_borrows_value) < repay_value {
             return Err(Error::<T>::TooMuchRepay.into());
         }
 
@@ -1531,17 +1533,14 @@ impl<T: Config> Pallet<T> {
         let collateral_value = Self::get_asset_value(collateral_asset_id, borrower_deposit_amount)?;
         // liquidate_value contains the incentive of liquidator and the punishment of the borrower
         let liquidate_value = Self::get_asset_value(liquidation_asset_id, repay_amount)?
-            .checked_mul(&market.liquidate_incentive)
-            .ok_or(ArithmeticError::Overflow)?;
+            .checked_fixed_point_mul(&market.liquidate_incentive)?;
 
-        if collateral_value < liquidate_value {
+        if collateral_value.lt(&liquidate_value)? {
             return Err(Error::<T>::InsufficientCollateral.into());
         }
 
         // Calculate the collateral will get
-        let liquidate_value_amount =
-            Amount::<T>::from_unsigned_fixed_point(liquidate_value, T::ReferenceAssetId::get())?;
-        let real_collateral_underlying_amount = liquidate_value_amount.convert_to(collateral_asset_id)?.amount();
+        let real_collateral_underlying_amount = liquidate_value.convert_to(collateral_asset_id)?.amount();
 
         //inside transfer token
         Self::liquidated_transfer(
@@ -1731,9 +1730,9 @@ impl<T: Config> Pallet<T> {
     // Returns `Err` If InsufficientLiquidity
     // `account`: account that need a liquidity check
     // `reduce_amount`: values that will have an impact on liquidity
-    fn ensure_liquidity(account: &T::AccountId, reduce_amount: FixedU128) -> DispatchResult {
-        let (total_liquidity, _) = Self::get_account_liquidity(account)?;
-        if total_liquidity >= reduce_amount {
+    fn ensure_liquidity(account: &T::AccountId, reduce_amount: Amount<T>) -> DispatchResult {
+        let AccountLiquidity { liquidity, .. } = Self::get_account_liquidity(account)?;
+        if liquidity.ge(&reduce_amount)? {
             return Ok(());
         }
         Err(Error::<T>::InsufficientLiquidity.into())
@@ -1796,10 +1795,9 @@ impl<T: Config> Pallet<T> {
 
     // Returns the value of the asset, in the reference currency.
     // Returns `Err` if oracle price not ready or arithmetic error.
-    pub fn get_asset_value(asset_id: AssetIdOf<T>, amount: BalanceOf<T>) -> Result<FixedU128, DispatchError> {
+    pub fn get_asset_value(asset_id: AssetIdOf<T>, amount: BalanceOf<T>) -> Result<Amount<T>, DispatchError> {
         let asset_amount = Amount::<T>::new(amount, asset_id);
-        let reference_amount = asset_amount.convert_to(T::ReferenceAssetId::get())?;
-        reference_amount.to_unsigned_fixed_point()
+        asset_amount.convert_to(T::ReferenceAssetId::get())
     }
 
     // Returns a stored Market.
@@ -1949,16 +1947,12 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
         log::trace!(
             target: "loans::collateral_asset",
             "total_collateral_value: {:?}, collateral_asset_value: {:?}, total_borrowed_value: {:?}",
-            total_collateral_value.into_inner(),
-            collateral_amount_value.into_inner(),
-            total_borrowed_value.into_inner(),
+            total_collateral_value.amount(),
+            collateral_amount_value.amount(),
+            total_borrowed_value.amount(),
         );
 
-        if total_collateral_value
-            < total_borrowed_value
-                .checked_add(&collateral_amount_value)
-                .ok_or(ArithmeticError::Overflow)?
-        {
+        if total_collateral_value.lt(&total_borrowed_value.checked_add(&collateral_amount_value)?)? {
             return Err(Error::<T>::InsufficientLiquidity.into());
         }
 

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -1227,13 +1227,12 @@ impl<T: Config> Pallet<T> {
 
     fn collateral_asset_value(supplier: &T::AccountId, asset_id: AssetIdOf<T>) -> Result<Amount<T>, DispatchError> {
         let lend_token_id = Self::lend_token_id(asset_id)?;
-        let zero = Amount::<T>::zero(T::ReferenceAssetId::get());
         if !AccountDeposits::<T>::contains_key(lend_token_id, supplier) {
-            return Ok(zero);
+            return Ok(Amount::<T>::zero(T::ReferenceAssetId::get()));
         }
         let deposits = Self::account_deposits(lend_token_id, supplier);
         if deposits.is_zero() {
-            return Ok(zero);
+            return Ok(Amount::<T>::zero(T::ReferenceAssetId::get()));
         }
         Self::collateral_amount_value(asset_id, deposits)
     }
@@ -1243,13 +1242,12 @@ impl<T: Config> Pallet<T> {
         asset_id: AssetIdOf<T>,
     ) -> Result<Amount<T>, DispatchError> {
         let lend_token_id = Self::lend_token_id(asset_id)?;
-        let zero = Amount::<T>::zero(T::ReferenceAssetId::get());
         if !AccountDeposits::<T>::contains_key(lend_token_id, borrower) {
-            return Ok(zero);
+            return Ok(Amount::<T>::zero(T::ReferenceAssetId::get()));
         }
         let deposits = Self::account_deposits(lend_token_id, borrower);
         if deposits.is_zero() {
-            return Ok(zero);
+            return Ok(Amount::<T>::zero(T::ReferenceAssetId::get()));
         }
         let exchange_rate = Self::exchange_rate_stored(asset_id)?;
         let underlying_amount = Self::calc_underlying_amount(deposits, exchange_rate)?;

--- a/crates/loans/src/mock.rs
+++ b/crates/loans/src/mock.rs
@@ -219,12 +219,12 @@ pub fn with_price(
         let (custom_currency, custom_price) = maybe_currency_price.unwrap_or((amount.currency(), FixedU128::one()));
         match (amount.currency(), to) {
             currencies if currencies == (custom_currency, DEFAULT_WRAPPED_CURRENCY) => {
-                let fixed_point_amount = amount.to_unsigned_fixed_point();
+                let fixed_point_amount = amount.to_unsigned_fixed_point().unwrap();
                 let new_amount = fixed_point_amount.mul(custom_price);
                 return MockResult::Return(Amount::from_unsigned_fixed_point(new_amount, to));
             }
             currencies if currencies == (DEFAULT_WRAPPED_CURRENCY, custom_currency) => {
-                let fixed_point_amount = amount.to_unsigned_fixed_point();
+                let fixed_point_amount = amount.to_unsigned_fixed_point().unwrap();
                 let new_amount = fixed_point_amount.div(custom_price);
                 return MockResult::Return(Amount::from_unsigned_fixed_point(new_amount, to));
             }

--- a/crates/loans/src/mock.rs
+++ b/crates/loans/src/mock.rs
@@ -219,17 +219,20 @@ pub fn with_price(
         let (custom_currency, custom_price) = maybe_currency_price.unwrap_or((amount.currency(), FixedU128::one()));
         match (amount.currency(), to) {
             currencies if currencies == (custom_currency, DEFAULT_WRAPPED_CURRENCY) => {
-                let fixed_point_amount = amount.to_unsigned_fixed_point().unwrap();
+                let fixed_point_amount = amount.to_unsigned_fixed_point();
                 let new_amount = fixed_point_amount.mul(custom_price);
                 return MockResult::Return(Amount::from_unsigned_fixed_point(new_amount, to));
             }
             currencies if currencies == (DEFAULT_WRAPPED_CURRENCY, custom_currency) => {
-                let fixed_point_amount = amount.to_unsigned_fixed_point().unwrap();
+                let fixed_point_amount = amount.to_unsigned_fixed_point();
                 let new_amount = fixed_point_amount.div(custom_price);
                 return MockResult::Return(Amount::from_unsigned_fixed_point(new_amount, to));
             }
             // The default is a 1:1 exchange rate
-            (_, currency) | (currency, _) if currency == DEFAULT_WRAPPED_CURRENCY => {
+            (_, currency) if currency == DEFAULT_WRAPPED_CURRENCY => {
+                return MockResult::Return(Ok(Amount::new(amount.amount(), DEFAULT_WRAPPED_CURRENCY)));
+            }
+            (currency, _) if currency == DEFAULT_WRAPPED_CURRENCY => {
                 return MockResult::Return(Ok(amount.clone()));
             }
             (_, _) => return MockResult::Return(Err(Error::<Test>::InvalidExchangeRate.into())),

--- a/crates/loans/src/rate_model.rs
+++ b/crates/loans/src/rate_model.rs
@@ -153,7 +153,7 @@ pub struct CurveModel {
 }
 
 impl CurveModel {
-    pub const MAX_BASE_RATE: Rate = Rate::from_inner(Rate::DIV / 100 * 10); // 10%
+    pub const MAX_BASE_RATE: Rate = Rate::from_inner(100_000_000_000_000_000); // 10%
 
     /// Create a new curve model
     pub fn new_model(base_rate: Rate) -> CurveModel {

--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -513,9 +513,10 @@ fn get_account_liquidity_works() {
         Loans::mint(RuntimeOrigin::signed(ALICE), IBTC, unit(200)).unwrap();
         Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), IBTC).unwrap();
 
-        let AccountLiquidity { liquidity, .. } = Loans::get_account_liquidity(&ALICE).unwrap();
-
-        assert_eq!(liquidity.amount(), unit(100));
+        assert_eq!(
+            Loans::get_account_liquidity(&ALICE).unwrap().liquidity().amount(),
+            unit(100)
+        );
     })
 }
 
@@ -534,16 +535,18 @@ fn get_account_liquidation_threshold_liquidity_works() {
         Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, unit(100)).unwrap();
         Loans::borrow(RuntimeOrigin::signed(ALICE), DOT, unit(100)).unwrap();
 
-        let AccountLiquidity { liquidity, .. } = Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
-
-        assert_eq!(liquidity.amount(), unit(20));
+        assert_eq!(
+            Loans::get_account_liquidation_threshold_liquidity(&ALICE)
+                .unwrap()
+                .liquidity()
+                .amount(),
+            unit(20)
+        );
 
         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
-        let AccountLiquidity { liquidity, shortfall } =
-            Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
-
-        assert_eq!(liquidity.amount(), unit(0));
-        assert_eq!(shortfall.amount(), unit(80));
+        let account_liquidity = Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
+        assert_eq!(account_liquidity.liquidity().amount(), unit(0));
+        assert_eq!(account_liquidity.shortfall().amount(), unit(80));
     })
 }
 

--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -513,9 +513,9 @@ fn get_account_liquidity_works() {
         Loans::mint(RuntimeOrigin::signed(ALICE), IBTC, unit(200)).unwrap();
         Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), IBTC).unwrap();
 
-        let (liquidity, _) = Loans::get_account_liquidity(&ALICE).unwrap();
+        let AccountLiquidity { liquidity, .. } = Loans::get_account_liquidity(&ALICE).unwrap();
 
-        assert_eq!(liquidity, FixedU128::from_inner(unit(100)));
+        assert_eq!(liquidity.to_unsigned_fixed_point(), FixedU128::from_inner(unit(100)));
     })
 }
 
@@ -534,15 +534,16 @@ fn get_account_liquidation_threshold_liquidity_works() {
         Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, unit(100)).unwrap();
         Loans::borrow(RuntimeOrigin::signed(ALICE), DOT, unit(100)).unwrap();
 
-        let (liquidity, _) = Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
+        let AccountLiquidity { liquidity, .. } = Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
 
-        assert_eq!(liquidity, FixedU128::from_inner(unit(20)));
+        assert_eq!(liquidity.to_unsigned_fixed_point(), FixedU128::from_inner(unit(20)));
 
         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
-        let (liquidity, shortfall) = Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
+        let AccountLiquidity { liquidity, shortfall } =
+            Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
 
-        assert_eq!(liquidity, FixedU128::from_inner(unit(0)));
-        assert_eq!(shortfall, FixedU128::from_inner(unit(80)));
+        assert_eq!(liquidity.to_unsigned_fixed_point(), FixedU128::from_inner(unit(0)));
+        assert_eq!(shortfall.to_unsigned_fixed_point(), FixedU128::from_inner(unit(80)));
     })
 }
 
@@ -679,7 +680,7 @@ fn total_collateral_value_works() {
         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), DOT));
         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), KSM));
         assert_eq!(
-            Loans::total_collateral_value(&ALICE).unwrap(),
+            Loans::total_collateral_value(&ALICE).unwrap().to_unsigned_fixed_point(),
             (collateral_factor.saturating_mul(FixedU128::from_inner(unit(100) + unit(200))))
         );
     })

--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -515,7 +515,7 @@ fn get_account_liquidity_works() {
 
         let AccountLiquidity { liquidity, .. } = Loans::get_account_liquidity(&ALICE).unwrap();
 
-        assert_eq!(liquidity.to_unsigned_fixed_point(), FixedU128::from_inner(unit(100)));
+        assert_eq!(liquidity.amount(), unit(100));
     })
 }
 
@@ -536,14 +536,14 @@ fn get_account_liquidation_threshold_liquidity_works() {
 
         let AccountLiquidity { liquidity, .. } = Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
 
-        assert_eq!(liquidity.to_unsigned_fixed_point(), FixedU128::from_inner(unit(20)));
+        assert_eq!(liquidity.amount(), unit(20));
 
         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
         let AccountLiquidity { liquidity, shortfall } =
             Loans::get_account_liquidation_threshold_liquidity(&ALICE).unwrap();
 
-        assert_eq!(liquidity.to_unsigned_fixed_point(), FixedU128::from_inner(unit(0)));
-        assert_eq!(shortfall.to_unsigned_fixed_point(), FixedU128::from_inner(unit(80)));
+        assert_eq!(liquidity.amount(), unit(0));
+        assert_eq!(shortfall.amount(), unit(80));
     })
 }
 
@@ -679,9 +679,13 @@ fn total_collateral_value_works() {
         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), USDT, unit(300)));
         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), DOT));
         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), KSM));
+        let fixed_u128_collateral = FixedU128::checked_from_integer(unit(100) + unit(200)).unwrap();
         assert_eq!(
-            Loans::total_collateral_value(&ALICE).unwrap().to_unsigned_fixed_point(),
-            (collateral_factor.saturating_mul(FixedU128::from_inner(unit(100) + unit(200))))
+            Loans::total_collateral_value(&ALICE)
+                .unwrap()
+                .to_unsigned_fixed_point()
+                .unwrap(),
+            collateral_factor.saturating_mul(fixed_u128_collateral)
         );
     })
 }

--- a/crates/loans/src/types.rs
+++ b/crates/loans/src/types.rs
@@ -4,7 +4,7 @@ use frame_support::pallet_prelude::*;
 use primitives::{CurrencyId, Liquidity, Rate, Ratio, Shortfall};
 use scale_info::TypeInfo;
 
-/// Container for borrow balance information
+/// Container for account liquidity information
 #[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo)]
 pub struct AccountLiquidity<T: Config> {
     pub liquidity: Amount<T>,

--- a/crates/loans/src/types.rs
+++ b/crates/loans/src/types.rs
@@ -1,7 +1,24 @@
-use crate::InterestRateModel;
+use crate::{Config, InterestRateModel};
+use currency::Amount;
 use frame_support::pallet_prelude::*;
-use primitives::{CurrencyId, Rate, Ratio};
+use primitives::{CurrencyId, Liquidity, Rate, Ratio, Shortfall};
 use scale_info::TypeInfo;
+
+/// Container for borrow balance information
+#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo)]
+pub struct AccountLiquidity<T: Config> {
+    pub liquidity: Amount<T>,
+    pub shortfall: Amount<T>,
+}
+
+impl<T: Config> AccountLiquidity<T> {
+    pub fn to_rpc_tuple(&self) -> (Liquidity, Shortfall) {
+        (
+            self.liquidity.to_unsigned_fixed_point(),
+            self.shortfall.to_unsigned_fixed_point(),
+        )
+    }
+}
 
 /// Container for borrow balance information
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, Default, TypeInfo)]

--- a/crates/loans/src/types.rs
+++ b/crates/loans/src/types.rs
@@ -12,11 +12,11 @@ pub struct AccountLiquidity<T: Config> {
 }
 
 impl<T: Config> AccountLiquidity<T> {
-    pub fn to_rpc_tuple(&self) -> (Liquidity, Shortfall) {
-        (
-            self.liquidity.to_unsigned_fixed_point(),
-            self.shortfall.to_unsigned_fixed_point(),
-        )
+    pub fn to_rpc_tuple(&self) -> Result<(Liquidity, Shortfall), DispatchError> {
+        Ok((
+            self.liquidity.to_unsigned_fixed_point()?,
+            self.shortfall.to_unsigned_fixed_point()?,
+        ))
     }
 }
 

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -1481,7 +1481,7 @@ impl_runtime_apis! {
         Balance,
     > for Runtime {
         fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidity(&account)
+            Loans::get_account_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
         }
 
         fn get_market_status(asset_id: CurrencyId) -> Result<(Rate, Rate, Rate, Ratio, Balance, Balance, FixedU128), DispatchError> {
@@ -1489,7 +1489,7 @@ impl_runtime_apis! {
         }
 
         fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidation_threshold_liquidity(&account)
+            Loans::get_account_liquidation_threshold_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
         }
     }
 

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -1481,7 +1481,8 @@ impl_runtime_apis! {
         Balance,
     > for Runtime {
         fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
+            Loans::get_account_liquidity(&account)
+            .and_then(|liquidity| liquidity.to_rpc_tuple())
         }
 
         fn get_market_status(asset_id: CurrencyId) -> Result<(Rate, Rate, Rate, Ratio, Balance, Balance, FixedU128), DispatchError> {
@@ -1489,7 +1490,8 @@ impl_runtime_apis! {
         }
 
         fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidation_threshold_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
+            Loans::get_account_liquidation_threshold_liquidity(&account)
+            .and_then(|liquidity| liquidity.to_rpc_tuple())
         }
     }
 

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -1480,7 +1480,8 @@ impl_runtime_apis! {
         Balance,
     > for Runtime {
         fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-           Loans::get_account_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
+           Loans::get_account_liquidity(&account)
+            .and_then(|liquidity| liquidity.to_rpc_tuple())
         }
 
         fn get_market_status(asset_id: CurrencyId) -> Result<(Rate, Rate, Rate, Ratio, Balance, Balance, FixedU128), DispatchError> {
@@ -1488,7 +1489,8 @@ impl_runtime_apis! {
         }
 
         fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidation_threshold_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
+            Loans::get_account_liquidation_threshold_liquidity(&account)
+            .and_then(|liquidity| liquidity.to_rpc_tuple())
         }
     }
 

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -1480,7 +1480,7 @@ impl_runtime_apis! {
         Balance,
     > for Runtime {
         fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidity(&account)
+           Loans::get_account_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
         }
 
         fn get_market_status(asset_id: CurrencyId) -> Result<(Rate, Rate, Rate, Ratio, Balance, Balance, FixedU128), DispatchError> {
@@ -1488,7 +1488,7 @@ impl_runtime_apis! {
         }
 
         fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidation_threshold_liquidity(&account)
+            Loans::get_account_liquidation_threshold_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
         }
     }
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1440,7 +1440,8 @@ impl_runtime_apis! {
         Balance,
     > for Runtime {
         fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
+            Loans::get_account_liquidity(&account)
+            .and_then(|liquidity| liquidity.to_rpc_tuple())
         }
 
         fn get_market_status(asset_id: CurrencyId) -> Result<(Rate, Rate, Rate, Ratio, Balance, Balance, FixedU128), DispatchError> {
@@ -1448,7 +1449,8 @@ impl_runtime_apis! {
         }
 
         fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidation_threshold_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
+            Loans::get_account_liquidation_threshold_liquidity(&account)
+            .and_then(|liquidity| liquidity.to_rpc_tuple())
         }
     }
 }

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1440,7 +1440,7 @@ impl_runtime_apis! {
         Balance,
     > for Runtime {
         fn get_account_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidity(&account)
+            Loans::get_account_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
         }
 
         fn get_market_status(asset_id: CurrencyId) -> Result<(Rate, Rate, Rate, Ratio, Balance, Balance, FixedU128), DispatchError> {
@@ -1448,7 +1448,7 @@ impl_runtime_apis! {
         }
 
         fn get_liquidation_threshold_liquidity(account: AccountId) -> Result<(Liquidity, Shortfall), DispatchError> {
-            Loans::get_account_liquidation_threshold_liquidity(&account)
+            Loans::get_account_liquidation_threshold_liquidity(&account).map(|liquidity| liquidity.to_rpc_tuple())
         }
     }
 }


### PR DESCRIPTION
Replaces many uses of `FixedU128` with `Amount<T>`, based on this [feedback piece](https://github.com/interlay/interbtc/pull/785#discussion_r1029366161).

Since to an extent it completes https://github.com/interlay/interbtc/issues/751 I will close it with this PR, and leave the rest of the work for https://github.com/interlay/interbtc/issues/755.
Closes https://github.com/interlay/interbtc/issues/751