### PR TITLE
feat: allow rewards to be paid in any currency

### DIFF
--- a/crates/reward/src/lib.rs
+++ b/crates/reward/src/lib.rs
@@ -26,7 +26,7 @@ use sp_runtime::{
     traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, MaybeSerializeDeserialize, Saturating, Zero},
     ArithmeticError,
 };
-use sp_std::{cmp::PartialOrd, convert::TryInto, fmt::Debug};
+use sp_std::{cmp::PartialOrd, collections::btree_set::BTreeSet, convert::TryInto, fmt::Debug};
 
 pub(crate) type SignedFixedPoint<T, I = ()> = <T as Config<I>>::SignedFixedPoint;
 
@@ -100,7 +100,15 @@ pub mod pallet {
     }
 
     #[pallet::hooks]
-    impl<T: Config<I>, I: 'static> Hooks<T::BlockNumber> for Pallet<T, I> {}
+    impl<T: Config<I>, I: 'static> Hooks<T::BlockNumber> for Pallet<T, I> {
+        fn on_runtime_upgrade() -> Weight {
+            RewardCurrencies::<T, I>::mutate(|reward_currencies| {
+                reward_currencies.insert(T::GetNativeCurrencyId::get());
+                reward_currencies.insert(T::GetWrappedCurrencyId::get());
+            });
+            Weight::zero()
+        }
+    }
 
     /// The total stake deposited to this reward pool.
     #[pallet::storage]
