### PR TITLE
Lending events refactoring

### DIFF
--- a/crates/loans/src/benchmarking.rs
+++ b/crates/loans/src/benchmarking.rs
@@ -149,7 +149,7 @@ benchmarks! {
     }: _(SystemOrigin::Root, KBTC, pending_market_mock::<T>(LEND_KBTC))
     verify {
         assert_last_event::<T>(Event::<T>::NewMarket {
-            underlying_currency: KBTC,
+            underlying_currency_id: KBTC,
             market: pending_market_mock::<T>(LEND_KBTC)
         }.into());
     }
@@ -159,7 +159,7 @@ benchmarks! {
     }: _(SystemOrigin::Root, KSM)
     verify {
         assert_last_event::<T>(Event::<T>::ActivatedMarket {
-            underlying_currency: KSM
+            underlying_currency_id: KSM
         }.into());
     }
 
@@ -171,7 +171,7 @@ benchmarks! {
         market.rate_model = RATE_MODEL_MOCK;
         assert_last_event::<T>(Event::<T>::UpdatedMarket
             {
-                underlying_currency: KSM,
+                underlying_currency_id: KSM,
                 market
             }.into());
     }
@@ -196,7 +196,7 @@ benchmarks! {
         market.close_factor = Ratio::from_percent(15);
         assert_last_event::<T>(Event::<T>::UpdatedMarket
             {
-                underlying_currency: KSM,
+                underlying_currency_id: KSM,
                 market
             }.into());
     }
@@ -207,7 +207,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::UpdatedMarket
             {
-                underlying_currency: KBTC,
+                underlying_currency_id: KBTC,
                 market: pending_market_mock::<T>(LEND_KBTC)
             }.into());
     }
@@ -242,7 +242,7 @@ benchmarks! {
     }: _(SystemOrigin::Root, KBTC, Some(1_000_000), Some(1_000_000))
     verify {
         assert_last_event::<T>(Event::<T>::MarketRewardSpeedUpdated {
-            underlying_currency: KBTC,
+            underlying_currency_id: KBTC,
             supply_reward_per_block: 1_000_000,
             borrow_reward_per_block: 1_000_000
         }.into());
@@ -295,7 +295,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::Deposited {
             account_id: caller,
-            currency: KBTC,
+            currency_id: KBTC,
             amount: amount.into()
         }.into());
     }
@@ -313,7 +313,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::Borrowed {
             account_id: caller,
-            currency: KBTC,
+            currency_id: KBTC,
             amount: borrowed_amount.into()
         }.into());
     }
@@ -330,7 +330,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::Redeemed {
             account_id: caller,
-            currency: KBTC,
+            currency_id: KBTC,
             amount: redeem_amount.into()
         }.into());
     }
@@ -346,7 +346,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::Redeemed {
             account_id: caller,
-            currency: KBTC,
+            currency_id: KBTC,
             amount: deposit_amount.into()
         }.into());
     }
@@ -366,7 +366,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::RepaidBorrow {
             account_id: caller,
-            currency: KBTC,
+            currency_id: KBTC,
             amount: repay_amount.into()
         }.into());
     }
@@ -386,7 +386,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::RepaidBorrow {
             account_id: caller,
-            currency: KBTC,
+            currency_id: KBTC,
             amount: borrowed_amount.into()
         }.into());
     }
@@ -408,7 +408,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::DepositCollateral {
             account_id: caller,
-            currency: LEND_KBTC,
+            currency_id: LEND_KBTC,
             amount: expected_lend_tokens as u128
         }.into());
     }
@@ -428,7 +428,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::WithdrawCollateral {
             account_id: caller,
-            currency: LEND_KBTC,
+            currency_id: LEND_KBTC,
             amount: expected_lend_tokens as u128
         }.into());
     }
@@ -496,7 +496,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::ReservesAdded {
             payer: caller,
-            currency: KBTC,
+            currency_id: KBTC,
             amount: amount.into(),
             new_reserve_amount: amount.into()
         }.into());
