### PR TITLE
Test multiple lending liquidations

### DIFF
--- a/crates/loans/src/benchmarking.rs
+++ b/crates/loans/src/benchmarking.rs
@@ -447,4 +447,4 @@ benchmarks! {
     }
 }
 
-impl_benchmark_test_suite!(Loans, crate::mock::new_test_ext_benchmarking(), crate::mock::Test);
+impl_benchmark_test_suite!(Loans, crate::mock::new_test_ext_no_markets(), crate::mock::Test);

--- a/crates/loans/src/mock.rs
+++ b/crates/loans/src/mock.rs
@@ -305,7 +305,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 }
 
 #[cfg(test)]
-pub(crate) fn new_test_ext_benchmarking() -> sp_io::TestExternalities {
+pub(crate) fn new_test_ext_no_markets() -> sp_io::TestExternalities {
     use currency::CurrencyConversion;
     use mocktopus::mocking::Mockable;
 

--- a/crates/loans/src/tests/liquidate_borrow.rs
+++ b/crates/loans/src/tests/liquidate_borrow.rs
@@ -59,16 +59,9 @@ fn deposit_of_borrower_must_be_collateral() {
             Error::<Test>::TooMuchRepay
         );
 
-        // Previously (in Parallel's original implementation), this extrinsic call used to
-        // return a `DepositsAreNotCollateral` error.
-        // However, because the collateral "toggle" has been removed, the extrinsic looks
-        // directly inside the `AccountDeposits` map, which no longer represents lend_token holdings
-        // but rather lend_tokens that have been locked as collateral.
-        // Since no KSM lend_tokens have been locked as collateral in this test, there will be zero
-        // collateral available for paying the liquidator, thus producing the error below.
         assert_noop!(
             Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, 10, DOT),
-            Error::<Test>::InsufficientCollateral
+            Error::<Test>::DepositsAreNotCollateral
         );
     })
 }
@@ -282,6 +275,7 @@ fn close_factor_may_require_multiple_liquidations_to_clear_bad_debt() {
         // secure ratio        = 40%
         // liquidation ratio   = 45%
         // liquidation premium = 110%
+        // close factor        = 50%
         initial_setup();
         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, unit(80)));
         // Step 1.

--- a/crates/loans/src/tests/liquidate_borrow.rs
+++ b/crates/loans/src/tests/liquidate_borrow.rs
@@ -1,20 +1,25 @@
 use crate::{
-    mock::{new_test_ext, with_price, CurrencyConvert, Loans, RuntimeOrigin, Test, Tokens, _run_to_block, ALICE, BOB},
+    mock::{
+        new_test_ext, with_price, CurrencyConvert, Loans, RuntimeOrigin, Test, Tokens, _run_to_block, market_mock,
+        new_test_ext_no_markets, ALICE, BOB, DEFAULT_WRAPPED_CURRENCY, LEND_KBTC, LEND_KSM,
+    },
     tests::unit,
-    Error, MarketState,
+    Amount, Error, Market, MarketState,
 };
 use currency::CurrencyConversion;
 use frame_support::{assert_noop, assert_ok, traits::fungibles::Inspect};
 use mocktopus::mocking::Mockable;
 use primitives::{
+    Balance,
     CurrencyId::{self, Token},
-    Rate, DOT as DOT_CURRENCY, KBTC as KBTC_CURRENCY, KSM as KSM_CURRENCY,
+    Rate, Ratio, DOT as DOT_CURRENCY, KBTC as KBTC_CURRENCY, KSM as KSM_CURRENCY,
 };
 use sp_runtime::FixedPointNumber;
+use traits::LoansApi;
 
 const DOT: CurrencyId = Token(DOT_CURRENCY);
 const KSM: CurrencyId = Token(KSM_CURRENCY);
