### PR TITLE
fix(loans): cargo docs

### DIFF
--- a/crates/loans/src/types.rs
+++ b/crates/loans/src/types.rs
@@ -4,7 +4,10 @@ use frame_support::pallet_prelude::*;
 use primitives::{CurrencyId, Liquidity, Rate, Ratio, Shortfall};
 use scale_info::TypeInfo;
 
+// TODO: `cargo doc` crashes on this type, remove the `hidden` macro
+// when upgrading rustc in case that fixes it
 /// Container for account liquidity information
+#[doc(hidden)]
 #[derive(Eq, PartialEq, Clone, RuntimeDebug)]
 pub enum AccountLiquidity<T: Config> {
     Liquidity(Amount<T>),


### PR DESCRIPTION
Embedding `Amount<T>` in an enum panics `cargo doc` with an unintelligible error (stemming from [here](https://github.com/rust-lang/rust/blob/6fc409ed0938cd2f501642abcaa675977fa5035a/src/librustc/traits/auto_trait.rs#L588), although that file no longer exists on the master branch of `rust`).

This PR just hides that enum from the docs.