### PR TITLE
fix: kintsugi authorship config should use collator-selection hook

### DIFF
--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -237,7 +237,7 @@ impl pallet_authorship::Config for Runtime {
     type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
     type UncleGenerations = UncleGenerations;
     type FilterUncle = ();
-    type EventHandler = ();
+    type EventHandler = (CollatorSelection,);
 }
 
 parameter_types! {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Oversight in the runtime configuration of Kintsugi which meant that `LastAuthoredBlock` was never updated when collators produced a block. Then because the `CollatorSelection` pallet was outdated it would incorrectly kick "stale" candidates.

Note: the additional rewards logic [here](https://github.com/interlay/interbtc/blob/6ad918a549bf1c1b3559c88fc5baf7dec85842a8/crates/collator-selection/src/lib.rs#L483) is superfluous because we already handle fees [here](https://github.com/interlay/interbtc/blob/6ad918a549bf1c1b3559c88fc5baf7dec85842a8/parachain/runtime/kintsugi/src/lib.rs#L348).