-const USDT: CurrencyId = Token(KBTC_CURRENCY);
+const KBTC: CurrencyId = Token(KBTC_CURRENCY);
 
 #[test]
 fn liquidate_borrow_allowed_works() {
@@ -80,7 +85,7 @@ fn collateral_value_must_be_greater_than_liquidation_value() {
         })
         .unwrap();
         assert_noop!(
-            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(50), USDT),
+            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(50), KBTC),
             Error::<Test>::InsufficientCollateral
         );
     })
@@ -99,7 +104,7 @@ fn full_workflow_works_as_expected() {
             ALICE,
             KSM,
             unit(50),
-            USDT
+            KBTC
         ));
 
         // KSM price = 2
@@ -110,46 +115,46 @@ fn full_workflow_works_as_expected() {
         // Alice KSM borrow balance: origin borrow balance - liquidate amount = 100 - 50 = 50
         // Bob KSM: cash - deposit - repay = 1000 - 200 - 50 = 750
         // Bob DOT collateral: incentive = 110-(110/1.1*0.03)=107
-        assert_eq!(Tokens::balance(USDT, &ALICE), unit(800),);
+        assert_eq!(Tokens::balance(KBTC, &ALICE), unit(800),);
         assert_eq!(
-            Loans::exchange_rate(USDT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(USDT).unwrap(), &ALICE)),
+            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KBTC).unwrap(), &ALICE)),
             unit(90),
         );
         assert_eq!(Tokens::balance(KSM, &ALICE), unit(1100),);
         assert_eq!(Loans::account_borrows(KSM, ALICE).principal, unit(50));
         assert_eq!(Tokens::balance(KSM, &BOB), unit(750));
         assert_eq!(
-            Loans::exchange_rate(USDT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(USDT).unwrap(), &BOB)),
+            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KBTC).unwrap(), &BOB)),
             unit(107),
         );
         // 3 dollar reserved in our incentive reward account
         let incentive_reward_account = Loans::incentive_reward_account_id().unwrap();
         println!("incentive reserve account:{:?}", incentive_reward_account.clone());
         assert_eq!(
-            Loans::exchange_rate(USDT).saturating_mul_int(Tokens::balance(
-                Loans::lend_token_id(USDT).unwrap(),
+            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
+                Loans::lend_token_id(KBTC).unwrap(),
                 &incentive_reward_account.clone()
             )),
             unit(3),
         );
-        assert_eq!(Tokens::balance(USDT, &ALICE), unit(800),);
+        assert_eq!(Tokens::balance(KBTC, &ALICE), unit(800),);
         // reduce 2 dollar from incentive reserve to alice account
         assert_ok!(Loans::reduce_incentive_reserves(
             RuntimeOrigin::root(),
             ALICE,
-            USDT,
+            KBTC,
             unit(2),
         ));
         // still 1 dollar left in reserve account
         assert_eq!(
-            Loans::exchange_rate(USDT).saturating_mul_int(Tokens::balance(
-                Loans::lend_token_id(USDT).unwrap(),
+            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
+                Loans::lend_token_id(KBTC).unwrap(),
                 &incentive_reward_account
             )),
             unit(1),
         );
         // 2 dollar transfer to alice
-        assert_eq!(Tokens::balance(USDT, &ALICE), unit(800) + unit(2),);
+        assert_eq!(Tokens::balance(KBTC, &ALICE), unit(800) + unit(2),);
     })
 }
 
@@ -160,7 +165,7 @@ fn withdrawing_incentive_reserve_accrues_interest() {
         initial_setup();
         alice_borrows_100_ksm();
         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), KSM));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(BOB), USDT, unit(100)));
+        assert_ok!(Loans::borrow(RuntimeOrigin::signed(BOB), KBTC, unit(100)));
         // adjust KSM price to make ALICE generate shortfall
         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
         // BOB repay the KSM borrow balance and get DOT from ALICE