@@ -144,6 +152,10 @@ pub mod pallet {
         SignedFixedPoint<T, I>,
         ValueQuery,
     >;
+
+    /// Track the currencies used for rewards.
+    #[pallet::storage]
+    pub type RewardCurrencies<T: Config<I>, I: 'static = ()> = StorageValue<_, BTreeSet<T::CurrencyId>, ValueQuery>;
 
     #[pallet::pallet]
     #[pallet::without_storage_info]
@@ -199,6 +211,23 @@ macro_rules! checked_sub_mut {
 
 // "Internal" functions, callable by code.
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+    // TODO: remove this after the migration, I have added
+    // this because it's not clear whether the capacity migration
+    // will run before or after the pallet hook and we need to make
+    // sure these are included for any deposits / withdrawals
+    fn add_default_currencies() {
+        let reward_currencies = RewardCurrencies::<T, I>::get();
+        if reward_currencies.contains(&T::GetNativeCurrencyId::get())
+            && reward_currencies.contains(&T::GetWrappedCurrencyId::get())
+        {
+            return;
+        }
+        RewardCurrencies::<T, I>::mutate(|reward_currencies| {
+            reward_currencies.insert(T::GetNativeCurrencyId::get());
+            reward_currencies.insert(T::GetWrappedCurrencyId::get());
+        });
+    }
+
     pub fn stake(pool_id: &T::PoolId, stake_id: &T::StakeId) -> SignedFixedPoint<T, I> {
         Stake::<T, I>::get((pool_id, stake_id))
     }
@@ -219,7 +248,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         checked_add_mut!(Stake<T, I>, (pool_id, stake_id), &amount);
         checked_add_mut!(TotalStake<T, I>, pool_id, &amount);
 
-        for currency_id in [T::GetNativeCurrencyId::get(), T::GetWrappedCurrencyId::get()] {
+        Self::add_default_currencies();
+        for currency_id in RewardCurrencies::<T, I>::get() {
             <RewardTally<T, I>>::mutate(currency_id, (pool_id, stake_id), |reward_tally| {
                 let reward_per_token = Self::reward_per_token(currency_id, pool_id);
                 let reward_per_token_mul_amount =
@@ -245,11 +275,16 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         currency_id: T::CurrencyId,
         reward: SignedFixedPoint<T, I>,
     ) -> DispatchResult {
-        let total_stake = Self::total_stake(pool_id);
         if reward.is_zero() {
             return Ok(());
         }
+        let total_stake = Self::total_stake(pool_id);
         ensure!(!total_stake.is_zero(), Error::<T, I>::ZeroTotalStake);
+
+        // track currency for future deposits / withdrawals
+        RewardCurrencies::<T, I>::mutate(|reward_currencies| {
+            reward_currencies.insert(currency_id);
+        });
 
         let reward_div_total_stake = reward.checked_div(&total_stake).ok_or(ArithmeticError::Underflow)?;
         checked_add_mut!(RewardPerToken<T, I>, currency_id, pool_id, &reward_div_total_stake);
@@ -293,7 +328,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         checked_sub_mut!(Stake<T, I>, (pool_id, stake_id), &amount);
         checked_sub_mut!(TotalStake<T, I>, pool_id, &amount);
 
-        for currency_id in [T::GetNativeCurrencyId::get(), T::GetWrappedCurrencyId::get()] {
+        Self::add_default_currencies();
+        for currency_id in RewardCurrencies::<T, I>::get() {
             <RewardTally<T, I>>::mutate(currency_id, (pool_id, stake_id), |reward_tally| {
                 let reward_per_token = Self::reward_per_token(currency_id, pool_id);
                 let reward_per_token_mul_amount =

--- a/crates/reward/src/mock.rs
+++ b/crates/reward/src/mock.rs
@@ -1,7 +1,12 @@
 use crate as reward;
 use crate::{Config, Error};
 use frame_support::{parameter_types, traits::Everything};
-pub use primitives::{CurrencyId, CurrencyId::Token, TokenSymbol::*, VaultCurrencyPair, VaultId};
+pub use primitives::{
+    CurrencyId,
+    CurrencyId::{ForeignAsset, Token},
+    TokenSymbol::*,
+    VaultCurrencyPair, VaultId,
+};
 use sp_arithmetic::FixedI128;
 use sp_core::H256;
 use sp_runtime::{

--- a/crates/reward/src/tests.rs
+++ b/crates/reward/src/tests.rs
@@ -147,3 +147,30 @@ fn should_distribute_with_many_rewards() {
         assert_ok!(Reward::withdraw_reward(&(), &BOB, Token(IBTC)), bob_reward);
     })
 }
+
+macro_rules! assert_approx_eq {
+    ($left:expr, $right:expr, $delta:expr) => {
+        assert!(if $left > $right { $left - $right } else { $right - $left } <= $delta)
+    };
+}
+
+#[test]
+fn should_distribute_with_different_rewards() {
+    run_test(|| {
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(100)));
+        assert_ok!(Reward::distribute_reward(&(), Token(IBTC), fixed!(1000)));
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(100)));
+        assert_ok!(Reward::distribute_reward(&(), Token(INTR), fixed!(1000)));
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(100)));
+        assert_ok!(Reward::distribute_reward(&(), Token(DOT), fixed!(1000)));
+        assert_ok!(Reward::deposit_stake(&(), &ALICE, fixed!(100)));
+        assert_ok!(Reward::distribute_reward(&(), ForeignAsset(0), fixed!(1000)));
+
+        assert_ok!(Reward::withdraw_stake(&(), &ALICE, fixed!(300)));
+
+        assert_approx_eq!(Reward::compute_reward(&(), &ALICE, Token(IBTC)).unwrap(), 1000, 1);
+        assert_approx_eq!(Reward::compute_reward(&(), &ALICE, Token(INTR)).unwrap(), 1000, 1);
+        assert_approx_eq!(Reward::compute_reward(&(), &ALICE, Token(DOT)).unwrap(), 1000, 1);
+        assert_approx_eq!(Reward::compute_reward(&(), &ALICE, ForeignAsset(0)).unwrap(), 1000, 1);
+    })
+}


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

An oversight required for #826 to pay rewards in all currencies, otherwise we would get undefined results when distributing currencies that were not KINT/INTR or kBTC/iBTC. I have not updated the staking pallet since this is only required for farming rewards, Vaults are unaffected.

I wanted to simply iterate over the currencies in `RewardPerToken` but there was no way to do that just for the first key / prefix so the complexity for collecting and de-duplicating that list would be too great. Instead I have added a new storage value for all the reward currencies.

See also: https://github.com/paritytech/substrate/issues/13162