### PR TITLE
chore(loans): remove `withdraw_missing_reward` extrinsic

### DIFF
--- a/crates/loans/src/benchmarking.rs
+++ b/crates/loans/src/benchmarking.rs
@@ -223,19 +223,6 @@ benchmarks! {
         }.into());
     }
 
-    withdraw_missing_reward {
-        let caller: T::AccountId = whitelisted_caller();
-        transfer_initial_balance::<T>(caller.clone());
-        assert_ok!(Loans::<T>::add_reward(SystemOrigin::Signed(caller.clone()).into(), 1_000_000_000_000_u128));
-        let receiver = T::Lookup::unlookup(caller.clone());
-    }: _(SystemOrigin::Root, receiver, 500_000_000_000_u128)
-    verify {
-        assert_last_event::<T>(Event::<T>::RewardWithdrawn {
-            receiver: caller,
-            amount: 500_000_000_000_u128
-        }.into());
-    }
-
     update_market_reward_speed {
         assert_ok!(Loans::<T>::add_market(SystemOrigin::Root.into(), KBTC, pending_market_mock::<T>(LEND_KBTC)));
         assert_ok!(Loans::<T>::activate_market(SystemOrigin::Root.into(), KBTC));

--- a/crates/loans/src/default_weights.rs
+++ b/crates/loans/src/default_weights.rs
@@ -40,7 +40,6 @@ pub trait WeightInfo {
 	fn update_market() -> Weight;
 	fn force_update_market() -> Weight;
 	fn add_reward() -> Weight;
-	fn withdraw_missing_reward() -> Weight;
 	fn update_market_reward_speed() -> Weight;
 	fn claim_reward() -> Weight;
 	fn claim_reward_for_market() -> Weight;
@@ -102,13 +101,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_ref_time(93_667_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
-	}
-	// Storage: Tokens Accounts (r:2 w:2)
-	// Storage: System Account (r:1 w:0)
-	fn withdraw_missing_reward() -> Weight {
-		Weight::from_ref_time(76_333_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(3 as u64))
-			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: Loans Markets (r:2 w:0)
 	// Storage: Loans RewardSupplySpeed (r:1 w:1)
@@ -381,13 +373,6 @@ impl WeightInfo for () {
 		Weight::from_ref_time(93_667_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
-	}
-	// Storage: Tokens Accounts (r:2 w:2)
-	// Storage: System Account (r:1 w:0)
-	fn withdraw_missing_reward() -> Weight {
-		Weight::from_ref_time(76_333_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(3 as u64))
-			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	// Storage: Loans Markets (r:2 w:0)
 	// Storage: Loans RewardSupplySpeed (r:1 w:1)

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -864,37 +864,6 @@ pub mod pallet {
             Ok(().into())
         }
 
-        /// Withdraw reward token from pallet account.
-        ///
-        /// The origin must conform to `UpdateOrigin`.
-        ///
-        /// - `target_account`: account receive reward token.
-        /// - `amount`: Withdraw amount
-        #[pallet::weight(<T as Config>::WeightInfo::withdraw_missing_reward())]
-        #[transactional]
-        pub fn withdraw_missing_reward(
-            origin: OriginFor<T>,
-            target_account: <T::Lookup as StaticLookup>::Source,
-            amount: BalanceOf<T>,
-        ) -> DispatchResultWithPostInfo {
-            T::UpdateOrigin::ensure_origin(origin)?;
-            ensure!(!amount.is_zero(), Error::<T>::InvalidAmount);
-
-            let reward_asset = T::RewardAssetId::get();
-            let pool_account = Self::reward_account_id();
-            let target_account = T::Lookup::lookup(target_account)?;
-
-            let amount_to_transfer: Amount<T> = Amount::new(amount, reward_asset);
-            amount_to_transfer.transfer(&pool_account, &target_account)?;
-
-            Self::deposit_event(Event::<T>::RewardWithdrawn {
-                receiver: target_account,
-                amount,
-            });
-
-            Ok(().into())
-        }
-
         /// Updates reward speed for the specified market
         ///
         /// The origin must conform to `UpdateOrigin`.

--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -290,10 +290,6 @@ fn zero_amount_extrinsics_fail() {
             Error::<Test>::InvalidAmount
         );
         assert_noop!(
-            Loans::withdraw_missing_reward(RuntimeOrigin::root(), BOB, unit(0)),
-            Error::<Test>::InvalidAmount
-        );
-        assert_noop!(
             Loans::mint(RuntimeOrigin::signed(ALICE), DOT, unit(0)),
             Error::<Test>::InvalidAmount
         );
@@ -1009,23 +1005,6 @@ fn ensure_valid_exchange_rate_works() {
             Loans::ensure_valid_exchange_rate(Rate::saturating_from_rational(101, 100)),
             Error::<Test>::InvalidExchangeRate,
         );
-    })
-}
-
-#[test]
-fn withdraw_missing_reward_works() {
-    new_test_ext().execute_with(|| {
-        assert_eq!(Tokens::balance(INTR, &DAVE), unit(1000));
-
-        assert_ok!(Loans::add_reward(RuntimeOrigin::signed(DAVE), unit(100)));
-
-        assert_ok!(Loans::withdraw_missing_reward(RuntimeOrigin::root(), ALICE, unit(40),));
-
-        assert_eq!(Tokens::balance(INTR, &DAVE), unit(900));
-
-        assert_eq!(Tokens::balance(INTR, &ALICE), unit(40));
-
-        assert_eq!(Tokens::balance(INTR, &Loans::reward_account_id()), unit(60));
     })
 }
 


### PR DESCRIPTION
`withdraw_missing_reward` simply moves some incentive funds from the pallet account to an account that presumably didn't receive enough rewards. This can be done through a governance token transfer as well. If the `UpdateOrigin` is set to Root then it really makes no difference.