### PR TITLE
fix: enable std on zenlink-protocol

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -32,4 +32,6 @@ std = [
     "sp-runtime/std",
 
     "bitcoin/std",
+
+    "zenlink-protocol/std",
 ]


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>