### PR TITLE
feat: true oracle medianizing

### DIFF
--- a/crates/currency/src/lib.rs
+++ b/crates/currency/src/lib.rs
@@ -92,7 +92,8 @@ pub mod pallet {
             + EncodeLike
             + Decode
             + MaybeSerializeDeserialize
-            + TypeInfo;
+            + TypeInfo
+            + From<BalanceOf<Self>>;
 
         type SignedInner: Debug
             + CheckedDiv

--- a/crates/oracle/src/lib.rs
+++ b/crates/oracle/src/lib.rs
@@ -366,20 +366,20 @@ impl<T: Config> Pallet<T> {
     }
 
     fn median(mut raw_values: Vec<UnsignedFixedPoint<T>>) -> Option<UnsignedFixedPoint<T>> {
-        let mid_index = raw_values.len() / 2;
+        let mid_index = raw_values.len().checked_div(2)?;
         raw_values.sort_unstable();
         match raw_values.len() {
             0 => None,
-            len if len % 2 == 0 => {
+            len if len.checked_rem(2)? == 0 => {
                 // even number - get avg of 2 values
-                let value_1 = raw_values[mid_index - 1];
-                let value_2 = raw_values[mid_index];
+                let value_1 = raw_values.get(mid_index.checked_sub(1)?)?;
+                let value_2 = raw_values.get(mid_index)?;
                 let value = value_1
                     .checked_add(&value_2)?
                     .checked_div(&UnsignedFixedPoint::<T>::from(2u32.into()))?;
                 Some(value)
             }
-            _ => Some(raw_values[mid_index]),
+            _ => Some(*raw_values.get(mid_index)?),
         }
     }
 

--- a/crates/oracle/src/lib.rs
+++ b/crates/oracle/src/lib.rs
@@ -353,16 +353,33 @@ impl<T: Config> Pallet<T> {
                 .map(|timestamp| timestamp + Self::get_max_delay())
                 .unwrap_or_default(); // Unwrap will never fail, but if somehow it did, we retry next block
 
-            let mid_index = raw_values.len() / 2;
-            let (_, value, _) = raw_values.select_nth_unstable_by(mid_index as usize, |a, b| a.value.cmp(&b.value));
+            let value = Self::median(raw_values.iter().map(|x| x.value).collect())?;
 
-            Aggregate::<T>::insert(key, value.value);
+            Aggregate::<T>::insert(key, value);
             ValidUntil::<T>::insert(key, valid_until);
             if let OracleKey::ExchangeRate(currency_id) = key {
                 T::OnExchangeRateChange::on_exchange_rate_change(currency_id);
             }
 
-            Some(value.value)
+            Some(value)
+        }
+    }
+
+    fn median(mut raw_values: Vec<UnsignedFixedPoint<T>>) -> Option<UnsignedFixedPoint<T>> {
+        let mid_index = raw_values.len() / 2;
+        raw_values.sort_unstable();
+        match raw_values.len() {
+            0 => None,
+            len if len % 2 == 0 => {
+                // even number - get avg of 2 values
+                let value_1 = raw_values[mid_index - 1];
+                let value_2 = raw_values[mid_index];
+                let value = value_1
+                    .checked_add(&value_2)?
+                    .checked_div(&UnsignedFixedPoint::<T>::from(2u32.into()))?;
+                Some(value)
+            }
+            _ => Some(raw_values[mid_index]),
         }
     }
 

--- a/crates/oracle/src/tests.rs
+++ b/crates/oracle/src/tests.rs
@@ -344,3 +344,22 @@ fn begin_block_set_oracle_offline_succeeds() {
         assert!(oracle_reported, "Oracle should be reported as offline");
     });
 }
+
+#[test]
+fn test_median() {
+    let test_cases = [
+        (vec![], None),
+        (vec![2], Some(2.0)),
+        (vec![2, 1], Some(1.5)),
+        (vec![1, 2, 3], Some(2.0)),
+        (vec![2, 1, 3], Some(2.0)),
+        (vec![10, 2, 1, 3], Some(2.5)),
+        (vec![10, 2, 1, 3, 0], Some(2.0)),
+    ];
+    for (input, output) in test_cases {
+        let input_fixedpoint = input.into_iter().map(|x| FixedU128::from(x)).collect();
+        let output_fixedpoint = output.map(|x| FixedU128::from_float(x));
+
+        assert_eq!(Oracle::median(input_fixedpoint), output_fixedpoint);
+    }
+}


### PR DESCRIPTION
Since we want to move toward having multiple oracle submitters, I think it's a good idea to have true medianizing rather than using the middle value. My reasoning is:
- the middle value was potentially unstable - given an input of even length, it would be very bad if we swap unpredictably between the two middle values
- with the true median, changes are a little bit smoother when the number of active oracles changes
- the number of authorized oracles is expected to be not very great, making the increased complexity of O(n*log(n)) (compared to O(n) for the middle value) not really important