### PR TITLE
test(loans): liquidation reward is auto-locked

### DIFF
--- a/crates/loans/src/mock.rs
+++ b/crates/loans/src/mock.rs
@@ -249,6 +249,7 @@ pub(crate) fn set_mock_balances() {
     Tokens::set_balance(RuntimeOrigin::root(), ALICE, Token(IBTC), 1_000_000_000_000_000, 0).unwrap();
     Tokens::set_balance(RuntimeOrigin::root(), BOB, Token(KSM), 1_000_000_000_000_000, 0).unwrap();
     Tokens::set_balance(RuntimeOrigin::root(), BOB, Token(DOT), 1_000_000_000_000_000, 0).unwrap();
+    Tokens::set_balance(RuntimeOrigin::root(), BOB, Token(KBTC), 1_000_000_000_000_000, 0).unwrap();
     Tokens::set_balance(RuntimeOrigin::root(), DAVE, Token(DOT), 1_000_000_000_000_000, 0).unwrap();
     Tokens::set_balance(RuntimeOrigin::root(), DAVE, Token(KBTC), 1_000_000_000_000_000, 0).unwrap();
     Tokens::set_balance(RuntimeOrigin::root(), DAVE, Token(KINT), 1_000_000_000_000_000, 0).unwrap();

--- a/crates/loans/src/tests/liquidate_borrow.rs
+++ b/crates/loans/src/tests/liquidate_borrow.rs
@@ -258,10 +258,11 @@ fn repay_currency_auto_locking_works() {
             .mul_floor(borrower_slash.checked_div(&liquidate_incentive).unwrap().amount());
         // The amount received by the liquidator should be whatever is slashed
         // from the borrower minus the reserve's share.
-        let expected_liquidator_reward = borrower_slash.amount().checked_sub(reserved_reward).unwrap();
+        let expected_liquidator_reward = borrower_slash.amount() - reserved_reward;
 
-        assert!(
-            actual_liquidator_reward.amount().eq(&expected_liquidator_reward),
+        assert_eq!(
+            actual_liquidator_reward.amount(),
+            expected_liquidator_reward,
             "The entirety of the liquidator's reward should have been auto-locked as collateral"
         );
     })
@@ -298,9 +299,7 @@ fn liquidated_transfer_reduces_locked_collateral() {
             .unwrap()
             .convert_to(DEFAULT_WRAPPED_CURRENCY)
             .unwrap();
-        assert!(liquidated_ksm_as_wrapped
-            .eq(&borrower_collateral_difference_as_wrapped)
-            .unwrap());
+        assert_eq!(liquidated_ksm_as_wrapped, borrower_collateral_difference_as_wrapped);
     })
 }
 

--- a/crates/loans/src/tests/liquidate_borrow.rs
+++ b/crates/loans/src/tests/liquidate_borrow.rs
@@ -221,6 +221,53 @@ fn liquidator_can_not_repay_more_than_the_close_factor_pct_multiplier() {
 }
 
 #[test]
+fn repay_currency_auto_locking_works() {
+    new_test_ext().execute_with(|| {
+        initial_setup();
+        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), KBTC, 1));
+        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), KBTC));
+        alice_borrows_100_ksm();
+        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+        let initial_borrower_locked_collateral =
+            Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
+        let initial_liquidator_locked_collateral =
+            Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &BOB), LEND_KBTC);
+        assert_ok!(Loans::liquidate_borrow(
+            RuntimeOrigin::signed(BOB),
+            ALICE,
+            KSM,
+            unit(50),
+            KBTC
+        ),);
+        let final_borrower_locked_collateral =
+            Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
+        let final_liquidator_locked_collateral =
+            Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &BOB), LEND_KBTC);
+        let actual_liquidator_reward = final_liquidator_locked_collateral
+            .checked_sub(&initial_liquidator_locked_collateral)
+            .unwrap();
+        let borrower_slash = initial_borrower_locked_collateral
+            .checked_sub(&final_borrower_locked_collateral)
+            .unwrap();
+        let Market {
+            liquidate_incentive,
+            liquidate_incentive_reserved_factor,
+            ..
+        } = Loans::market(KSM).unwrap();
+        let reserved_reward = liquidate_incentive_reserved_factor
+            .mul_floor(borrower_slash.checked_div(&liquidate_incentive).unwrap().amount());
+        // The amount received by the liquidator should be whatever is slashed
+        // from the borrower minus the reserve's share.
+        let expected_liquidator_reward = borrower_slash.amount().checked_sub(reserved_reward).unwrap();
+
+        assert!(
+            actual_liquidator_reward.amount().eq(&expected_liquidator_reward),
+            "The entirety of the liquidator's reward should have been auto-locked as collateral"
+        );
+    })
+}
+
+#[test]
 fn liquidated_transfer_reduces_locked_collateral() {
     new_test_ext().execute_with(|| {
         initial_setup();


### PR DESCRIPTION
Tests that if the liquidator of a bad loan chooses to be rewarded in a currency they already locked as collateral, the received amount is auto-locked as collateral as well.