@@ -515,7 +515,7 @@ benchmarks! {
     verify {
         assert_last_event::<T>(Event::<T>::ReservesReduced {
             receiver: caller,
-            currency: KBTC,
+            currency_id: KBTC,
             amount: reduce_amount.into(),
             new_reserve_amount: (add_amount - reduce_amount).into()
         }.into());

--- a/crates/loans/src/farming.rs
+++ b/crates/loans/src/farming.rs
@@ -132,7 +132,7 @@ impl<T: Config> Pallet<T> {
                     .checked_add(reward_delta)
                     .ok_or(ArithmeticError::Overflow)?;
                 Self::deposit_event(Event::<T>::DistributedSupplierReward {
-                    underlying_currency: asset_id,
+                    underlying_currency_id: asset_id,
                     supplier: supplier.clone(),
                     reward_delta,
                     supply_reward_index: supply_state.index,
@@ -164,7 +164,7 @@ impl<T: Config> Pallet<T> {
                     .checked_add(reward_delta)
                     .ok_or(ArithmeticError::Overflow)?;
                 Self::deposit_event(Event::<T>::DistributedBorrowerReward {
-                    underlying_currency: asset_id,
+                    underlying_currency_id: asset_id,
                     borrower: borrower.clone(),
                     reward_delta,
                     borrow_reward_index: borrow_state.index,

--- a/crates/loans/src/farming.rs
+++ b/crates/loans/src/farming.rs
@@ -131,12 +131,12 @@ impl<T: Config> Pallet<T> {
                 *total_reward = total_reward
                     .checked_add(reward_delta)
                     .ok_or(ArithmeticError::Overflow)?;
-                Self::deposit_event(Event::<T>::DistributedSupplierReward(
-                    asset_id,
-                    supplier.clone(),
+                Self::deposit_event(Event::<T>::DistributedSupplierReward {
+                    underlying_currency: asset_id,
+                    supplier: supplier.clone(),
                     reward_delta,
-                    supply_state.index,
-                ));
+                    supply_reward_index: supply_state.index,
+                });
 
                 Ok(())
             })
@@ -163,12 +163,12 @@ impl<T: Config> Pallet<T> {
                 *total_reward = total_reward
                     .checked_add(reward_delta)
                     .ok_or(ArithmeticError::Overflow)?;
-                Self::deposit_event(Event::<T>::DistributedBorrowerReward(
-                    asset_id,
-                    borrower.clone(),
+                Self::deposit_event(Event::<T>::DistributedBorrowerReward {
+                    underlying_currency: asset_id,
+                    borrower: borrower.clone(),
                     reward_delta,
-                    borrow_state.index,
-                ));
+                    borrow_reward_index: borrow_state.index,
+                });
 
                 Ok(())
             })
@@ -194,7 +194,10 @@ impl<T: Config> Pallet<T> {
             amount.transfer(&pool_account, user)?;
             RewardAccrued::<T>::remove(user);
         }
-        Self::deposit_event(Event::<T>::RewardPaid(user.clone(), total_reward));
+        Self::deposit_event(Event::<T>::RewardPaid {
+            receiver: user.clone(),
+            amount: total_reward,
+        });
         Ok(())
     }
 }

--- a/crates/loans/src/interest.rs
+++ b/crates/loans/src/interest.rs
@@ -49,7 +49,7 @@ impl<T: Config> Pallet<T> {
         ExchangeRate::<T>::insert(asset_id, exchange_rate);
 
         Self::deposit_event(Event::<T>::InterestAccrued {
-            underlying_currency: asset_id,
+            underlying_currency_id: asset_id,
             total_borrows: total_borrows_new,
             total_reserves: total_reserves_new,
             borrow_index: borrow_index_new,

--- a/crates/loans/src/interest.rs
+++ b/crates/loans/src/interest.rs
@@ -48,6 +48,17 @@ impl<T: Config> Pallet<T> {
         SupplyRate::<T>::insert(asset_id, supply_rate);
         ExchangeRate::<T>::insert(asset_id, exchange_rate);
 
+        Self::deposit_event(Event::<T>::InterestAccrued {
+            underlying_currency: asset_id,
+            total_borrows: total_borrows_new,
+            total_reserves: total_reserves_new,
+            borrow_index: borrow_index_new,
+            utilization_ratio: util,
+            borrow_rate,
+            supply_rate,
+            exchange_rate,
+        });
+
         Ok(())
     }
 

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -299,72 +299,72 @@ pub mod pallet {
         /// Enable collateral for certain asset
         DepositCollateral {
             account_id: T::AccountId,
-            currency: AssetIdOf<T>,
+            currency_id: AssetIdOf<T>,
             amount: BalanceOf<T>,
         },
         /// Disable collateral for certain asset
         WithdrawCollateral {
             account_id: T::AccountId,
-            currency: AssetIdOf<T>,
+            currency_id: AssetIdOf<T>,
             amount: BalanceOf<T>,
         },
         /// Event emitted when assets are deposited
         Deposited {
             account_id: T::AccountId,
-            currency: AssetIdOf<T>,
+            currency_id: AssetIdOf<T>,
             amount: BalanceOf<T>,
         },
         /// Event emitted when assets are redeemed
         Redeemed {
             account_id: T::AccountId,
-            currency: AssetIdOf<T>,
+            currency_id: AssetIdOf<T>,
             amount: BalanceOf<T>,
         },
         /// Event emitted when cash is borrowed
         Borrowed {
             account_id: T::AccountId,
-            currency: AssetIdOf<T>,
+            currency_id: AssetIdOf<T>,
             amount: BalanceOf<T>,
         },
         /// Event emitted when a borrow is repaid
         RepaidBorrow {
             account_id: T::AccountId,
-            currency: AssetIdOf<T>,
+            currency_id: AssetIdOf<T>,
             amount: BalanceOf<T>,
         },
         /// Event emitted when a borrow is liquidated
         LiquidatedBorrow {
             liquidator: T::AccountId,
             borrower: T::AccountId,
-            liquidation_currency: AssetIdOf<T>,
-            collateral_currency: AssetIdOf<T>,
+            liquidation_currency_id: AssetIdOf<T>,
+            collateral_currency_id: AssetIdOf<T>,
             repay_amount: BalanceOf<T>,
             collateral_underlying_amount: BalanceOf<T>,
         },
         /// Event emitted when the reserves are reduced
         ReservesReduced {
             receiver: T::AccountId,
-            currency: AssetIdOf<T>,
+            currency_id: AssetIdOf<T>,
             amount: BalanceOf<T>,
             new_reserve_amount: BalanceOf<T>,
         },
         /// Event emitted when the reserves are added
         ReservesAdded {
             payer: T::AccountId,
-            currency: AssetIdOf<T>,
+            currency_id: AssetIdOf<T>,
             amount: BalanceOf<T>,
             new_reserve_amount: BalanceOf<T>,
         },
         /// New market is set
         NewMarket {
-            underlying_currency: AssetIdOf<T>,
+            underlying_currency_id: AssetIdOf<T>,
             market: Market<BalanceOf<T>>,
         },
         /// Event emitted when a market is activated
-        ActivatedMarket { underlying_currency: AssetIdOf<T> },
+        ActivatedMarket { underlying_currency_id: AssetIdOf<T> },
         /// New market parameters is updated
         UpdatedMarket {
-            underlying_currency: AssetIdOf<T>,
+            underlying_currency_id: AssetIdOf<T>,
             market: Market<BalanceOf<T>>,
         },
         /// Reward added
@@ -376,20 +376,20 @@ pub mod pallet {
         },
         /// Event emitted when market reward speed updated.
         MarketRewardSpeedUpdated {
-            underlying_currency: AssetIdOf<T>,
+            underlying_currency_id: AssetIdOf<T>,
             supply_reward_per_block: BalanceOf<T>,
             borrow_reward_per_block: BalanceOf<T>,
         },
         /// Deposited when Reward is distributed to a supplier
         DistributedSupplierReward {
-            underlying_currency: AssetIdOf<T>,
+            underlying_currency_id: AssetIdOf<T>,
             supplier: T::AccountId,
             reward_delta: BalanceOf<T>,
             supply_reward_index: BalanceOf<T>,
         },
         /// Deposited when Reward is distributed to a borrower
         DistributedBorrowerReward {
-            underlying_currency: AssetIdOf<T>,
+            underlying_currency_id: AssetIdOf<T>,
             borrower: T::AccountId,
             reward_delta: BalanceOf<T>,
             borrow_reward_index: BalanceOf<T>,
@@ -402,12 +402,12 @@ pub mod pallet {
         /// Event emitted when the incentive reserves are redeemed and transfer to receiver's account
         IncentiveReservesReduced {
             receiver: T::AccountId,
-            currency: AssetIdOf<T>,
+            currency_id: AssetIdOf<T>,
             amount: BalanceOf<T>,
         },
         /// Event emitted when interest has been accrued for a market
         InterestAccrued {
-            underlying_currency: AssetIdOf<T>,
+            underlying_currency_id: AssetIdOf<T>,
             total_borrows: BalanceOf<T>,
             total_reserves: BalanceOf<T>,
             borrow_index: FixedU128,
@@ -690,7 +690,7 @@ pub mod pallet {
             // Emit an `InterestAccrued` event so event subscribers can see the
             // initial exchange rate.
             Self::deposit_event(Event::<T>::InterestAccrued {
-                underlying_currency: asset_id,
+                underlying_currency_id: asset_id,
                 total_borrows: Balance::zero(),
                 total_reserves: Balance::zero(),
                 borrow_index: initial_borrow_index,
@@ -700,7 +700,7 @@ pub mod pallet {
                 exchange_rate: initial_exchange_rate,
             });
             Self::deposit_event(Event::<T>::NewMarket {
-                underlying_currency: asset_id,
+                underlying_currency_id: asset_id,
                 market,
             });
             Ok(().into())
@@ -723,7 +723,7 @@ pub mod pallet {
                 stored_market.clone()
             })?;
             Self::deposit_event(Event::<T>::ActivatedMarket {
-                underlying_currency: asset_id,
+                underlying_currency_id: asset_id,
             });
             Ok(().into())
         }
@@ -747,7 +747,7 @@ pub mod pallet {
                 stored_market.clone()
             })?;
             Self::deposit_event(Event::<T>::UpdatedMarket {
-                underlying_currency: asset_id,
+                underlying_currency_id: asset_id,
                 market,
             });
 
@@ -821,7 +821,7 @@ pub mod pallet {
                 stored_market.clone()
             })?;
             Self::deposit_event(Event::<T>::UpdatedMarket {
-                underlying_currency: asset_id,
+                underlying_currency_id: asset_id,
                 market,
             });
 
@@ -855,7 +855,7 @@ pub mod pallet {
             })?;
 
             Self::deposit_event(Event::<T>::UpdatedMarket {
-                underlying_currency: asset_id,
+                underlying_currency_id: asset_id,
                 market: updated_market,
             });
             Ok(().into())
@@ -952,7 +952,7 @@ pub mod pallet {
             }
 
             Self::deposit_event(Event::<T>::MarketRewardSpeedUpdated {
-                underlying_currency: asset_id,
+                underlying_currency_id: asset_id,
                 supply_reward_per_block,
                 borrow_reward_per_block,
             });
@@ -1081,7 +1081,7 @@ pub mod pallet {
             let redeem_amount = Self::do_redeem_voucher(&who, asset_id, lend_tokens.amount())?;
             Self::deposit_event(Event::<T>::Redeemed {
                 account_id: who,
-                currency: asset_id,
+                currency_id: asset_id,
                 amount: redeem_amount,
             });
 
@@ -1222,7 +1222,7 @@ pub mod pallet {
 
             Self::deposit_event(Event::<T>::ReservesAdded {
                 payer,
-                currency: asset_id,
+                currency_id: asset_id,
                 amount: add_amount,
                 new_reserve_amount: total_reserves_new,
             });
@@ -1265,7 +1265,7 @@ pub mod pallet {
 
             Self::deposit_event(Event::<T>::ReservesReduced {
                 receiver,
-                currency: asset_id,
+                currency_id: asset_id,
                 amount: reduce_amount,
                 new_reserve_amount: total_reserves_new,
             });
@@ -1300,7 +1300,7 @@ pub mod pallet {
 
             Self::deposit_event(Event::<T>::IncentiveReservesReduced {
                 receiver,
-                currency: asset_id,
+                currency_id: asset_id,
                 amount: redeem_amount,
             });
             Ok(().into())
@@ -1761,8 +1761,8 @@ impl<T: Config> Pallet<T> {
         Self::deposit_event(Event::<T>::LiquidatedBorrow {
             liquidator: liquidator.clone(),
             borrower: borrower.clone(),
-            liquidation_currency: liquidation_asset_id,
-            collateral_currency: collateral_asset_id,
+            liquidation_currency_id: liquidation_asset_id,
+            collateral_currency_id: collateral_asset_id,
             repay_amount,
             collateral_underlying_amount,
         });
@@ -1990,7 +1990,7 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
 
         Self::deposit_event(Event::<T>::Deposited {
             account_id: supplier.clone(),
-            currency: asset_id,
+            currency_id: asset_id,
             amount,
         });
         Ok(())
@@ -2024,7 +2024,7 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
 
         Self::deposit_event(Event::<T>::Borrowed {
             account_id: borrower.clone(),
-            currency: asset_id,
+            currency_id: asset_id,
             amount,
         });
         Ok(())
@@ -2052,7 +2052,7 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
 
         Self::deposit_event(Event::<T>::DepositCollateral {
             account_id: supplier.clone(),
-            currency: lend_token_amount.currency(),
+            currency_id: lend_token_amount.currency(),
             amount: lend_token_amount.amount(),
         });
         Ok(())
@@ -2102,7 +2102,7 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
 
         Self::deposit_event(Event::<T>::WithdrawCollateral {
             account_id: supplier.clone(),
-            currency: lend_token_amount.currency(),
+            currency_id: lend_token_amount.currency(),
             amount: lend_token_amount.amount(),
         });
         Ok(())
@@ -2119,7 +2119,7 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
         Self::do_repay_borrow_with_amount(borrower, asset_id, account_borrows, amount)?;
         Self::deposit_event(Event::<T>::RepaidBorrow {
             account_id: borrower.clone(),
-            currency: asset_id,
+            currency_id: asset_id,
             amount,
         });
         Ok(())
@@ -2134,7 +2134,7 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
         let redeem_amount = Self::do_redeem_voucher(supplier, asset_id, voucher_amount)?;
         Self::deposit_event(Event::<T>::Redeemed {
             account_id: supplier.clone(),
-            currency: asset_id,
+            currency_id: asset_id,
             amount: redeem_amount,
         });
         Ok(())

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -297,63 +297,114 @@ pub mod pallet {
     #[pallet::generate_deposit(pub (crate) fn deposit_event)]
     pub enum Event<T: Config> {
         /// Enable collateral for certain asset
-        /// [sender, asset_id]
-        DepositCollateral(T::AccountId, AssetIdOf<T>, BalanceOf<T>),
+        DepositCollateral {
+            account_id: T::AccountId,
+            currency: AssetIdOf<T>,
+            amount: BalanceOf<T>,
+        },
         /// Disable collateral for certain asset
-        /// [sender, asset_id]
-        WithdrawCollateral(T::AccountId, AssetIdOf<T>, BalanceOf<T>),
+        WithdrawCollateral {
+            account_id: T::AccountId,
+            currency: AssetIdOf<T>,
+            amount: BalanceOf<T>,
+        },
         /// Event emitted when assets are deposited
-        /// [sender, asset_id, amount]
-        Deposited(T::AccountId, AssetIdOf<T>, BalanceOf<T>),
+        Deposited {
+            account_id: T::AccountId,
+            currency: AssetIdOf<T>,
+            amount: BalanceOf<T>,
+        },
         /// Event emitted when assets are redeemed
-        /// [sender, asset_id, amount]
-        Redeemed(T::AccountId, AssetIdOf<T>, BalanceOf<T>),
+        Redeemed {
+            account_id: T::AccountId,
+            currency: AssetIdOf<T>,
+            amount: BalanceOf<T>,
+        },
         /// Event emitted when cash is borrowed
-        /// [sender, asset_id, amount]
-        Borrowed(T::AccountId, AssetIdOf<T>, BalanceOf<T>),
+        Borrowed {
+            account_id: T::AccountId,
+            currency: AssetIdOf<T>,
+            amount: BalanceOf<T>,
+        },
         /// Event emitted when a borrow is repaid
-        /// [sender, asset_id, amount]
-        RepaidBorrow(T::AccountId, AssetIdOf<T>, BalanceOf<T>),
+        RepaidBorrow {
+            account_id: T::AccountId,
+            currency: AssetIdOf<T>,
+            amount: BalanceOf<T>,
+        },
         /// Event emitted when a borrow is liquidated
-        /// [liquidator, borrower, liquidation_asset_id, collateral_asset_id, repay_amount, collateral_amount]
-        LiquidatedBorrow(
-            T::AccountId,
-            T::AccountId,
-            AssetIdOf<T>,
-            AssetIdOf<T>,
-            BalanceOf<T>,
-            BalanceOf<T>,
-        ),
+        LiquidatedBorrow {
+            liquidator: T::AccountId,
+            borrower: T::AccountId,
+            liquidation_currency: AssetIdOf<T>,
+            collateral_currency: AssetIdOf<T>,
+            repay_amount: BalanceOf<T>,
+            collateral_underlying_amount: BalanceOf<T>,
+        },
         /// Event emitted when the reserves are reduced
-        /// [admin, asset_id, reduced_amount, total_reserves]
-        ReservesReduced(T::AccountId, AssetIdOf<T>, BalanceOf<T>, BalanceOf<T>),
+        ReservesReduced {
+            receiver: T::AccountId,
+            currency: AssetIdOf<T>,
+            amount: BalanceOf<T>,
+            new_reserve_amount: BalanceOf<T>,
+        },
         /// Event emitted when the reserves are added
-        /// [admin, asset_id, added_amount, total_reserves]
-        ReservesAdded(T::AccountId, AssetIdOf<T>, BalanceOf<T>, BalanceOf<T>),
+        ReservesAdded {
+            payer: T::AccountId,
+            currency: AssetIdOf<T>,
+            amount: BalanceOf<T>,
+            new_reserve_amount: BalanceOf<T>,
+        },
         /// New market is set
-        /// [new_interest_rate_model]
-        NewMarket(AssetIdOf<T>, Market<BalanceOf<T>>),
+        NewMarket {
+            underlying_currency: AssetIdOf<T>,
+            market: Market<BalanceOf<T>>,
+        },
         /// Event emitted when a market is activated
-        /// [admin, asset_id]
-        ActivatedMarket(AssetIdOf<T>),
+        ActivatedMarket { underlying_currency: AssetIdOf<T> },
         /// New market parameters is updated
-        /// [admin, asset_id]
-        UpdatedMarket(AssetIdOf<T>, Market<BalanceOf<T>>),
+        UpdatedMarket {
+            underlying_currency: AssetIdOf<T>,
+            market: Market<BalanceOf<T>>,
+        },
         /// Reward added
-        RewardAdded(T::AccountId, BalanceOf<T>),
+        RewardAdded { payer: T::AccountId, amount: BalanceOf<T> },
         /// Reward withdrawed
-        RewardWithdrawn(T::AccountId, BalanceOf<T>),
+        RewardWithdrawn {
+            receiver: T::AccountId,
+            amount: BalanceOf<T>,
+        },
         /// Event emitted when market reward speed updated.
-        MarketRewardSpeedUpdated(AssetIdOf<T>, BalanceOf<T>, BalanceOf<T>),
+        MarketRewardSpeedUpdated {
+            underlying_currency: AssetIdOf<T>,
+            supply_reward_per_block: BalanceOf<T>,
+            borrow_reward_per_block: BalanceOf<T>,
+        },
         /// Deposited when Reward is distributed to a supplier
-        DistributedSupplierReward(AssetIdOf<T>, T::AccountId, BalanceOf<T>, BalanceOf<T>),
+        DistributedSupplierReward {
+            underlying_currency: AssetIdOf<T>,
+            supplier: T::AccountId,
+            reward_delta: BalanceOf<T>,
+            supply_reward_index: BalanceOf<T>,
+        },
         /// Deposited when Reward is distributed to a borrower
-        DistributedBorrowerReward(AssetIdOf<T>, T::AccountId, BalanceOf<T>, BalanceOf<T>),
+        DistributedBorrowerReward {
+            underlying_currency: AssetIdOf<T>,
+            borrower: T::AccountId,
+            reward_delta: BalanceOf<T>,
+            borrow_reward_index: BalanceOf<T>,
+        },
         /// Reward Paid for user
-        RewardPaid(T::AccountId, BalanceOf<T>),
+        RewardPaid {
+            receiver: T::AccountId,
+            amount: BalanceOf<T>,
+        },
         /// Event emitted when the incentive reserves are redeemed and transfer to receiver's account
-        /// [receive_account_id, asset_id, reduced_amount]
-        IncentiveReservesReduced(T::AccountId, AssetIdOf<T>, BalanceOf<T>),
+        IncentiveReservesReduced {
+            receiver: T::AccountId,
+            currency: AssetIdOf<T>,
+            amount: BalanceOf<T>,
+        },
     }
 
     #[pallet::hooks]
@@ -623,7 +674,10 @@ pub mod pallet {
             ExchangeRate::<T>::insert(asset_id, Self::min_exchange_rate());
             BorrowIndex::<T>::insert(asset_id, Rate::one());
 
-            Self::deposit_event(Event::<T>::NewMarket(asset_id, market));
+            Self::deposit_event(Event::<T>::NewMarket {
+                underlying_currency: asset_id,
+                market,
+            });
             Ok(().into())
         }
 
@@ -643,7 +697,9 @@ pub mod pallet {
                 stored_market.state = MarketState::Active;
                 stored_market.clone()
             })?;
-            Self::deposit_event(Event::<T>::ActivatedMarket(asset_id));
+            Self::deposit_event(Event::<T>::ActivatedMarket {
+                underlying_currency: asset_id,
+            });
             Ok(().into())
         }
 
@@ -665,7 +721,10 @@ pub mod pallet {
                 stored_market.rate_model = rate_model;
                 stored_market.clone()
             })?;
-            Self::deposit_event(Event::<T>::UpdatedMarket(asset_id, market));
+            Self::deposit_event(Event::<T>::UpdatedMarket {
+                underlying_currency: asset_id,
+                market,
+            });
 
             Ok(().into())
         }
@@ -736,7 +795,10 @@ pub mod pallet {
                 };
                 stored_market.clone()
             })?;
-            Self::deposit_event(Event::<T>::UpdatedMarket(asset_id, market));
+            Self::deposit_event(Event::<T>::UpdatedMarket {
+                underlying_currency: asset_id,
+                market,
+            });
 
             Ok(().into())
         }
@@ -767,7 +829,10 @@ pub mod pallet {
                 stored_market.clone()
             })?;
 
-            Self::deposit_event(Event::<T>::UpdatedMarket(asset_id, updated_market));
+            Self::deposit_event(Event::<T>::UpdatedMarket {
+                underlying_currency: asset_id,
+                market: updated_market,
+            });
             Ok(().into())
         }
 
@@ -786,7 +851,7 @@ pub mod pallet {
             let amount_to_transfer: Amount<T> = Amount::new(amount, reward_asset);
             amount_to_transfer.transfer(&who, &pool_account)?;
 
-            Self::deposit_event(Event::<T>::RewardAdded(who, amount));
+            Self::deposit_event(Event::<T>::RewardAdded { payer: who, amount });
 
             Ok(().into())
         }
@@ -814,7 +879,10 @@ pub mod pallet {
             let amount_to_transfer: Amount<T> = Amount::new(amount, reward_asset);
             amount_to_transfer.transfer(&pool_account, &target_account)?;
 
-            Self::deposit_event(Event::<T>::RewardWithdrawn(target_account, amount));
+            Self::deposit_event(Event::<T>::RewardWithdrawn {
+                receiver: target_account,
+                amount,
+            });
 
             Ok(().into())
         }
@@ -858,11 +926,11 @@ pub mod pallet {
                 })?;
             }
 
-            Self::deposit_event(Event::<T>::MarketRewardSpeedUpdated(
-                asset_id,
+            Self::deposit_event(Event::<T>::MarketRewardSpeedUpdated {
+                underlying_currency: asset_id,
                 supply_reward_per_block,
                 borrow_reward_per_block,
-            ));
+            });
             Ok(().into())
         }
 
@@ -986,7 +1054,11 @@ pub mod pallet {
             let lend_tokens = Self::free_lend_tokens(asset_id, &who)?;
             ensure!(!lend_tokens.is_zero(), Error::<T>::InvalidAmount);
             let redeem_amount = Self::do_redeem_voucher(&who, asset_id, lend_tokens.amount())?;
-            Self::deposit_event(Event::<T>::Redeemed(who, asset_id, redeem_amount));
+            Self::deposit_event(Event::<T>::Redeemed {
+                account_id: who,
+                currency: asset_id,
+                amount: redeem_amount,
+            });
 
             Ok(().into())
         }
@@ -1123,12 +1195,12 @@ pub mod pallet {
                 .ok_or(ArithmeticError::Overflow)?;
             TotalReserves::<T>::insert(asset_id, total_reserves_new);
 
-            Self::deposit_event(Event::<T>::ReservesAdded(
+            Self::deposit_event(Event::<T>::ReservesAdded {
                 payer,
-                asset_id,
-                add_amount,
-                total_reserves_new,
-            ));
+                currency: asset_id,
+                amount: add_amount,
+                new_reserve_amount: total_reserves_new,
+            });
 
             Ok(().into())
         }
@@ -1166,12 +1238,12 @@ pub mod pallet {
             let amount_to_transfer: Amount<T> = Amount::new(reduce_amount, asset_id);
             amount_to_transfer.transfer(&Self::account_id(), &receiver)?;
 
-            Self::deposit_event(Event::<T>::ReservesReduced(
+            Self::deposit_event(Event::<T>::ReservesReduced {
                 receiver,
-                asset_id,
-                reduce_amount,
-                total_reserves_new,
-            ));
+                currency: asset_id,
+                amount: reduce_amount,
+                new_reserve_amount: total_reserves_new,
+            });
 
             Ok(().into())
         }
@@ -1201,7 +1273,11 @@ pub mod pallet {
             let amount_to_transfer: Amount<T> = Amount::new(redeem_amount, asset_id);
             amount_to_transfer.transfer(&from, &receiver)?;
 
-            Self::deposit_event(Event::<T>::IncentiveReservesReduced(receiver, asset_id, redeem_amount));
+            Self::deposit_event(Event::<T>::IncentiveReservesReduced {
+                receiver,
+                currency: asset_id,
+                amount: redeem_amount,
+            });
             Ok(().into())
         }
     }
@@ -1657,14 +1733,14 @@ impl<T: Config> Pallet<T> {
         let incentive_reserved_amount: Amount<T> = Amount::new(incentive_reserved, lend_token_id);
         incentive_reserved_amount.transfer(borrower, &Self::incentive_reward_account_id()?)?;
 
-        Self::deposit_event(Event::<T>::LiquidatedBorrow(
-            liquidator.clone(),
-            borrower.clone(),
-            liquidation_asset_id,
-            collateral_asset_id,
+        Self::deposit_event(Event::<T>::LiquidatedBorrow {
+            liquidator: liquidator.clone(),
+            borrower: borrower.clone(),
+            liquidation_currency: liquidation_asset_id,
+            collateral_currency: collateral_asset_id,
             repay_amount,
             collateral_underlying_amount,
-        ));
+        });
 
         Ok(())
     }
@@ -1887,7 +1963,11 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
         let lend_tokens_to_mint: Amount<T> = Amount::new(voucher_amount, lend_token_id);
         lend_tokens_to_mint.mint_to(supplier)?;
 
-        Self::deposit_event(Event::<T>::Deposited(supplier.clone(), asset_id, amount));
+        Self::deposit_event(Event::<T>::Deposited {
+            account_id: supplier.clone(),
+            currency: asset_id,
+            amount,
+        });
         Ok(())
     }
 
