### PR TITLE
fix(loans): accrue interest before changing reserve balances

### DIFF
--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -50,7 +50,10 @@ use sp_runtime::{
     },
     ArithmeticError, FixedPointNumber, FixedU128,
 };
-use sp_std::{marker, result::Result, vec::Vec};
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
+use sp_std::{marker, result::Result};
+
 use traits::{ConvertToBigUint, LoansApi as LoansTrait, LoansMarketDataProvider, MarketInfo, MarketStatus};
 
 pub use orml_traits::currency::{OnDeposit, OnSlash, OnTransfer};

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -1181,15 +1181,13 @@ pub mod pallet {
             asset_id: AssetIdOf<T>,
             #[pallet::compact] redeem_amount: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
-            T::ReserveOrigin::ensure_origin(origin.clone())?;
-            let who = ensure_signed(origin)?;
+            T::ReserveOrigin::ensure_origin(origin)?;
             ensure!(!redeem_amount.is_zero(), Error::<T>::InvalidAmount);
             let receiver = T::Lookup::lookup(receiver)?;
             let from = Self::incentive_reward_account_id()?;
             Self::ensure_active_market(asset_id)?;
             Self::accrue_interest(asset_id)?;
             let exchange_rate = Self::exchange_rate_stored(asset_id)?;
-            Self::update_earned_stored(&who, asset_id, exchange_rate)?;
             let voucher_amount = Self::calc_collateral_amount(redeem_amount, exchange_rate)?;
             let redeem_amount = Self::do_redeem_voucher(&from, asset_id, voucher_amount)?;
 


### PR DESCRIPTION
Started out looking to add tests for the internal exchange rate based on https://github.com/interlay/interbtc/issues/747. I realised that `accrue_interest()` must always have been called before any of the following storage items is read: `TotalBorrows`, `TotalReserves`, `BorrowIndex`. This affects the value of the internal exchange rate, as well as other calculations.

- Decided against creating wrapper getters that auto-accrue interest, because that would make it even less obvious that many of the operations depend on `accrue_interest()` being called first. We will just have to be careful about this with future extensions.
- Improved comments on why `repay_all` uses `saturated_sub` instead of `checked_sub`.
- Included calls to `accrue_interest()` in the extrinsics that change the `TotalReserve`, and also when the reserve's share of liquidated LendTokens is withdrawn.

