### PR TITLE
refactor: transfer expired griefing to treasury

### DIFF
--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -259,6 +259,10 @@ impl fee::Config for Test {
     type MaxExpectedValue = MaxExpectedValue;
 }
 
+parameter_types! {
+    pub const TreasuryPalletId: PalletId = PalletId(*b"mod/trsy");
+}
+
 pub struct BlockNumberToBalance;
 
 impl Convert<BlockNumber, Balance> for BlockNumberToBalance {
@@ -268,6 +272,7 @@ impl Convert<BlockNumber, Balance> for BlockNumberToBalance {
 }
 
 impl Config for Test {
+    type TreasuryPalletId = TreasuryPalletId;
     type RuntimeEvent = RuntimeEvent;
     type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();

--- a/crates/issue/src/tests.rs
+++ b/crates/issue/src/tests.rs
@@ -271,7 +271,7 @@ fn test_execute_issue_underpayment_succeeds() {
             ext::vault_registry::transfer_funds::<Test>.mock_raw(|from, to, amount| {
                 transfer_funds_called = true;
                 assert_eq!(from.account_id(), USER);
-                assert_eq!(to.account_id(), VAULT.account_id);
+                assert_eq!(to.account_id(), Issue::treasury_account_id());
                 // to_release_collateral = (griefing_collateral * amount_transferred) / expected_total_amount
                 // slashed_collateral = griefing_collateral - to_release_collateral
                 // 20 - (20 * 1 / 10) = 18

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1028,6 +1028,7 @@ impl fee::Config for Runtime {
 pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
+    type TreasuryPalletId = TreasuryPalletId;
     type RuntimeEvent = RuntimeEvent;
     type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1028,6 +1028,7 @@ impl fee::Config for Runtime {
 pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
+    type TreasuryPalletId = TreasuryPalletId;
     type RuntimeEvent = RuntimeEvent;
     type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -997,6 +997,7 @@ impl fee::Config for Runtime {
 pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
+    type TreasuryPalletId = TreasuryPalletId;
     type RuntimeEvent = RuntimeEvent;
     type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -999,6 +999,7 @@ impl fee::Config for Runtime {
 pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
+    type TreasuryPalletId = TreasuryPalletId;
     type RuntimeEvent = RuntimeEvent;
     type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -926,6 +926,7 @@ impl fee::Config for Runtime {
 pub use issue::{Event as IssueEvent, IssueRequest};
 
 impl issue::Config for Runtime {
+    type TreasuryPalletId = TreasuryPalletId;
     type RuntimeEvent = RuntimeEvent;
     type BlockNumberToBalance = BlockNumberToBalance;
     type WeightInfo = ();

--- a/standalone/runtime/tests/test_issue.rs
+++ b/standalone/runtime/tests/test_issue.rs
@@ -754,7 +754,7 @@ mod execute_pending_issue_tests {
                     // user loses 75% of griefing collateral for having only fulfilled 25%
                     (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
                     (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).free += returned_griefing_collateral;
-                    *vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += slashed_griefing_collateral;
+                    // TODO: check treasury balance includes griefing collateral
 
                     // token updating as if only 25% was requested
                     (*user.balances.get_mut(&vault_id.wrapped_currency()).unwrap()).free += issue.amount() / 4;
@@ -1095,7 +1095,7 @@ mod cancel_issue_tests {
                 ParachainState::get(&vault_id),
                 post_request_state.with_changes(|user, vault, _, _| {
                     (*user.balances.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap()).locked -= issue.griefing_collateral();
-                    *vault.free_balance.get_mut(&DEFAULT_GRIEFING_CURRENCY).unwrap() += issue.griefing_collateral();
+                    // TODO: check treasury balance includes griefing collateral
                     vault.to_be_issued -= issue.amount() + issue.fee();
                 })
             );


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Closes #822

Always transfer griefing collateral from an expired issue request to treasury instead of the Vault since it is likely under the capacity model that they may have deliberately blocked minting.