@@ -1917,7 +1997,11 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
         let amount_to_transfer: Amount<T> = Amount::new(amount, asset_id);
         amount_to_transfer.transfer(&Self::account_id(), borrower)?;
 
-        Self::deposit_event(Event::<T>::Borrowed(borrower.clone(), asset_id, amount));
+        Self::deposit_event(Event::<T>::Borrowed {
+            account_id: borrower.clone(),
+            currency: asset_id,
+            amount,
+        });
         Ok(())
     }
 
@@ -1941,11 +2025,11 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
             .ok_or(ArithmeticError::Overflow)?;
         AccountDeposits::<T>::insert(lend_token_amount.currency(), supplier, new_deposit);
 
-        Self::deposit_event(Event::<T>::DepositCollateral(
-            supplier.clone(),
-            lend_token_amount.currency(),
-            lend_token_amount.amount(),
-        ));
+        Self::deposit_event(Event::<T>::DepositCollateral {
+            account_id: supplier.clone(),
+            currency: lend_token_amount.currency(),
+            amount: lend_token_amount.amount(),
+        });
         Ok(())
     }
 
@@ -1991,11 +2075,11 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
             Ok(())
         })?;
 
-        Self::deposit_event(Event::<T>::WithdrawCollateral(
-            supplier.clone(),
-            lend_token_amount.currency(),
-            lend_token_amount.amount(),
-        ));
+        Self::deposit_event(Event::<T>::WithdrawCollateral {
+            account_id: supplier.clone(),
+            currency: lend_token_amount.currency(),
+            amount: lend_token_amount.amount(),
+        });
         Ok(())
     }
 
