### PR TITLE
fix: use precise stake in reward calculation

### DIFF
--- a/crates/staking/src/tests.rs
+++ b/crates/staking/src/tests.rs
@@ -95,8 +95,7 @@ fn slash_stake_does_not_break_state() {
 
         // The bug that we observed
         Staking::distribute_reward(currency, &VAULT, f(14234191584160000000000000000000)).unwrap();
-        // same as distributed amount except for rounding error
-        assert_eq!(Staking::withdraw_reward(currency, &VAULT, &account).unwrap(), 14234191584159);
+        assert_eq!(Staking::withdraw_reward(currency, &VAULT, &account).unwrap(), 14234191584160);
     })
 }
 


### PR DESCRIPTION
.. This doesn't really matter while nomination is disabled, since stakes will always be integers. If nomination is enabled, however, slashing can lead to non-integer stakes, so this becomes important. It's unsure what we'll do with the nomination, but this change doesn't hurt to have

Closes https://github.com/interlay/interbtc/issues/875