### PR TITLE
fix: estimate vault reward rate for lend token vault collateral

### DIFF
--- a/crates/fee/src/lib.rs
+++ b/crates/fee/src/lib.rs
@@ -490,14 +490,14 @@ impl<T: Config> Pallet<T> {
         vault_id: &DefaultVaultId<T>,
         nominator_id: &T::AccountId,
         currency_id: CurrencyId<T>,
-    ) -> Result<BalanceOf<T>, DispatchError> {
+    ) -> Result<Amount<T>, DispatchError> {
         // use a closure so we can use the `?` operator
-        let get_rewards = || -> Result<BalanceOf<T>, DispatchError> {
+        let get_rewards = || -> Result<Amount<T>, DispatchError> {
             let balance_before = currency::get_free_balance::<T>(currency_id, nominator_id);
             Self::withdraw_vault_rewards(vault_id, nominator_id, None, currency_id)?;
             let balance_after = currency::get_free_balance::<T>(currency_id, nominator_id);
             let reward = balance_after.saturating_sub(&balance_before)?;
-            Ok(reward.amount())
+            Ok(reward)
         };
 
         // don't commit storage changes

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1592,7 +1592,7 @@ impl_runtime_apis! {
         }
 
         fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?;
+            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?.amount();
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1578,7 +1578,7 @@ impl_runtime_apis! {
         }
 
         fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?;
+            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?.amount();
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -1531,7 +1531,7 @@ impl_runtime_apis! {
         }
 
         fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?;
+            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?.amount();
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -1583,7 +1583,7 @@ impl_runtime_apis! {
         }
 
         fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?;
+            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?.amount();
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1522,7 +1522,7 @@ impl_runtime_apis! {
         }
 
         fn compute_vault_reward(vault_id: VaultId, currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError> {
-            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?;
+            let amount = Fee::compute_vault_rewards(&vault_id, &vault_id.account_id, currency_id)?.amount();
             let balance = BalanceWrapper::<Balance> { amount };
             Ok(balance)
         }

--- a/standalone/runtime/tests/test_fee_pool.rs
+++ b/standalone/runtime/tests/test_fee_pool.rs
@@ -125,9 +125,6 @@ fn get_vault_collateral(vault_id: &VaultId) -> Amount<Runtime> {
 #[test]
 fn integration_test_estimate_vault_reward_rate() {
     test_with(|vault_id| {
-        if vault_id.collateral_currency().is_lend_token() {
-            return; // not supported yet. TODO!
-        }
         let rewards1 = Amount::<Runtime>::new(1000000000000000, REWARD_CURRENCY);
         rewards1.mint_to(&VaultAnnuityPallet::account_id()).unwrap();
         VaultAnnuityPallet::update_reward_per_block();


### PR DESCRIPTION
The previous implementation did not work for lending tokens since it directly interfaced with the oracle pallet rather than using the `CurrencyConvert` converter that has additional logic for lending