### PR TITLE
fix(loans): remove logic that redeems locked lend tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,9 +345,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "689894c2db1ea643a50834b999abf1c110887402542955ff5451dab8f861f9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -2011,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2026,15 +2026,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4088,7 +4088,7 @@ checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes 1.0.4",
- "rustix 0.36.6",
+ "rustix 0.36.7",
  "windows-sys 0.42.0",
 ]
 
@@ -5319,7 +5319,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
 dependencies = [
- "rustix 0.36.6",
+ "rustix 0.36.7",
 ]
 
 [[package]]
@@ -5755,9 +5755,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
 ]
@@ -7224,9 +7224,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
+checksum = "e7ab01d0f889e957861bc65888d5ccbe82c158d0270136ba46820d43837cdf72"
 dependencies = [
  "arrayvec 0.7.2",
  "bitvec",
@@ -7239,9 +7239,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
+checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9735,9 +9735,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
  "errno",
@@ -11076,9 +11076,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -11089,9 +11089,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -12885,9 +12885,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -13179,9 +13179,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
 
 [[package]]
 name = "unicode-ident"
@@ -13854,9 +13854,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
  "libc",

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -286,6 +286,8 @@ pub mod pallet {
         WithdrawAllCollateralFailed,
         /// Tokens already locked for a different purpose than borrow collateral
         TokensAlreadyLocked,
+        /// Only free lend tokens are redeemable
+        LockedTokensCannotBeRedeemed,
     }
 
     #[pallet::event]
@@ -1435,25 +1437,12 @@ impl<T: Config> Pallet<T> {
         let redeem_amount = Self::calc_underlying_amount(voucher_amount, exchange_rate)?;
         Self::ensure_enough_cash(asset_id, redeem_amount)?;
 
-        // TODO: Only free lend tokens are redeemable. Replace logic below with this:
-        // if voucher_amount > Self::free_lend_tokens(asset_id, redeemer)?.amount() {
-        //     return Err(...);
-        // }
-
-        // Ensure that withdrawing deposited collateral doesn't leave the user undercollateralized.
-        let collateral_amount = voucher_amount.saturating_sub(Self::free_lend_tokens(asset_id, redeemer)?.amount());
-        let collateral_underlying_amount = Self::calc_underlying_amount(collateral_amount, exchange_rate)?;
-        let market = Self::market(asset_id)?;
-        let effects_amount = market.collateral_factor.mul_ceil(collateral_underlying_amount);
-        let redeem_effects_value = Self::get_asset_value(asset_id, effects_amount)?;
-        log::trace!(
-            target: "loans::redeem_allowed",
-            "redeem_amount: {:?}, redeem_effects_value: {:?}",
-            redeem_amount,
-            redeem_effects_value.amount(),
-        );
-
-        Self::ensure_liquidity(redeemer, redeem_effects_value)?;
+        // Only free tokens are redeemable. If the account has enough liquidity, the lend tokens
+        // must first be withdrawn from collateral (this happens automatically in the `redeem` and
+        // `redeem_all` extrinsics)
+        if voucher_amount > Self::free_lend_tokens(asset_id, redeemer)?.amount() {
+            return Err(Error::<T>::LockedTokensCannotBeRedeemed.into());
+        }
         Ok(())
     }
 
@@ -1842,8 +1831,8 @@ impl<T: Config> Pallet<T> {
 
     /// Ensures that `account` has sufficient liquidity to cover a withdrawal
     /// Returns `Err` If InsufficientLiquidity
-    /// `account`: account that need a liquidity check
-    /// `reduce_amount`: values that will have an impact on liquidity
+    /// `account`: account that needs a liquidity check
+    /// `reduce_amount`: amount to reduce the liquidity (collateral) of the `account` by
     fn ensure_liquidity(account: &T::AccountId, reduce_amount: Amount<T>) -> DispatchResult {
         if Self::get_account_liquidity(account)?.liquidity().ge(&reduce_amount)? {
             return Ok(());

--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -269,11 +269,7 @@ fn redeem_allowed_works() {
             Error::<Test>::InsufficientLiquidity
         );
         // Redeeming 100 KSM is ok because the withdrawal succeds (the user has enough backing liquidity)
-        assert_ok!(Loans::redeem(
-            RuntimeOrigin::signed(ALICE),
-            KSM,
-            100
-        ));
+        assert_ok!(Loans::redeem(RuntimeOrigin::signed(ALICE), KSM, 100));
     })
 }
 

--- a/crates/loans/src/tests/lend_tokens.rs
+++ b/crates/loans/src/tests/lend_tokens.rs
@@ -189,15 +189,19 @@ fn transfer_lend_tokens_under_collateral_does_not_work() {
         // Repay 40 KINT
         assert_ok!(Loans::repay_borrow(RuntimeOrigin::signed(DAVE), KINT, unit(40)));
 
-        // Allowed to redeem 20 lend_tokens
-        assert_ok!(Loans::redeem_allowed(KINT, &DAVE, unit(20) * 50,));
-        // Not allowed to transfer the same 20 lend_tokens because they are locked
+        // Not allowed to redeem 20 lend_tokens because they are locked
+        assert_noop!(
+            Loans::redeem_allowed(KINT, &DAVE, unit(20) * 50),
+            Error::<Test>::LockedTokensCannotBeRedeemed
+        );
+        // Not allowed to transfer 20 lend_tokens because they are locked
         assert_noop!(
             Loans::transfer(LEND_KINT, &DAVE, &ALICE, unit(20) * 50, true),
             Error::<Test>::InsufficientCollateral
         );
         // First, withdraw some tokens. Note that directly withdrawing part of the locked
-        // lend_tokens is not possible through extrinsics.
+        // lend_tokens is not possible through extrinsics. Users can only withdraw the full
+        // amount for a currency via extrinsics, to enforce the collateral toggle.
         assert_ok!(Loans::do_withdraw_collateral(&DAVE, LEND_KINT, unit(20) * 50));
         // Check entries from orml-tokens directly
         assert_eq!(free_balance(LEND_KINT, &DAVE), unit(20) * 50);


### PR DESCRIPTION
Our lending implementation aims to forbid redeeming locked lend tokens. These must first be withdrawn, to simplify the logic. These checks were already there in the extrinsic functions (`redeem` and `redeem_all`), but there was a leftover check in `redeem_allowed` that still considered locked lend tokens OK to redeem. This fix is not critical because the redeem execution flow would never make it that far, but it's good to clean up.