@@ -169,11 +174,11 @@ fn withdrawing_incentive_reserve_accrues_interest() {
             ALICE,
             KSM,
             unit(50),
-            USDT
+            KBTC
         ));
         assert_eq!(
-            Loans::exchange_rate(USDT).saturating_mul_int(Tokens::balance(
-                Loans::lend_token_id(USDT).unwrap(),
+            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
+                Loans::lend_token_id(KBTC).unwrap(),
                 &incentive_reward_account
             )),
             unit(3),
@@ -185,7 +190,7 @@ fn withdrawing_incentive_reserve_accrues_interest() {
         assert_ok!(Loans::reduce_incentive_reserves(
             RuntimeOrigin::root(),
             ALICE,
-            USDT,
+            KBTC,
             3000169788955,
         ));
     })
@@ -223,6 +228,142 @@ fn liquidator_can_not_repay_more_than_the_close_factor_pct_multiplier() {
 }
 
 #[test]
+fn liquidated_transfer_reduces_locked_collateral() {
+    new_test_ext().execute_with(|| {
+        initial_setup();
+        alice_borrows_100_ksm();
+        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+        let amount_to_liquidate = Amount::<Test>::new(unit(50), KSM);
+        let initial_locked_collateral = Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
+        let initial_locked_underlying = Loans::recompute_underlying_amount(&initial_locked_collateral).unwrap();
+        assert_ok!(Loans::liquidate_borrow(
+            RuntimeOrigin::signed(BOB),
+            ALICE,
+            KSM,
+            amount_to_liquidate.amount(),
+            KBTC
+        ),);
+        let final_locked_collateral = Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
+        let final_locked_underlying = Loans::recompute_underlying_amount(&final_locked_collateral).unwrap();
+        // The total liquidated KSM includes the market's liquidation incentive
+        let liquidation_incentive = Loans::market(KSM).unwrap().liquidate_incentive;
+        let liquidated_ksm = amount_to_liquidate
+            .checked_fixed_point_mul(&liquidation_incentive)
+            .unwrap();
+        let liquidated_ksm_as_wrapped = liquidated_ksm.convert_to(DEFAULT_WRAPPED_CURRENCY).unwrap();
+        // The borrower's locked collateral (as tracked by the `AccountDeposits` storage item) must have been decreased
+        // by the liquidated amount.
+        let borrower_collateral_difference_as_wrapped = initial_locked_underlying
+            .checked_sub(&final_locked_underlying)
+            .unwrap()
+            .convert_to(DEFAULT_WRAPPED_CURRENCY)
+            .unwrap();
+        assert!(liquidated_ksm_as_wrapped
+            .eq(&borrower_collateral_difference_as_wrapped)
+            .unwrap());
+    })
+}
+
+#[test]
+fn close_factor_may_require_multiple_liquidations_to_clear_bad_debt() {
+    new_test_ext_no_markets().execute_with(|| {
+        fn conservative_mock_market(lend_token: CurrencyId) -> Market<Balance> {
+            Market {
+                collateral_factor: Ratio::from_percent(40),
+                liquidation_threshold: Ratio::from_percent(45),
+                ..market_mock(lend_token)
+            }
+        }
+        Loans::add_market(RuntimeOrigin::root(), KSM, conservative_mock_market(LEND_KSM)).unwrap();
+        Loans::activate_market(RuntimeOrigin::root(), KSM).unwrap();
+        Loans::add_market(RuntimeOrigin::root(), KBTC, conservative_mock_market(LEND_KBTC)).unwrap();
+        Loans::activate_market(RuntimeOrigin::root(), KBTC).unwrap();
+        // Market setup:
+        // secure ratio        = 40%
+        // liquidation ratio   = 45%
+        // liquidation premium = 110%
+        initial_setup();
+        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, unit(80)));
+        // Step 1.
+        // Collateral = 200 KBTC (worth 200 reference units)
+        // Debt       =  80 KSM  (worth  80 reference units)
+        // Collateral ratio = 40%
+        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+
+        // Step 2.
+        // Collateral = 200 KBTC (worth 200 reference units)
+        // Debt       =  80 KSM  (worth 160 reference units)
+        // Collateral ratio = 80% (unhealthy)
+        assert_noop!(
+            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(41), KBTC),
+            Error::<Test>::TooMuchRepay
+        );
+        assert_ok!(Loans::liquidate_borrow(
+            RuntimeOrigin::signed(BOB),
+            ALICE,
+            KSM,
+            unit(40),
+            KBTC
+        ),);
+        // There is still shortfall in spite of liquidating the max available amount
+        let shortfall = Loans::get_account_liquidation_threshold_liquidity(&ALICE)
+            .unwrap()
+            .shortfall();
+        assert!(
+            !shortfall.is_zero(),
+            "Shortfall should be greater than zero, because the close factor limited the max liquidatable amount"
+        );
+
+        // Step 3.
+        // Collateral = 112 KBTC (worth 112 reference units)
+        // Debt       =  40 KSM  (worth 80 reference units)
+        // Collateral ratio = 71% (unhealthy)
+        assert_ok!(Loans::liquidate_borrow(
+            RuntimeOrigin::signed(BOB),
+            ALICE,
+            KSM,
+            unit(20),
+            KBTC
+        ),);
+
+        // Step 4.
+        // Collateral =  68 KBTC (worth 68 reference units)
+        // Debt       =  20 KSM  (worth 40 reference units)
+        // Collateral ratio = 59% (unhealthy)
+        assert_ok!(Loans::liquidate_borrow(
+            RuntimeOrigin::signed(BOB),
+            ALICE,
+            KSM,
+            unit(10),
+            KBTC
+        ),);
+
+        // Step 5.
+        // Collateral =  24 KBTC (worth 24 reference units)
+        // Debt       =  10 KSM  (worth 10 reference units)
+        // Collateral ratio = 42% (healthy)
+        // At this point the debt is healthy, cannot liquidate even one planck
+        assert_noop!(
+            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, 1, KBTC),
+            Error::<Test>::InsufficientShortfall
+        );
+        let shortfall_final = Loans::get_account_liquidation_threshold_liquidity(&ALICE)
+            .unwrap()
+            .shortfall();
+        assert!(
+            shortfall_final.is_zero(),
+            "The borrower should have no shortfall after repeated max liquidations"
+        );
+
+        // The borrower can take on no additional debt because they exceeded the 40% secure ratio
+        assert_noop!(
+            Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, 1),
+            Error::<Test>::InsufficientLiquidity
+        );
+    })
+}
+
+#[test]
 fn liquidator_must_not_be_borrower() {
     new_test_ext().execute_with(|| {
         initial_setup();
@@ -240,7 +381,7 @@ fn alice_borrows_100_ksm() {
 fn initial_setup() {
     // Bob deposits 200 KSM
     assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), KSM, unit(200)));
-    // Alice deposits 200 DOT as collateral
-    assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), USDT, unit(200)));
-    assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), USDT));
+    // Alice deposits 200 KBTC as collateral
+    assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), KBTC, unit(200)));
+    assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), KBTC));
 }


### PR DESCRIPTION
The `close factor` parameter restricts how much a liquidator can clear of a borrower's debt, and is usually set to 50%. In the case where a borrower becomes very poorly collateralized, a single liquidation extrinsic may not be enough, because the resulting collateral ratio may still be above the configured liquidation ratio. The `close_factor_may_require_multiple_liquidations_to_clear_bad_debt` unit test checks this works as expected.

In addition, I found a bug where borrowers would be able to keep reborrowing after being liquidated, based on the value of their pre-liquidation collateral. The `liquidated_transfer_reduces_locked_collateral` unit test checks this edge case.

The PR also refactors the `liquidate_borrow` extrinsic to better match the original implementation, to simplify comparing the two codebases.