### PR TITLE
feat(loans): add loans accounts dust whitelist on testnets

### DIFF
--- a/crates/loans/src/farming.rs
+++ b/crates/loans/src/farming.rs
@@ -15,16 +15,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use sp_io::hashing::blake2_256;
 use sp_runtime::{traits::Zero, DispatchResult};
 
 use crate::*;
 
 impl<T: Config> Pallet<T> {
     pub fn reward_account_id() -> T::AccountId {
-        let account_id: T::AccountId = T::PalletId::get().into_account_truncating();
-        let entropy = (REWARD_ACCOUNT_PREFIX, &[account_id]).using_encoded(blake2_256);
-        T::AccountId::decode(&mut &entropy[..]).expect("Account derivation failure")
+        T::PalletId::get().into_sub_account_truncating(REWARD_SUB_ACCOUNT)
     }
 
     fn reward_scale() -> u128 {

--- a/crates/loans/src/farming.rs
+++ b/crates/loans/src/farming.rs
@@ -21,10 +21,10 @@ use sp_runtime::{traits::Zero, DispatchResult};
 use crate::*;
 
 impl<T: Config> Pallet<T> {
-    pub fn reward_account_id() -> Result<T::AccountId, DispatchError> {
+    pub fn reward_account_id() -> T::AccountId {
         let account_id: T::AccountId = T::PalletId::get().into_account_truncating();
         let entropy = (REWARD_ACCOUNT_PREFIX, &[account_id]).using_encoded(blake2_256);
-        Ok(T::AccountId::decode(&mut &entropy[..]).map_err(|_| Error::<T>::CodecError)?)
+        T::AccountId::decode(&mut &entropy[..]).expect("Account derivation failure")
     }
 
     fn reward_scale() -> u128 {
@@ -186,7 +186,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn pay_reward(user: &T::AccountId) -> DispatchResult {
-        let pool_account = Self::reward_account_id()?;
+        let pool_account = Self::reward_account_id();
         let reward_asset = T::RewardAssetId::get();
         let total_reward = RewardAccrued::<T>::get(user);
         if total_reward > 0 {

--- a/crates/loans/src/farming.rs
+++ b/crates/loans/src/farming.rs
@@ -21,7 +21,7 @@ use sp_runtime::{traits::Zero, DispatchResult};
 use crate::*;
 
 impl<T: Config> Pallet<T> {
-    pub(crate) fn reward_account_id() -> Result<T::AccountId, DispatchError> {
+    pub fn reward_account_id() -> Result<T::AccountId, DispatchError> {
         let account_id: T::AccountId = T::PalletId::get().into_account_truncating();
         let entropy = (REWARD_ACCOUNT_PREFIX, &[account_id]).using_encoded(blake2_256);
         Ok(T::AccountId::decode(&mut &entropy[..]).map_err(|_| Error::<T>::CodecError)?)

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -855,7 +855,7 @@ pub mod pallet {
             ensure!(!amount.is_zero(), Error::<T>::InvalidAmount);
 
             let reward_asset = T::RewardAssetId::get();
-            let pool_account = Self::reward_account_id()?;
+            let pool_account = Self::reward_account_id();
 
             let amount_to_transfer: Amount<T> = Amount::new(amount, reward_asset);
             amount_to_transfer.transfer(&who, &pool_account)?;
@@ -882,7 +882,7 @@ pub mod pallet {
             ensure!(!amount.is_zero(), Error::<T>::InvalidAmount);
 
             let reward_asset = T::RewardAssetId::get();
-            let pool_account = Self::reward_account_id()?;
+            let pool_account = Self::reward_account_id();
             let target_account = T::Lookup::lookup(target_account)?;
 
             let amount_to_transfer: Amount<T> = Amount::new(amount, reward_asset);
@@ -1270,7 +1270,7 @@ pub mod pallet {
             T::ReserveOrigin::ensure_origin(origin)?;
             ensure!(!redeem_amount.is_zero(), Error::<T>::InvalidAmount);
             let receiver = T::Lookup::lookup(receiver)?;
-            let from = Self::incentive_reward_account_id()?;
+            let from = Self::incentive_reward_account_id();
             Self::ensure_active_market(asset_id)?;
             Self::accrue_interest(asset_id)?;
             let exchange_rate = Self::exchange_rate_stored(asset_id)?;
@@ -1691,7 +1691,7 @@ impl<T: Config> Pallet<T> {
         Self::update_reward_supply_index(collateral_asset_id)?;
         Self::distribute_supplier_reward(collateral_asset_id, liquidator)?;
         Self::distribute_supplier_reward(collateral_asset_id, borrower)?;
-        Self::distribute_supplier_reward(collateral_asset_id, &Self::incentive_reward_account_id()?)?;
+        Self::distribute_supplier_reward(collateral_asset_id, &Self::incentive_reward_account_id())?;
 
         // 3.the liquidator will receive voucher token from borrower
         let exchange_rate = Self::exchange_rate_stored(collateral_asset_id)?;
@@ -1727,7 +1727,7 @@ impl<T: Config> Pallet<T> {
         liquidator_amount.transfer(borrower, liquidator)?;
 
         // increase reserve's voucher_balance
-        incentive_reserved_amount.transfer(borrower, &Self::incentive_reward_account_id()?)?;
+        incentive_reserved_amount.transfer(borrower, &Self::incentive_reward_account_id())?;
 
         Self::deposit_event(Event::<T>::LiquidatedBorrow {
             liquidator: liquidator.clone(),
@@ -1929,10 +1929,10 @@ impl<T: Config> Pallet<T> {
     }
 
     // Returns the incentive reward account
-    pub fn incentive_reward_account_id() -> Result<T::AccountId, DispatchError> {
+    pub fn incentive_reward_account_id() -> T::AccountId {
         let account_id: T::AccountId = T::PalletId::get().into_account_truncating();
         let entropy = (INCENTIVE_ACCOUNT_PREFIX, &[account_id]).using_encoded(blake2_256);
-        Ok(T::AccountId::decode(&mut &entropy[..]).map_err(|_| Error::<T>::CodecError)?)
+        T::AccountId::decode(&mut &entropy[..]).expect("Account derivation failure")
     }
 }
 

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -59,7 +59,6 @@ use traits::{
 
 pub use default_weights::WeightInfo;
 pub use orml_traits::currency::{OnDeposit, OnSlash, OnTransfer};
-use sp_io::hashing::blake2_256;
 pub use types::{BorrowSnapshot, EarnedSnapshot, Market, MarketState, RewardMarketState};
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -79,8 +78,8 @@ mod types;
 
 mod default_weights;
 
-pub const REWARD_ACCOUNT_PREFIX: &[u8; 13] = b"loans/farming";
-pub const INCENTIVE_ACCOUNT_PREFIX: &[u8; 15] = b"loans/incentive";
+pub const REWARD_SUB_ACCOUNT: &[u8; 7] = b"farming";
+pub const INCENTIVE_SUB_ACCOUNT: &[u8; 9] = b"incentive";
 
 pub const DEFAULT_MAX_EXCHANGE_RATE: u128 = 1_000_000_000_000_000_000; // 1
 pub const DEFAULT_MIN_EXCHANGE_RATE: u128 = 20_000_000_000_000_000; // 0.02
@@ -1930,9 +1929,7 @@ impl<T: Config> Pallet<T> {
 
     // Returns the incentive reward account
     pub fn incentive_reward_account_id() -> T::AccountId {
-        let account_id: T::AccountId = T::PalletId::get().into_account_truncating();
-        let entropy = (INCENTIVE_ACCOUNT_PREFIX, &[account_id]).using_encoded(blake2_256);
-        T::AccountId::decode(&mut &entropy[..]).expect("Account derivation failure")
+        T::PalletId::get().into_sub_account_truncating(INCENTIVE_SUB_ACCOUNT)
     }
 }
 

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -51,8 +51,6 @@ use sp_runtime::{
     },
     ArithmeticError, FixedPointNumber, FixedU128,
 };
-#[cfg(feature = "try-runtime")]
-use sp_std::vec::Vec;
 use sp_std::{marker, result::Result};
 
 use traits::{

--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -1025,7 +1025,7 @@ fn withdraw_missing_reward_works() {
 
         assert_eq!(Tokens::balance(INTR, &ALICE), unit(40));
 
-        assert_eq!(Tokens::balance(INTR, &Loans::reward_account_id().unwrap()), unit(60));
+        assert_eq!(Tokens::balance(INTR, &Loans::reward_account_id()), unit(60));
     })
 }
 
@@ -1235,7 +1235,7 @@ fn reward_calculation_one_player_in_multi_markets_works() {
         assert_eq!(Tokens::balance(INTR, &DAVE), unit(800));
         assert_eq!(almost_equal(Tokens::balance(INTR, &ALICE), unit(130)), true);
         assert_eq!(
-            almost_equal(Tokens::balance(INTR, &Loans::reward_account_id().unwrap()), unit(70)),
+            almost_equal(Tokens::balance(INTR, &Loans::reward_account_id()), unit(70)),
             true
         );
         assert_ok!(Loans::update_market_reward_speed(
@@ -1364,7 +1364,7 @@ fn reward_calculation_multi_player_in_one_market_works() {
         assert_eq!(almost_equal(Tokens::balance(INTR, &ALICE), unit(58)), true);
         assert_eq!(almost_equal(Tokens::balance(INTR, &BOB), unit(22)), true);
         assert_eq!(
-            almost_equal(Tokens::balance(INTR, &Loans::reward_account_id().unwrap()), unit(120)),
+            almost_equal(Tokens::balance(INTR, &Loans::reward_account_id()), unit(120)),
             true
         );
     })
@@ -1452,14 +1452,14 @@ fn reward_calculation_after_liquidate_borrow_works() {
         assert_ok!(Loans::distribute_borrower_reward(KSM, &BOB));
         assert_ok!(Loans::distribute_supplier_reward(
             DOT,
-            &Loans::incentive_reward_account_id().unwrap(),
+            &Loans::incentive_reward_account_id(),
         ));
 
         assert_eq!(almost_equal(Loans::reward_accrued(ALICE), milli_unit(22375)), true);
         assert_eq!(almost_equal(Loans::reward_accrued(BOB), micro_unit(37512500)), true);
         assert_eq!(
             almost_equal(
-                Loans::reward_accrued(Loans::incentive_reward_account_id().unwrap()),
+                Loans::reward_accrued(Loans::incentive_reward_account_id()),
                 micro_unit(112500),
             ),
             true,

--- a/crates/loans/src/tests/liquidate_borrow.rs
+++ b/crates/loans/src/tests/liquidate_borrow.rs
@@ -121,7 +121,7 @@ fn full_workflow_works_as_expected() {
             unit(107),
         );
         // 3 dollar reserved in our incentive reward account
-        let incentive_reward_account = Loans::incentive_reward_account_id().unwrap();
+        let incentive_reward_account = Loans::incentive_reward_account_id();
         println!("incentive reserve account:{:?}", incentive_reward_account.clone());
         assert_eq!(
             Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
@@ -154,7 +154,7 @@ fn full_workflow_works_as_expected() {
 #[test]
 fn withdrawing_incentive_reserve_accrues_interest() {
     new_test_ext().execute_with(|| {
-        let incentive_reward_account = Loans::incentive_reward_account_id().unwrap();
+        let incentive_reward_account = Loans::incentive_reward_account_id();
         initial_setup();
         alice_borrows_100_ksm();
         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), KSM));

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -633,10 +633,10 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
         LoansAccount::get(),
         // Reserve account where lending liquidation rewards are routed as lend tokens
         // Assumes that derivation of the incentive reward account can never fail
-        Loans::incentive_reward_account_id().unwrap(),
+        Loans::incentive_reward_account_id(),
         // Account where lending and borrowing subsidy rewards are deposited
         // Assumes that derivation of the reward account can never fail
-        Loans::reward_account_id().unwrap(),
+        Loans::reward_account_id(),
     ]
 }
 

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -617,6 +617,8 @@ parameter_types! {
     pub CollatorSelectionAccount: AccountId = CollatorPotId::get().into_account_truncating();
     // wd9yNSwR5jsJWJrtHcnS8Wf6D5zF2dbQhxwRuvAzg9jefbhuM
     pub VaultRegistryAccount: AccountId = VaultRegistryPalletId::get().into_account_truncating();
+    // wd9yNSwR5jsJWJZ6yzpWRRhe59Z8xLQvZpxrPF7ux76mKaBZ6
+    pub LoansAccount: AccountId = LoansPalletId::get().into_account_truncating();
 }
 
 pub fn get_all_module_accounts() -> Vec<AccountId> {
@@ -628,6 +630,13 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
         TreasuryAccount::get(),
         CollatorSelectionAccount::get(),
         VaultRegistryAccount::get(),
+        LoansAccount::get(),
+        // Reserve account where lending liquidation rewards are routed as lend tokens
+        // Assumes that derivation of the incentive reward account can never fail
+        Loans::incentive_reward_account_id().unwrap(),
+        // Account where lending and borrowing subsidy rewards are deposited
+        // Assumes that derivation of the reward account can never fail
+        Loans::reward_account_id().unwrap(),
     ]
 }
 

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -635,10 +635,10 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
         LoansAccount::get(),
         // Reserve account where lending liquidation rewards are routed as lend tokens
         // Assumes that derivation of the incentive reward account can never fail
-        Loans::incentive_reward_account_id().unwrap(),
+        Loans::incentive_reward_account_id(),
         // Account where lending and borrowing subsidy rewards are deposited
         // Assumes that derivation of the reward account can never fail
-        Loans::reward_account_id().unwrap(),
+        Loans::reward_account_id(),
     ]
 }
 

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -619,6 +619,8 @@ parameter_types! {
     pub CollatorSelectionAccount: AccountId = CollatorPotId::get().into_account_truncating();
     // a3cgeH7D28bBsHbch2n7DChKEapamDqY9yAm441K9WUQZbBGJ
     pub VaultRegistryAccount: AccountId = VaultRegistryPalletId::get().into_account_truncating();
+    // a3cgeH7D28bBsHHqPQpBW7js6ePUgvf41qCBXNxERTqXDZcpv
+    pub LoansAccount: AccountId = LoansPalletId::get().into_account_truncating();
 }
 
 pub fn get_all_module_accounts() -> Vec<AccountId> {
@@ -630,6 +632,13 @@ pub fn get_all_module_accounts() -> Vec<AccountId> {
         TreasuryAccount::get(),
         CollatorSelectionAccount::get(),
         VaultRegistryAccount::get(),
+        LoansAccount::get(),
+        // Reserve account where lending liquidation rewards are routed as lend tokens
+        // Assumes that derivation of the incentive reward account can never fail
+        Loans::incentive_reward_account_id().unwrap(),
+        // Account where lending and borrowing subsidy rewards are deposited
+        // Assumes that derivation of the reward account can never fail
+        Loans::reward_account_id().unwrap(),
     ]
 }
 

--- a/standalone/runtime/tests/test_loans.rs
+++ b/standalone/runtime/tests/test_loans.rs
@@ -199,14 +199,14 @@ fn integration_test_liquidation() {
         // the rest of the slashed collateral routed to the incentive reward account's free balance
         assert_eq!(
             almost_equal(
-                free_balance(LEND_KINT, &LoansPallet::incentive_reward_account_id().unwrap()),
+                free_balance(LEND_KINT, &LoansPallet::incentive_reward_account_id()),
                 10 * one_kint,
                 lend_kint_precision
             ),
             true
         );
         assert_eq!(
-            reserved_balance(LEND_KINT, &LoansPallet::incentive_reward_account_id().unwrap()),
+            reserved_balance(LEND_KINT, &LoansPallet::incentive_reward_account_id()),
             0
         );
     });


### PR DESCRIPTION
Investigating the dust amount edge case in lending (part of https://github.com/interlay/interbtc/issues/747) led to finding this dust whitelist. Dust amounts are currently set to zero but it's good to keep the whitelist up-to-date.

Adds lendining accounts to the dust whitelist on the testnets:
- `LoansAccount::get()` - Main account where pool assets are held, along with the interest rewards of the reserve.
- `Loans::incentive_reward_account_id()` - Reserve account where lending liquidation rewards are routed as Lend Tokens.
- `Loans::reward_account_id()` - Account where lending and borrowing subsidy rewards are deposited.

Two issues I am thinking of:
- The last two calls above require `unwrap`ping. If you believe this should be avoided I can look into some alternative implementations for these accounts.
- Is a migration required when the pallet config (the whitelist) changes?