### PR TITLE
feat: table two proposals on monday

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,11 +2063,13 @@ dependencies = [
 name = "democracy"
 version = "1.2.0"
 dependencies = [
+ "chrono",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",
  "pallet-scheduler",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/crates/democracy/Cargo.toml
+++ b/crates/democracy/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.130", default-features = false, features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
+chrono = {version = "0.4.23", default-features = false }
 
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
@@ -29,6 +30,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31" }
 
 [features]
 default = ["std"]

--- a/crates/democracy/src/benchmarking.rs
+++ b/crates/democracy/src/benchmarking.rs
@@ -42,7 +42,7 @@ fn add_referendum<T: Config>(n: u32) -> Result<ReferendumIndex, &'static str> {
     let proposal_hash: T::Hash = T::Hashing::hash_of(&n);
     let vote_threshold = VoteThreshold::SimpleMajority;
 
-    Democracy::<T>::inject_referendum(T::LaunchPeriod::get(), proposal_hash, vote_threshold, 0u32.into());
+    Democracy::<T>::inject_referendum(T::VotingPeriod::get(), proposal_hash, vote_threshold, 0u32.into());
     let referendum_index: ReferendumIndex = ReferendumCount::<T>::get() - 1;
     T::Scheduler::schedule_named(
         (DEMOCRACY_ID, referendum_index).encode(),
@@ -198,7 +198,7 @@ benchmarks! {
         // Launch public
         assert!(add_proposal::<T>(r).is_ok(), "proposal not created");
 
-        let block_number = T::LaunchPeriod::get();
+        let block_number = T::VotingPeriod::get();
 
     }: { Democracy::<T>::on_initialize(block_number) }
     verify {
@@ -264,7 +264,7 @@ benchmarks! {
         assert_eq!(Democracy::<T>::referendum_count(), r, "referenda not created");
         assert_eq!(Democracy::<T>::lowest_unbaked(), 0, "invalid referenda init");
 
-        let block_number = T::LaunchPeriod::get();
+        let block_number = T::VotingPeriod::get();
 
     }: { Democracy::<T>::on_initialize(block_number) }
     verify {

--- a/crates/democracy/src/lib.rs
+++ b/crates/democracy/src/lib.rs
@@ -1091,6 +1091,8 @@ impl<T: Config> Pallet<T> {
             // full block weight.
             if Self::launch_next(now).is_ok() {
                 weight = max_block_weight;
+                // try to launch another one. We ignore the result since weight can't increase beyond max_block_weight
+                let _ = Self::launch_next(now);
             } else {
                 weight = weight.saturating_add(T::WeightInfo::on_initialize_base_with_launch_period(r));
             }

--- a/crates/democracy/src/lib.rs
+++ b/crates/democracy/src/lib.rs
@@ -1127,7 +1127,7 @@ impl<T: Config> Pallet<T> {
         let next_week = beginning_of_week
             .checked_add_days(Days::new(7))
             .ok_or(Error::<T>::TryIntoIntError)?
-            .and_time(NaiveTime::default());
+            .and_time(NaiveTime::from_hms_opt(9, 0, 0).ok_or(Error::<T>::TryIntoIntError)?); // 9 AM UTC
 
         // update storage
         let next_timestamp: u64 = next_week.timestamp().try_into()?;

--- a/crates/democracy/src/tests.rs
+++ b/crates/democracy/src/tests.rs
@@ -136,6 +136,7 @@ parameter_types! {
     pub const MaxVotes: u32 = 100;
     pub const MaxProposals: u32 = MAX_PROPOSALS;
     pub static PreimageByteDeposit: u64 = 0;
+    pub LaunchOffsetMillis: u64 = 9 * 60 * 60 * 1000; // 9 hours offset, i.e. MON 9 AM
 }
 ord_parameter_types! {
     pub const One: u64 = 1;
@@ -171,6 +172,8 @@ impl Config for Test {
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
     type UnixTime = Timestamp;
+    type Moment = u64;
+    type LaunchOffsetMillis = LaunchOffsetMillis;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/crates/democracy/src/tests.rs
+++ b/crates/democracy/src/tests.rs
@@ -287,9 +287,9 @@ fn should_launch_works() {
         let arbitrary_timestamp = 1670864631; // Mon Dec 12 2022 17:03:51 UTC
 
         let week_boundaries = [
-            1671408000, // Mon Dec 19 2022 00:00:00 UTC
-            1672012800, // Mon Dec 26 2022 00:00:00
-            1672617600, // Mon Jan 02 2023 00:00:00
+            1671440400, // Mon Dec 19 2022 09:00:00 UTC
+            1672045200, // Mon Dec 26 2022 09:00:00 UTC
+            1672650000, // Mon Jan 02 2023 09:00:00 UTC
         ];
         // first launch immediately after launch of chain / first runtime upgrade
         assert!(Democracy::should_launch(Duration::from_secs(arbitrary_timestamp)).unwrap());
@@ -304,5 +304,26 @@ fn should_launch_works() {
             assert!(Democracy::should_launch(Duration::from_secs(boundary)).unwrap());
             assert!(!Democracy::should_launch(Duration::from_secs(boundary)).unwrap());
         }
+    });
+}
+
+#[test]
+fn should_launch_edge_case_behavior() {
+    new_test_ext().execute_with(|| {
+        // test edge case where we launch on monday before 9 am. Next launch will be
+        // in slightly more than 7 days
+        let initial_launch = 1670828400; // Mon Dec 12 2022 07:00:00 UTC
+        let next_launch = 1671440400; // Mon Dec 19 2022 09:00:00 UTC
+
+        // first launch immediately after launch of chain / first runtime upgrade
+        assert!(Democracy::should_launch(Duration::from_secs(initial_launch)).unwrap());
+        assert!(!Democracy::should_launch(Duration::from_secs(initial_launch)).unwrap());
+
+        // one second before the next week it should still return false
+        assert!(!Democracy::should_launch(Duration::from_secs(next_launch - 1)).unwrap());
+
+        // first second of next week it should return true exactly once
+        assert!(Democracy::should_launch(Duration::from_secs(next_launch)).unwrap());
+        assert!(!Democracy::should_launch(Duration::from_secs(next_launch)).unwrap());
     });
 }

--- a/crates/democracy/src/tests/voting.rs
+++ b/crates/democracy/src/tests/voting.rs
@@ -21,15 +21,15 @@ fn single_proposal_should_work() {
         let r = 0;
         assert!(Democracy::referendum_info(r).is_none());
 
-        // start of 2 => next referendum scheduled.
-        fast_forward_to(2);
+        // start of 1 => next referendum scheduled.
+        fast_forward_to(1);
         assert_ok!(Democracy::vote(RuntimeOrigin::signed(1), r, aye(1)));
 
         assert_eq!(Democracy::referendum_count(), 1);
         assert_eq!(
             Democracy::referendum_status(0),
             Ok(ReferendumStatus {
-                end: 4,
+                end: 3,
                 proposal_hash: set_balance_proposal_hash_and_note(2),
                 threshold: VoteThreshold::SuperMajorityAgainst,
                 delay: 2,
@@ -41,19 +41,19 @@ fn single_proposal_should_work() {
             })
         );
 
-        fast_forward_to(3);
+        fast_forward_to(2);
 
         // referendum still running
         assert_ok!(Democracy::referendum_status(0));
 
-        // referendum runs during 2 and 3, ends @ start of 4.
-        fast_forward_to(4);
+        // referendum runs during 1 and 2, ends @ start of 3.
+        fast_forward_to(3);
 
         assert_noop!(Democracy::referendum_status(0), Error::<Test>::ReferendumInvalid);
-        assert!(pallet_scheduler::Agenda::<Test>::get(6)[0].is_some());
+        assert!(pallet_scheduler::Agenda::<Test>::get(5)[0].is_some());
 
         // referendum passes and wait another two blocks for enactment.
-        fast_forward_to(6);
+        fast_forward_to(5);
 
         assert_eq!(Balances::free_balance(42), 2);
     });

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -370,7 +370,7 @@ pub mod pallet {
         }
 
         #[cfg(feature = "try-runtime")]
-        fn post_upgrade(_pre_upgrade_state: Vec<u8>) -> Result<(), &'static str> {
+        fn post_upgrade(_pre_upgrade_state: sp_std::vec::Vec<u8>) -> Result<(), &'static str> {
             let max_exchange_rate = crate::MaxExchangeRate::<T>::get();
             let min_exchange_rate = crate::MinExchangeRate::<T>::get();
             ensure!(

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -468,6 +468,7 @@ parameter_types! {
     pub PreimageByteDeposit: Balance = 10 * MILLICENTS;
     pub const MaxVotes: u32 = 100;
     pub const MaxProposals: u32 = 100;
+    pub LaunchOffsetMillis: u64 = 9 * 60 * 60 * 1000; // 9 hours offset, i.e. MON 9 AM
 }
 
 impl democracy::Config for Runtime {
@@ -489,6 +490,8 @@ impl democracy::Config for Runtime {
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
     type UnixTime = Timestamp;
+    type Moment = Moment;
+    type LaunchOffsetMillis = LaunchOffsetMillis;
 }
 
 parameter_types! {

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -459,7 +459,6 @@ type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
 >;
 
 parameter_types! {
-    pub const LaunchPeriod: BlockNumber = 7 * DAYS;
     pub const VotingPeriod: BlockNumber = 7 * DAYS;
     pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
     // Require 250 vINTR to make a proposal. Given the crowdloan airdrop, this qualifies about 7500
@@ -476,7 +475,6 @@ impl democracy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Escrow;
     type EnactmentPeriod = EnactmentPeriod;
-    type LaunchPeriod = LaunchPeriod;
     type VotingPeriod = VotingPeriod;
     type MinimumDeposit = MinimumDeposit;
     /// The technical committee can have any proposal be tabled immediately
@@ -490,6 +488,7 @@ impl democracy::Config for Runtime {
     type MaxVotes = MaxVotes;
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
+    type UnixTime = Timestamp;
 }
 
 parameter_types! {

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -468,6 +468,7 @@ parameter_types! {
     pub PreimageByteDeposit: Balance = 10 * MILLICENTS;
     pub const MaxVotes: u32 = 100;
     pub const MaxProposals: u32 = 100;
+    pub LaunchOffsetMillis: u64 = 9 * 60 * 60 * 1000; // 9 hours offset, i.e. MON 9 AM
 }
 
 impl democracy::Config for Runtime {
@@ -489,6 +490,8 @@ impl democracy::Config for Runtime {
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
     type UnixTime = Timestamp;
+    type Moment = Moment;
+    type LaunchOffsetMillis = LaunchOffsetMillis;
 }
 
 parameter_types! {

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -458,7 +458,6 @@ type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
 >;
 
 parameter_types! {
-    pub const LaunchPeriod: BlockNumber = 7 * DAYS;
     pub const VotingPeriod: BlockNumber = 2 * DAYS;
     pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
     // Require 5 vKINT to make a proposal. Given the crowdloan airdrop, this qualifies about 3500
@@ -476,7 +475,6 @@ impl democracy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Escrow;
     type EnactmentPeriod = EnactmentPeriod;
-    type LaunchPeriod = LaunchPeriod;
     type VotingPeriod = VotingPeriod;
     type MinimumDeposit = MinimumDeposit;
     /// The technical committee can have any proposal be tabled immediately
@@ -490,6 +488,7 @@ impl democracy::Config for Runtime {
     type MaxVotes = MaxVotes;
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
+    type UnixTime = Timestamp;
 }
 
 parameter_types! {

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -432,7 +432,6 @@ type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
 >;
 
 parameter_types! {
-    pub const LaunchPeriod: BlockNumber = 7 * DAYS;
     pub const VotingPeriod: BlockNumber = 7 * DAYS;
     pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
     // Require 5 vKINT to make a proposal. Given the crowdloan airdrop, this qualifies about 3500
@@ -450,7 +449,6 @@ impl democracy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Escrow;
     type EnactmentPeriod = EnactmentPeriod;
-    type LaunchPeriod = LaunchPeriod;
     type VotingPeriod = VotingPeriod;
     type MinimumDeposit = MinimumDeposit;
     /// The technical committee can have any proposal be tabled immediately
@@ -464,6 +462,7 @@ impl democracy::Config for Runtime {
     type MaxVotes = MaxVotes;
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
+    type UnixTime = Timestamp;
 }
 
 parameter_types! {

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -442,6 +442,7 @@ parameter_types! {
     pub PreimageByteDeposit: Balance = 10 * MILLICENTS;
     pub const MaxVotes: u32 = 100;
     pub const MaxProposals: u32 = 100;
+    pub LaunchOffsetMillis: u64 = 9 * 60 * 60 * 1000; // 9 hours offset, i.e. MON 9 AM
 }
 
 impl democracy::Config for Runtime {
@@ -463,6 +464,8 @@ impl democracy::Config for Runtime {
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
     type UnixTime = Timestamp;
+    type Moment = Moment;
+    type LaunchOffsetMillis = LaunchOffsetMillis;
 }
 
 parameter_types! {

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -432,7 +432,6 @@ type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
 >;
 
 parameter_types! {
-    pub const LaunchPeriod: BlockNumber = 7 * DAYS;
     pub const VotingPeriod: BlockNumber = 2 * DAYS;
     pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
     // Require 5 vKINT to make a proposal. Given the crowdloan airdrop, this qualifies about 3500
@@ -450,7 +449,6 @@ impl democracy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Escrow;
     type EnactmentPeriod = EnactmentPeriod;
-    type LaunchPeriod = LaunchPeriod;
     type VotingPeriod = VotingPeriod;
     type MinimumDeposit = MinimumDeposit;
     /// The technical committee can have any proposal be tabled immediately
@@ -464,6 +462,7 @@ impl democracy::Config for Runtime {
     type MaxVotes = MaxVotes;
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
+    type UnixTime = Timestamp;
 }
 
 parameter_types! {

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -442,6 +442,7 @@ parameter_types! {
     pub PreimageByteDeposit: Balance = 10 * MILLICENTS;
     pub const MaxVotes: u32 = 100;
     pub const MaxProposals: u32 = 100;
+    pub LaunchOffsetMillis: u64 = 9 * 60 * 60 * 1000; // 9 hours offset, i.e. MON 9 AM
 }
 
 impl democracy::Config for Runtime {
@@ -463,6 +464,8 @@ impl democracy::Config for Runtime {
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
     type UnixTime = Timestamp;
+    type Moment = Moment;
+    type LaunchOffsetMillis = LaunchOffsetMillis;
 }
 
 parameter_types! {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -432,7 +432,6 @@ type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
 >;
 
 parameter_types! {
-    pub const LaunchPeriod: BlockNumber = 2 * MINUTES;
     pub const VotingPeriod: BlockNumber = 5 * MINUTES;
     pub const FastTrackVotingPeriod: BlockNumber = 1 * MINUTES;
     pub MinimumDeposit: Balance = 100 * DOLLARS;
@@ -447,7 +446,6 @@ impl democracy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Escrow;
     type EnactmentPeriod = EnactmentPeriod;
-    type LaunchPeriod = LaunchPeriod;
     type VotingPeriod = VotingPeriod;
     type MinimumDeposit = MinimumDeposit;
     /// The technical committee can have any proposal be tabled immediately
@@ -461,6 +459,7 @@ impl democracy::Config for Runtime {
     type MaxVotes = MaxVotes;
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
+    type UnixTime = Timestamp;
 }
 
 parameter_types! {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -439,6 +439,7 @@ parameter_types! {
     pub PreimageByteDeposit: Balance = 1 * CENTS;
     pub const MaxVotes: u32 = 100;
     pub const MaxProposals: u32 = 100;
+    pub LaunchOffsetMillis: u64 = 9 * 60 * 60 * 1000; // 9 hours offset, i.e. MON 9 AM
 }
 
 impl democracy::Config for Runtime {
@@ -460,6 +461,8 @@ impl democracy::Config for Runtime {
     type WeightInfo = ();
     type MaxProposals = MaxProposals;
     type UnixTime = Timestamp;
+    type Moment = Moment;
+    type LaunchOffsetMillis = LaunchOffsetMillis;
 }
 
 parameter_types! {

--- a/standalone/runtime/tests/test_governance.rs
+++ b/standalone/runtime/tests/test_governance.rs
@@ -138,7 +138,7 @@ fn create_set_balance_proposal(amount_to_set: Balance) -> H256 {
 }
 
 fn launch_and_approve_referendum() -> (BlockNumber, ReferendumIndex) {
-    let start_height = <Runtime as democracy::Config>::LaunchPeriod::get();
+    let start_height = <Runtime as democracy::Config>::VotingPeriod::get();
     DemocracyPallet::on_initialize(start_height);
     let index = assert_democracy_started_event();
 
@@ -338,7 +338,7 @@ fn integration_test_governance_voter_can_change_vote() {
         let amount_to_set = 1000;
         create_set_balance_proposal(amount_to_set);
 
-        let start_height = <Runtime as democracy::Config>::LaunchPeriod::get();
+        let start_height = <Runtime as democracy::Config>::VotingPeriod::get();
         DemocracyPallet::on_initialize(start_height);
         let index = assert_democracy_started_event();
 
@@ -404,7 +404,7 @@ fn integration_test_fast_track_referendum() {
         let amount_to_set = 1000;
         let proposal_hash = create_set_balance_proposal(amount_to_set);
 
-        let start_height = <Runtime as democracy::Config>::LaunchPeriod::get();
+        let start_height = <Runtime as democracy::Config>::VotingPeriod::get();
         DemocracyPallet::on_initialize(start_height);
         let index = assert_democracy_started_event();
 
@@ -446,7 +446,7 @@ fn integration_test_governance_voter_can_change_vote_with_limited_funds() {
         let amount_to_set = 1000;
         create_set_balance_proposal(amount_to_set);
 
-        let start_height = <Runtime as democracy::Config>::LaunchPeriod::get();
+        let start_height = <Runtime as democracy::Config>::VotingPeriod::get();
         DemocracyPallet::on_initialize(start_height);
         let index = assert_democracy_started_event();
 
@@ -565,10 +565,10 @@ fn integration_test_vote_exceeds_total_voting_power() {
     ExtBuilder::build().execute_with(|| {
         set_free_balance(account_of(ALICE), 10_000_000_000_000_000_000_000);
 
-        // we choose a referendum height that is both on a SPAN and LAUNCHPERIOD boundary
+        // we choose a referendum height that is both on a SPAN and VotingPeriod boundary
         let referendum_height =
-            <Runtime as democracy::Config>::LaunchPeriod::get() * <Runtime as escrow::Config>::Span::get();
-        let start_height = referendum_height - <Runtime as democracy::Config>::LaunchPeriod::get();
+            <Runtime as democracy::Config>::VotingPeriod::get() * <Runtime as escrow::Config>::Span::get();
+        let start_height = referendum_height - <Runtime as democracy::Config>::VotingPeriod::get();
         let end_height = start_height + <Runtime as democracy::Config>::VotingPeriod::get();
 
         SystemPallet::set_block_number(start_height);
@@ -607,7 +607,7 @@ fn integration_test_vote_exceeds_total_voting_power() {
 fn integration_test_proposing_and_voting_only_possible_with_staked_tokens() {
     ExtBuilder::build().execute_with(|| {
         let minimum_proposal_value = <Runtime as democracy::Config>::MinimumDeposit::get();
-        let start_height = <Runtime as democracy::Config>::LaunchPeriod::get();
+        let start_height = <Runtime as democracy::Config>::VotingPeriod::get();
 
         // making a proposal to increase Eve's balance without having tokens staked fails
         let amount_to_fund = 100_000;
@@ -747,7 +747,7 @@ fn integration_test_proposal_vkint_gets_released_on_regular_launch() {
             start_vkint_carol - minimum_proposal_value
         );
 
-        DemocracyPallet::on_initialize(<Runtime as democracy::Config>::LaunchPeriod::get());
+        DemocracyPallet::on_initialize(<Runtime as democracy::Config>::VotingPeriod::get());
 
         // now that it's no longer a proposal, the deposit should be released
         assert_eq!(get_free_vkint(account_of(ALICE)), start_vkint_alice);


### PR DESCRIPTION
Tables 2 proposals on week boundaries, i.e. monday morning at 9:00 UTC.

Implementation details: 
- stores the next boundary rather than recalculating it every block. This will be better performance-wise, and will make it easier for external tools to determine when tabling happens
- uses `chrono`
- after running the runtime upgrade, the `NextLaunchTimestamp` will be zero, meaning tabling will happen immediately
- Every time launching should happen, the next one is scheduled to be 7 days after the start of the current week. 
- We don't consider leap seconds since that kind of granularity is not required for us
- If block production stops for whatever reasons, and the week boundary is passed in the meantime, the next block will table the proposals regardless of the day
- Referendum duration remains a fixed number of blocks, so the enactment date still depends on the blocktime
- if launching happens on monday before 9 AM, the next launch will be next week 9AM, (rather than today 9AM). So in this case there will be slightly more than 7 days between tablings

Closes #803