@@ -2008,7 +2092,11 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
         Self::accrue_interest(asset_id)?;
         let account_borrows = Self::current_borrow_balance(borrower, asset_id)?;
         Self::do_repay_borrow_with_amount(borrower, asset_id, account_borrows, amount)?;
-        Self::deposit_event(Event::<T>::RepaidBorrow(borrower.clone(), asset_id, amount));
+        Self::deposit_event(Event::<T>::RepaidBorrow {
+            account_id: borrower.clone(),
+            currency: asset_id,
+            amount,
+        });
         Ok(())
     }
 
@@ -2019,7 +2107,11 @@ impl<T: Config> LoansTrait<AssetIdOf<T>, AccountIdOf<T>, BalanceOf<T>, Amount<T>
         Self::update_earned_stored(supplier, asset_id, exchange_rate)?;
         let voucher_amount = Self::calc_collateral_amount(amount, exchange_rate)?;
         let redeem_amount = Self::do_redeem_voucher(supplier, asset_id, voucher_amount)?;
-        Self::deposit_event(Event::<T>::Redeemed(supplier.clone(), asset_id, redeem_amount));
+        Self::deposit_event(Event::<T>::Redeemed {
+            account_id: supplier.clone(),
+            currency: asset_id,
+            amount: redeem_amount,
+        });
         Ok(())
     }
 


### PR DESCRIPTION
Depends on https://github.com/interlay/interbtc/pull/821
Closes https://github.com/interlay/interbtc/issues/757

- Refactors lending events from tuple types to struct types
- Adds an `InterestAccrued` event emitted when a market is created and whenever interest is accrued, so event subscribes can track the latest internal exchange rate of lend tokens

