### PR TITLE
fix: make rewards rpc work

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1609,6 +1609,7 @@ impl_runtime_apis! {
             // distribute rewards accrued over block count
             let reward = VaultAnnuity::min_reward_per_block().saturating_mul(YEARS.into());
             <VaultCapacity as reward::RewardsApi<(), CurrencyId, Balance>>::distribute_reward(&(), NATIVE_CURRENCY_ID, reward)?;
+            Amount::<Runtime>::new(reward, NATIVE_CURRENCY_ID).mint_to(&Fee::fee_pool_account_id())?;
             // compute and convert rewards
             let received = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, NATIVE_CURRENCY_ID)?;
             let received_as_wrapped = Oracle::collateral_to_wrapped(received, NATIVE_CURRENCY_ID)?;

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1595,6 +1595,7 @@ impl_runtime_apis! {
             // distribute rewards accrued over block count
             let reward = VaultAnnuity::min_reward_per_block().saturating_mul(YEARS.into());
             <VaultCapacity as reward::RewardsApi<(), CurrencyId, Balance>>::distribute_reward(&(), NATIVE_CURRENCY_ID, reward)?;
+            Amount::<Runtime>::new(reward, NATIVE_CURRENCY_ID).mint_to(&Fee::fee_pool_account_id())?;
             // compute and convert rewards
             let received = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, NATIVE_CURRENCY_ID)?;
             let received_as_wrapped = Oracle::collateral_to_wrapped(received, NATIVE_CURRENCY_ID)?;

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -1547,6 +1547,7 @@ impl_runtime_apis! {
             // distribute rewards accrued over block count
             let reward = VaultAnnuity::min_reward_per_block().saturating_mul(YEARS.into());
             <VaultCapacity as reward::RewardsApi<(), CurrencyId, Balance>>::distribute_reward(&(), NATIVE_CURRENCY_ID, reward)?;
+            Amount::<Runtime>::new(reward, NATIVE_CURRENCY_ID).mint_to(&Fee::fee_pool_account_id())?;
             // compute and convert rewards
             let received = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, NATIVE_CURRENCY_ID)?;
             let received_as_wrapped = Oracle::collateral_to_wrapped(received, NATIVE_CURRENCY_ID)?;

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -1601,6 +1601,7 @@ impl_runtime_apis! {
             // distribute rewards accrued over block count
             let reward = VaultAnnuity::min_reward_per_block().saturating_mul(YEARS.into());
             <VaultCapacity as reward::RewardsApi<(), CurrencyId, Balance>>::distribute_reward(&(), NATIVE_CURRENCY_ID, reward)?;
+            Amount::<Runtime>::new(reward, NATIVE_CURRENCY_ID).mint_to(&Fee::fee_pool_account_id())?;
             // compute and convert rewards
             let received = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, NATIVE_CURRENCY_ID)?;
             let received_as_wrapped = Oracle::collateral_to_wrapped(received, NATIVE_CURRENCY_ID)?;

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1537,6 +1537,7 @@ impl_runtime_apis! {
             // distribute rewards accrued over block count
             let reward = VaultAnnuity::min_reward_per_block().saturating_mul(YEARS.into());
             <VaultCapacity as reward::RewardsApi<(), CurrencyId, Balance>>::distribute_reward(&(), NATIVE_CURRENCY_ID, reward)?;
+            Amount::<Runtime>::new(reward, NATIVE_CURRENCY_ID).mint_to(&Fee::fee_pool_account_id())?;
             // compute and convert rewards
             let received = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, NATIVE_CURRENCY_ID)?;
             let received_as_wrapped = Oracle::collateral_to_wrapped(received, NATIVE_CURRENCY_ID)?;

--- a/standalone/runtime/tests/mock/mod.rs
+++ b/standalone/runtime/tests/mock/mod.rs
@@ -193,6 +193,8 @@ pub type LoansPallet = loans::Pallet<Runtime>;
 
 pub type AuraPallet = pallet_aura::Pallet<Runtime>;
 
+pub type VaultAnnuityPallet = annuity::Pallet<Runtime, VaultAnnuityInstance>;
+
 pub const DEFAULT_COLLATERAL_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(DOT);
 pub const DEFAULT_WRAPPED_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(IBTC);
 pub const DEFAULT_NATIVE_CURRENCY: <Runtime as orml_tokens::Config>::CurrencyId = Token(INTR);


### PR DESCRIPTION
Without this, the rpc would fail with `Unable to estimate the current reward` because withdrawing the rewards would fail