### PR TITLE
feat: add a disabled sudo pallet back in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4330,6 +4330,7 @@ dependencies = [
  "pallet-scheduler",
  "pallet-session",
  "pallet-society",
+ "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",

--- a/parachain/runtime/interlay/Cargo.toml
+++ b/parachain/runtime/interlay/Cargo.toml
@@ -268,6 +268,7 @@ try-runtime = [
   "pallet-preimage/try-runtime",
   "pallet-multisig/try-runtime",
   "pallet-identity/try-runtime",
+  "pallet-sudo/try-runtime",
   "currency/try-runtime",
   "orml-tokens/try-runtime",
   "supply/try-runtime",

--- a/parachain/runtime/kintsugi/Cargo.toml
+++ b/parachain/runtime/kintsugi/Cargo.toml
@@ -41,6 +41,7 @@ pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "
 pallet-multisig = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 pallet-preimage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
 frame-try-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false, optional = true }
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
@@ -166,6 +167,7 @@ std = [
   "pallet-multisig/std",
   "pallet-preimage/std",
   "pallet-identity/std",
+	"pallet-sudo/std",
 
   "frame-system-rpc-runtime-api/std",
   "pallet-transaction-payment-rpc-runtime-api/std",
@@ -263,8 +265,7 @@ try-runtime = [
 	"frame-executive/try-runtime",
 	"frame-system/try-runtime",
 	"frame-support/try-runtime",
-
-  "frame-system/try-runtime",
+	"pallet-sudo/try-runtime",
   "pallet-timestamp/try-runtime",
   "pallet-utility/try-runtime",
   "pallet-transaction-payment/try-runtime",

--- a/parachain/src/chain_spec/interlay.rs
+++ b/parachain/src/chain_spec/interlay.rs
@@ -228,5 +228,6 @@ fn interlay_mainnet_genesis(
         polkadot_xcm: interlay_runtime::PolkadotXcmConfig {
             safe_xcm_version: Some(2),
         },
+        sudo: Default::default(),
     }
 }

--- a/parachain/src/chain_spec/kintsugi.rs
+++ b/parachain/src/chain_spec/kintsugi.rs
@@ -256,5 +256,6 @@ fn kintsugi_mainnet_genesis(
         polkadot_xcm: kintsugi_runtime::PolkadotXcmConfig {
             safe_xcm_version: Some(2),
         },
+        sudo: Default::default(),
     }
 }

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -161,6 +161,7 @@ pub type SecurityPallet = security::Pallet<Runtime>;
 pub type SecurityCall = security::Call<Runtime>;
 
 pub type SudoCall = pallet_sudo::Call<Runtime>;
+pub type SudoError = pallet_sudo::Error<Runtime>;
 
 pub type SystemPallet = frame_system::Pallet<Runtime>;
 pub type SystemError = frame_system::Error<Runtime>;


### PR DESCRIPTION
To facilitate Chopsticks testing - chopsticks will set overwrite the sudo key in the local fork. I added a migration that clears the key, which is required since the storage still contains the sudo key from back when we were still using sudo. I also added a test that verifies that when the key is unset, no sudo calls can be made.