### PR TITLE
wip(loans): add `currency_id`  field to `unit()` utility

### DIFF
--- a/crates/loans/src/mock.rs
+++ b/crates/loans/src/mock.rs
@@ -26,8 +26,8 @@ use frame_system::EnsureRoot;
 use mocktopus::{macros::mockable, mocking::MockResult};
 use orml_traits::{currency::MutationHooks, parameter_type_with_key};
 use primitives::{
-    CurrencyId::{self, LendToken, Token},
-    DOT, IBTC, INTR, KBTC, KINT, KSM,
+    CurrencyId::{LendToken, Token},
+    DOT, IBTC, INTR, KBTC, KINT, KSM, CurrencyInfo,
 };
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32, FixedI128};
@@ -196,6 +196,7 @@ impl Config for Test {
     type UpdateOrigin = EnsureRoot<AccountId>;
     type WeightInfo = ();
     type UnixTime = TimestampPallet;
+    type Assets = Tokens;
     type RewardAssetId = GetNativeCurrencyId;
     type ReferenceAssetId = GetWrappedCurrencyId;
     type OnExchangeRateChange = ();
@@ -347,11 +348,11 @@ pub(crate) fn _run_to_block(n: BlockNumber) {
     }
 }
 
-pub fn almost_equal(target: u128, value: u128) -> bool {
+pub fn almost_equal(target: u128, value: u128, currency_id: CurrencyId) -> bool {
     let target = target as i128;
     let value = value as i128;
     let diff = (target - value).abs() as u128;
-    diff < micro_unit(1)
+    diff < micro_unit(1, currency_id)
 }
 
 pub fn accrue_interest_per_block(asset_id: CurrencyId, block_delta_secs: u64, run_to_block: u64) {
@@ -361,20 +362,24 @@ pub fn accrue_interest_per_block(asset_id: CurrencyId, block_delta_secs: u64, ru
     }
 }
 
-pub fn unit(d: u128) -> u128 {
-    d.saturating_mul(10_u128.pow(12))
+pub fn unit(d: u128, currency_id: CurrencyId) -> u128 {
+    if let CurrencyId::Token(token) = currency_id {
+        d.saturating_mul(10_u128.pow(token.decimals().into()))
+    } else {
+        panic!("Expected the currency to be a regular `CurrencyId::Token`");
+    }
 }
 
-pub fn milli_unit(d: u128) -> u128 {
-    d.saturating_mul(10_u128.pow(9))
+pub fn milli_unit(d: u128, currency_id: CurrencyId) -> u128 {
+    unit(d, currency_id).saturating_div(10_u128.pow(3))
 }
 
-pub fn micro_unit(d: u128) -> u128 {
-    d.saturating_mul(10_u128.pow(6))
+pub fn micro_unit(d: u128, currency_id: CurrencyId) -> u128 {
+    unit(d, currency_id).saturating_div(10_u128.pow(6))
 }
 
-pub fn million_unit(d: u128) -> u128 {
-    unit(d) * 10_u128.pow(6)
+pub fn million_unit(d: u128, currency_id: CurrencyId) -> u128 {
+    unit(d, currency_id) * 10_u128.pow(6)
 }
 
 pub const fn market_mock(lend_token_id: CurrencyId) -> Market<Balance> {
@@ -405,3 +410,4 @@ pub const ACTIVE_MARKET_MOCK: Market<Balance> = {
     market.state = MarketState::Active;
     market
 };
+

--- a/crates/loans/src/tests/edge_cases.rs
+++ b/crates/loans/src/tests/edge_cases.rs
@@ -1,266 +1,269 @@
-use super::*;
-use crate::{mock::*, tests::Loans, Error};
-use currency::Amount;
-use frame_support::{assert_err, assert_ok};
-use primitives::{
-    CurrencyId::{ForeignAsset, Token},
-    DOT, KSM,
-};
-use sp_runtime::FixedPointNumber;
+// use super::*;
+// use crate::{mock::*, tests::Loans, Error};
+// use currency::Amount;
+// use frame_support::{assert_err, assert_ok};
+// use primitives::{
+//     CurrencyId::{ForeignAsset, Token},
+//     DOT, KSM,
+// };
+// use sp_runtime::FixedPointNumber;
 
-#[test]
-fn exceeded_supply_cap() {
-    new_test_ext().execute_with(|| {
-        Tokens::set_balance(RuntimeOrigin::root(), ALICE, Token(DOT), million_unit(1001), 0).unwrap();
-        let amount = million_unit(501);
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), amount));
-        // Exceed upper bound.
-        assert_err!(
-            Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), amount),
-            Error::<Test>::SupplyCapacityExceeded
-        );
+// #[test]
+// fn exceeded_supply_cap() {
+//     new_test_ext().execute_with(|| {
+//         Tokens::set_balance(RuntimeOrigin::root(), ALICE, Token(DOT), million_unit(1001), 0).unwrap();
+//         let amount = million_unit(501);
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), amount));
+//         // Exceed upper bound.
+//         assert_err!(
+//             Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), amount),
+//             Error::<Test>::SupplyCapacityExceeded
+//         );
 
-        Loans::redeem(RuntimeOrigin::signed(ALICE), Token(DOT), amount).unwrap();
-        // Here should work, cause we redeemed already.
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), amount));
-    })
-}
+//         Loans::redeem(RuntimeOrigin::signed(ALICE), Token(DOT), amount).unwrap();
+//         // Here should work, cause we redeemed already.
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), amount));
+//     })
+// }
 
-#[test]
-fn repay_borrow_all_no_underflow() {
-    new_test_ext().execute_with(|| {
-        // Alice deposits 200 KSM as collateral
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(KSM), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(KSM)));
+// #[test]
+// fn repay_borrow_all_no_underflow() {
+//     new_test_ext().execute_with(|| {
+//         // Alice deposits 200 KSM as collateral
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(KSM), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(KSM)));
 
-        // Alice borrow only 1/1e5 KSM which is hard to accrue total borrows interest in 100 seconds
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), 10_u128.pow(7)));
+//         // Alice borrow only 1/1e5 KSM which is hard to accrue total borrows interest in 100 seconds
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), 10_u128.pow(7)));
 
-        accrue_interest_per_block(Token(KSM), 100, 9);
+//         accrue_interest_per_block(Token(KSM), 100, 9);
 
-        assert_eq!(Loans::current_borrow_balance(&ALICE, Token(KSM)), Ok(10000005));
-        // FIXME since total_borrows is too small and we accrue internal on it every 100 seconds
-        // accrue_interest fails every time
-        // as you can see the current borrow balance is not equal to total_borrows anymore
-        assert_eq!(Loans::total_borrows(Token(KSM)), 10000000);
+//         assert_eq!(Loans::current_borrow_balance(&ALICE, Token(KSM)), Ok(10000005));
+//         // FIXME since total_borrows is too small and we accrue internal on it every 100 seconds
+//         // accrue_interest fails every time
+//         // as you can see the current borrow balance is not equal to total_borrows anymore
+//         assert_eq!(Loans::total_borrows(Token(KSM)), 10000000);
 
-        // Alice repay all borrow balance. total_borrows = total_borrows.saturating_sub(10000005) = 0.
-        assert_ok!(Loans::repay_borrow_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
+//         // Alice repay all borrow balance. total_borrows = total_borrows.saturating_sub(10000005) = 0.
+//         assert_ok!(Loans::repay_borrow_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
 
-        assert_eq!(Tokens::balance(Token(KSM), &ALICE), unit(800) - 5);
+//         assert_eq!(Tokens::balance(Token(KSM), &ALICE), unit(800) - 5);
 
-        assert_eq!(
-            Loans::exchange_rate(Token(DOT)).saturating_mul_int(Loans::account_deposits(
-                Loans::lend_token_id(Token(KSM)).unwrap(),
-                ALICE
-            )),
-            unit(200)
-        );
+//         assert_eq!(
+//             Loans::exchange_rate(Token(DOT)).saturating_mul_int(Loans::account_deposits(
+//                 Loans::lend_token_id(Token(KSM)).unwrap(),
+//                 ALICE
+//             )),
+//             unit(200)
+//         );
 
-        let borrow_snapshot = Loans::account_borrows(Token(KSM), ALICE);
-        assert_eq!(borrow_snapshot.principal, 0);
-        assert_eq!(borrow_snapshot.borrow_index, Loans::borrow_index(Token(KSM)));
-    })
-}
+//         let borrow_snapshot = Loans::account_borrows(Token(KSM), ALICE);
+//         assert_eq!(borrow_snapshot.principal, 0);
+//         assert_eq!(borrow_snapshot.borrow_index, Loans::borrow_index(Token(KSM)));
+//     })
+// }
 
-#[test]
-fn ensure_capacity_fails_when_market_not_existed() {
-    new_test_ext().execute_with(|| {
-        assert_err!(
-            Loans::ensure_under_supply_cap(ForeignAsset(987997280), unit(100)),
-            Error::<Test>::MarketDoesNotExist
-        );
-    });
-}
+// #[test]
+// fn ensure_capacity_fails_when_market_not_existed() {
+//     new_test_ext().execute_with(|| {
+//         assert_err!(
+//             Loans::ensure_under_supply_cap(ForeignAsset(987997280), unit(100)),
+//             Error::<Test>::MarketDoesNotExist
+//         );
+//     });
+// }
 
-#[test]
-fn redeem_all_should_be_accurate() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(KSM), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(KSM)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
+// #[test]
+// fn redeem_all_should_be_accurate() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(KSM), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(KSM)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
 
-        // let exchange_rate greater than 0.02
-        accrue_interest_per_block(Token(KSM), 6, 2);
-        assert_eq!(Loans::exchange_rate(Token(KSM)), Rate::from_inner(20000000036387000));
+//         // let exchange_rate greater than 0.02
+//         accrue_interest_per_block(Token(KSM), 6, 2);
+//         assert_eq!(Loans::exchange_rate(Token(KSM)), Rate::from_inner(20000000036387000));
 
-        assert_ok!(Loans::repay_borrow_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
-        // It failed with InsufficientLiquidity before #839
-        assert_ok!(Loans::redeem_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
-        assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
-        assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
-    })
-}
+//         assert_ok!(Loans::repay_borrow_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
+//         // It failed with InsufficientLiquidity before #839
+//         assert_ok!(Loans::redeem_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
+//         assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+//         assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+//     })
+// }
 
-// FIXME: this test fails because of rounding
-#[ignore]
-#[test]
-fn converting_to_and_from_collateral_should_not_change_results() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(KSM), unit(201)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(KSM)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
+// // FIXME: this test fails because of rounding
+// #[ignore]
+// #[test]
+// fn converting_to_and_from_collateral_should_not_change_results() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(KSM), unit(201)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(KSM)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
 
-        // let exchange_rate greater than 0.02
-        accrue_interest_per_block(Token(KSM), 1, 131);
-        assert_eq!(Loans::exchange_rate(Token(KSM)), Rate::from_inner(20000000782289552));
+//         // let exchange_rate greater than 0.02
+//         accrue_interest_per_block(Token(KSM), 1, 131);
+//         assert_eq!(Loans::exchange_rate(Token(KSM)), Rate::from_inner(20000000782289552));
 
-        let base_ksm_amount = 100007444213;
-        for offset in 0..=1000 {
-            let ksm_amount = Amount::new(base_ksm_amount + offset, Token(KSM));
-            let conv_pksm_amount = Loans::recompute_collateral_amount(&ksm_amount).unwrap();
-            let conv_ksm_amount = Loans::recompute_underlying_amount(&conv_pksm_amount).unwrap();
-            assert_eq!(conv_ksm_amount.amount(), ksm_amount.amount());
-        }
-    })
-}
+//         let base_ksm_amount = 100007444213;
+//         for offset in 0..=1000 {
+//             let ksm_amount = Amount::new(base_ksm_amount + offset, Token(KSM));
+//             let conv_pksm_amount = Loans::recompute_collateral_amount(&ksm_amount).unwrap();
+//             let conv_ksm_amount = Loans::recompute_underlying_amount(&conv_pksm_amount).unwrap();
+//             assert_eq!(conv_ksm_amount.amount(), ksm_amount.amount());
+//         }
+//     })
+// }
 
-#[test]
-fn prevent_the_exchange_rate_attack() {
-    new_test_ext().execute_with(|| {
-        // Initialize Eve's balance
-        assert_ok!(Tokens::transfer(
-            RuntimeOrigin::signed(ALICE),
-            EVE,
-            Token(DOT),
-            unit(200),
-        ));
-        // Eve deposits a small amount
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(EVE), Token(DOT), 1));
-        // !!! Eve transfer a big amount to Loans::account_id
-        assert_ok!(Tokens::transfer(
-            RuntimeOrigin::signed(EVE),
-            Loans::account_id(),
-            Token(DOT),
-            unit(100),
-        ));
-        assert_eq!(Tokens::balance(Token(DOT), &EVE), 99999999999999);
-        assert_eq!(Tokens::balance(Token(DOT), &Loans::account_id()), 100000000000001);
-        assert_eq!(
-            Loans::total_supply(Token(DOT)).unwrap(),
-            1 * 50, // 1 / 0.02
-        );
-        TimestampPallet::set_timestamp(12000);
-        // Eve can not let the exchange rate greater than 1
-        assert_noop!(Loans::accrue_interest(Token(DOT)), Error::<Test>::InvalidExchangeRate);
+// #[test]
+// fn prevent_the_exchange_rate_attack() {
+//     new_test_ext().execute_with(|| {
+//         // Initialize Eve's balance
+//         assert_ok!(<Tokens as Transfer<AccountId>>::transfer(
+//             Token(DOT),
+//             &ALICE,
+//             &EVE,
+//             unit(200),
+//             false
+//         ));
+//         // Eve deposits a small amount
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(EVE), Token(DOT), 1));
+//         // !!! Eve transfer a big amount to Loans::account_id
+//         assert_ok!(<Tokens as Transfer<AccountId>>::transfer(
+//             Token(DOT),
+//             &EVE,
+//             &Loans::account_id(),
+//             unit(100),
+//             false
+//         ));
+//         assert_eq!(Tokens::balance(Token(DOT), &EVE), 99999999999999);
+//         assert_eq!(Tokens::balance(Token(DOT), &Loans::account_id()), 100000000000001);
+//         assert_eq!(
+//             Loans::total_supply(Token(DOT)).unwrap(),
+//             1 * 50, // 1 / 0.02
+//         );
+//         TimestampPallet::set_timestamp(12000);
+//         // Eve can not let the exchange rate greater than 1
+//         assert_noop!(Loans::accrue_interest(Token(DOT)), Error::<Test>::InvalidExchangeRate);
 
-        // Mock a BIG exchange_rate: 100000000000.02
-        ExchangeRate::<Test>::insert(Token(DOT), Rate::saturating_from_rational(100000000000020u128, 20 * 50));
-        // Bob can not deposit 0.1 DOT because the voucher_balance can not be 0.
-        assert_noop!(
-            Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), 100000000000),
-            Error::<Test>::InvalidExchangeRate
-        );
-    })
-}
+//         // Mock a BIG exchange_rate: 100000000000.02
+//         ExchangeRate::<Test>::insert(Token(DOT), Rate::saturating_from_rational(100000000000020u128, 20 * 50));
+//         // Bob can not deposit 0.1 DOT because the voucher_balance can not be 0.
+//         assert_noop!(
+//             Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), 100000000000),
+//             Error::<Test>::InvalidExchangeRate
+//         );
+//     })
+// }
 
-#[test]
-fn deposit_all_collateral_fails_if_locked_tokens_exist() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        // Assume 1 lend_token is locked for some other reason than borrow collateral
-        Tokens::reserve(Loans::lend_token_id(Token(DOT)).unwrap(), &ALICE, unit(1)).unwrap();
-        // If there are _any_ locked lend tokens, then the "toggle" cannot be enforced
-        // and the extrinsic fails.
-        assert_noop!(
-            Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)),
-            Error::<Test>::TokensAlreadyLocked
-        );
-    })
-}
+// #[test]
+// fn deposit_all_collateral_fails_if_locked_tokens_exist() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         // Assume 1 lend_token is locked for some other reason than borrow collateral
+//         Tokens::reserve(Loans::lend_token_id(Token(DOT)).unwrap(), &ALICE, unit(1)).unwrap();
+//         // If there are _any_ locked lend tokens, then the "toggle" cannot be enforced
+//         // and the extrinsic fails.
+//         assert_noop!(
+//             Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)),
+//             Error::<Test>::TokensAlreadyLocked
+//         );
+//     })
+// }
 
-#[test]
-fn new_minted_collateral_is_auto_deposited_if_collateral() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
-        assert_eq!(
-            Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
-            unit(10000)
-        );
+// #[test]
+// fn new_minted_collateral_is_auto_deposited_if_collateral() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+//         assert_eq!(
+//             Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
+//             unit(10000)
+//         );
 
-        // Mint more lend tokens, without explicitly depositing.
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(13)));
-        // These new tokens are automatically deposited as collateral
-        assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
-        assert_eq!(
-            Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
-            unit(10650)
-        );
-    })
-}
+//         // Mint more lend tokens, without explicitly depositing.
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(13)));
+//         // These new tokens are automatically deposited as collateral
+//         assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+//         assert_eq!(
+//             Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
+//             unit(10650)
+//         );
+//     })
+// }
 
-#[test]
-fn new_minted_collateral_is_not_auto_deposited_if_not_collateral() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_eq!(
-            Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
-            unit(10000)
-        );
-        assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+// #[test]
+// fn new_minted_collateral_is_not_auto_deposited_if_not_collateral() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_eq!(
+//             Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
+//             unit(10000)
+//         );
+//         assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
 
-        // Mint more lend tokens.
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(13)));
-        // These new tokens are NOT automatically deposited as collateral
-        assert_eq!(
-            Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
-            unit(10650)
-        );
-        assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
-    })
-}
+//         // Mint more lend tokens.
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(13)));
+//         // These new tokens are NOT automatically deposited as collateral
+//         assert_eq!(
+//             Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
+//             unit(10650)
+//         );
+//         assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+//     })
+// }
 
-#[test]
-fn new_transferred_collateral_is_auto_deposited_if_collateral() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        let lend_token_id = Loans::lend_token_id(Token(DOT)).unwrap();
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
-        assert_eq!(
-            Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
-            unit(10000)
-        );
-        // Mint some tokens to another user's account
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), unit(200)));
+// #[test]
+// fn new_transferred_collateral_is_auto_deposited_if_collateral() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         let lend_token_id = Loans::lend_token_id(Token(DOT)).unwrap();
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+//         assert_eq!(
+//             Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
+//             unit(10000)
+//         );
+//         // Mint some tokens to another user's account
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), unit(200)));
 
-        // Transfer some free lend tokens to Alice
-        let amount_to_transfer = Amount::<Test>::new(unit(11), lend_token_id);
-        amount_to_transfer.transfer(&BOB, &ALICE).unwrap();
+//         // Transfer some free lend tokens to Alice
+//         let amount_to_transfer = Amount::<Test>::new(unit(11), lend_token_id);
+//         amount_to_transfer.transfer(&BOB, &ALICE).unwrap();
 
-        // These received tokens are automatically deposited as collateral
-        assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
-        assert_eq!(
-            Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
-            unit(10011)
-        );
-    })
-}
+//         // These received tokens are automatically deposited as collateral
+//         assert_eq!(Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+//         assert_eq!(
+//             Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
+//             unit(10011)
+//         );
+//     })
+// }
 
-#[test]
-fn new_transferred_collateral_is_not_auto_deposited_if_not_collateral() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        let lend_token_id = Loans::lend_token_id(Token(DOT)).unwrap();
-        assert_eq!(
-            Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
-            unit(10000)
-        );
-        assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
-        // Mint some tokens to another user's account
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), unit(200)));
+// #[test]
+// fn new_transferred_collateral_is_not_auto_deposited_if_not_collateral() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         let lend_token_id = Loans::lend_token_id(Token(DOT)).unwrap();
+//         assert_eq!(
+//             Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
+//             unit(10000)
+//         );
+//         assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+//         // Mint some tokens to another user's account
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), unit(200)));
 
-        // Transfer some free lend tokens to Alice
-        let amount_to_transfer = Amount::<Test>::new(unit(11), lend_token_id);
-        amount_to_transfer.transfer(&BOB, &ALICE).unwrap();
+//         // Transfer some free lend tokens to Alice
+//         let amount_to_transfer = Amount::<Test>::new(unit(11), lend_token_id);
+//         amount_to_transfer.transfer(&BOB, &ALICE).unwrap();
 
-        // These received tokens are automatically deposited as collateral
-        assert_eq!(
-            Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
-            unit(10011)
-        );
-        assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
-    })
-}
+//         // These received tokens are automatically deposited as collateral
+//         assert_eq!(
+//             Loans::free_lend_tokens(Token(DOT), &ALICE).unwrap().amount(),
+//             unit(10011)
+//         );
+//         assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+//     })
+// }
+

--- a/crates/loans/src/tests/interest_rate.rs
+++ b/crates/loans/src/tests/interest_rate.rs
@@ -1,337 +1,338 @@
-use crate::{mock::*, tests::Loans, Markets};
-use currency::{Amount, CurrencyConversion};
-use frame_support::assert_ok;
-use mocktopus::mocking::Mockable;
-use primitives::{CurrencyId::Token, Rate, Ratio, DOT, KSM, SECONDS_PER_YEAR};
-use sp_runtime::{
-    traits::{CheckedDiv, One, Saturating},
-    FixedPointNumber,
-};
+// use crate::{mock::*, tests::Loans, Markets};
+// use currency::{Amount, CurrencyConversion};
+// use frame_support::assert_ok;
+// use mocktopus::mocking::Mockable;
+// use primitives::{CurrencyId::Token, Rate, Ratio, DOT, KSM, SECONDS_PER_YEAR};
+// use sp_runtime::{
+//     traits::{CheckedDiv, One, Saturating},
+//     FixedPointNumber,
+// };
 
-#[test]
-fn utilization_rate_works() {
-    // 50% borrow
-    assert_eq!(Loans::calc_utilization_ratio(1, 1, 0).unwrap(), Ratio::from_percent(50));
-    assert_eq!(
-        Loans::calc_utilization_ratio(100, 100, 0).unwrap(),
-        Ratio::from_percent(50)
-    );
-    // no borrow
-    assert_eq!(Loans::calc_utilization_ratio(1, 0, 0).unwrap(), Ratio::zero());
-    // full borrow
-    assert_eq!(
-        Loans::calc_utilization_ratio(0, 1, 0).unwrap(),
-        Ratio::from_percent(100)
-    );
-}
+// #[test]
+// fn utilization_rate_works() {
+//     // 50% borrow
+//     assert_eq!(Loans::calc_utilization_ratio(1, 1, 0).unwrap(), Ratio::from_percent(50));
+//     assert_eq!(
+//         Loans::calc_utilization_ratio(100, 100, 0).unwrap(),
+//         Ratio::from_percent(50)
+//     );
+//     // no borrow
+//     assert_eq!(Loans::calc_utilization_ratio(1, 0, 0).unwrap(), Ratio::zero());
+//     // full borrow
+//     assert_eq!(
+//         Loans::calc_utilization_ratio(0, 1, 0).unwrap(),
+//         Ratio::from_percent(100)
+//     );
+// }
 
-#[test]
-fn interest_rate_model_works() {
-    new_test_ext().execute_with(|| {
-        let rate_decimal: u128 = 1_000_000_000_000_000_000;
-        Tokens::set_balance(
-            RuntimeOrigin::root(),
-            ALICE,
-            Token(DOT),
-            million_unit(1000) - unit(1000),
-            0,
-        )
-        .unwrap();
-        // Deposit 200 DOT and borrow 100 DOT
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), million_unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::borrow(
-            RuntimeOrigin::signed(ALICE),
-            Token(DOT),
-            million_unit(100)
-        ));
+// #[test]
+// fn interest_rate_model_works() {
+//     new_test_ext().execute_with(|| {
+//         let rate_decimal: u128 = 1_000_000_000_000_000_000;
+//         Tokens::set_balance(
+//             RuntimeOrigin::root(),
+//             ALICE,
+//             Token(DOT),
+//             million_unit(1000) - unit(1000),
+//             0,
+//         )
+//         .unwrap();
+//         // Deposit 200 DOT and borrow 100 DOT
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), million_unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::borrow(
+//             RuntimeOrigin::signed(ALICE),
+//             Token(DOT),
+//             million_unit(100)
+//         ));
 
-        let total_cash = million_unit(200) - million_unit(100);
-        let total_supply = Loans::calc_collateral_amount(million_unit(200), Loans::exchange_rate(Token(DOT))).unwrap();
-        assert_eq!(Loans::total_supply(Token(DOT)).unwrap(), total_supply);
+//         let total_cash = million_unit(200) - million_unit(100);
+//         let total_supply = Loans::calc_collateral_amount(million_unit(200), Loans::exchange_rate(Token(DOT))).unwrap();
+//         assert_eq!(Loans::total_supply(Token(DOT)).unwrap(), total_supply);
 
-        let borrow_snapshot = Loans::account_borrows(Token(DOT), ALICE);
-        assert_eq!(borrow_snapshot.principal, million_unit(100));
-        assert_eq!(borrow_snapshot.borrow_index, Rate::one());
+//         let borrow_snapshot = Loans::account_borrows(Token(DOT), ALICE);
+//         assert_eq!(borrow_snapshot.principal, million_unit(100));
+//         assert_eq!(borrow_snapshot.borrow_index, Rate::one());
 
-        let base_rate = Rate::saturating_from_rational(2, 100);
-        let jump_rate = Rate::saturating_from_rational(10, 100);
-        // let full_rate = Rate::saturating_from_rational(32, 100);
-        let jump_utilization = Ratio::from_percent(80);
+//         let base_rate = Rate::saturating_from_rational(2, 100);
+//         let jump_rate = Rate::saturating_from_rational(10, 100);
+//         // let full_rate = Rate::saturating_from_rational(32, 100);
+//         let jump_utilization = Ratio::from_percent(80);
 
-        let mut borrow_index = Rate::one();
-        let mut total_borrows = borrow_snapshot.principal;
-        let mut total_reserves: u128 = 0;
+//         let mut borrow_index = Rate::one();
+//         let mut total_borrows = borrow_snapshot.principal;
+//         let mut total_reserves: u128 = 0;
 
-        // Interest accrued from blocks 1 to 49
-        for i in 1..49 {
-            let delta_time = 6u128;
-            TimestampPallet::set_timestamp(6000 * (i + 1));
-            assert_ok!(Loans::accrue_interest(Token(DOT)));
-            // utilizationRatio = totalBorrows / (totalCash + totalBorrows - totalReserves)
-            let util_ratio = Ratio::from_rational(total_borrows, total_cash + total_borrows - total_reserves);
-            assert_eq!(Loans::utilization_ratio(Token(DOT)), util_ratio);
+//         // Interest accrued from blocks 1 to 49
+//         for i in 1..49 {
+//             let delta_time = 6u128;
+//             TimestampPallet::set_timestamp(6000 * (i + 1));
+//             assert_ok!(Loans::accrue_interest(Token(DOT)));
+//             // utilizationRatio = totalBorrows / (totalCash + totalBorrows - totalReserves)
+//             let util_ratio = Ratio::from_rational(total_borrows, total_cash + total_borrows - total_reserves);
+//             assert_eq!(Loans::utilization_ratio(Token(DOT)), util_ratio);
 
-            let borrow_rate = (jump_rate - base_rate) * util_ratio.into() / jump_utilization.into() + base_rate;
-            let interest_accumulated: u128 = borrow_rate
-                .saturating_mul_int(total_borrows)
-                .saturating_mul(delta_time.into())
-                .checked_div(SECONDS_PER_YEAR.into())
-                .unwrap();
-            total_borrows = interest_accumulated + total_borrows;
-            assert_eq!(Loans::total_borrows(Token(DOT)), total_borrows);
-            total_reserves = Markets::<Test>::get(&Token(DOT))
-                .unwrap()
-                .reserve_factor
-                .mul_floor(interest_accumulated)
-                + total_reserves;
-            assert_eq!(Loans::total_reserves(Token(DOT)), total_reserves);
+//             let borrow_rate = (jump_rate - base_rate) * util_ratio.into() / jump_utilization.into() + base_rate;
+//             let interest_accumulated: u128 = borrow_rate
+//                 .saturating_mul_int(total_borrows)
+//                 .saturating_mul(delta_time.into())
+//                 .checked_div(SECONDS_PER_YEAR.into())
+//                 .unwrap();
+//             total_borrows = interest_accumulated + total_borrows;
+//             assert_eq!(Loans::total_borrows(Token(DOT)), total_borrows);
+//             total_reserves = Markets::<Test>::get(&Token(DOT))
+//                 .unwrap()
+//                 .reserve_factor
+//                 .mul_floor(interest_accumulated)
+//                 + total_reserves;
+//             assert_eq!(Loans::total_reserves(Token(DOT)), total_reserves);
 
-            // exchangeRate = (totalCash + totalBorrows - totalReserves) / totalSupply
-            assert_eq!(
-                Loans::exchange_rate(Token(DOT)).into_inner(),
-                (total_cash + total_borrows - total_reserves) * rate_decimal / total_supply
-            );
-            let numerator = borrow_index
-                .saturating_mul(borrow_rate)
-                .saturating_mul(Rate::saturating_from_integer(delta_time))
-                .checked_div(&Rate::saturating_from_integer(SECONDS_PER_YEAR))
-                .unwrap();
-            borrow_index = numerator + borrow_index;
-            assert_eq!(Loans::borrow_index(Token(DOT)), borrow_index);
-        }
-        assert_eq!(total_borrows, 100000063926960646826);
-        assert_eq!(total_reserves, 9589044097001);
-        assert_eq!(borrow_index, Rate::from_inner(1000000639269606444));
-        assert_eq!(Loans::exchange_rate(Token(DOT)), Rate::from_inner(20000005433791654));
+//             // exchangeRate = (totalCash + totalBorrows - totalReserves) / totalSupply
+//             assert_eq!(
+//                 Loans::exchange_rate(Token(DOT)).into_inner(),
+//                 (total_cash + total_borrows - total_reserves) * rate_decimal / total_supply
+//             );
+//             let numerator = borrow_index
+//                 .saturating_mul(borrow_rate)
+//                 .saturating_mul(Rate::saturating_from_integer(delta_time))
+//                 .checked_div(&Rate::saturating_from_integer(SECONDS_PER_YEAR))
+//                 .unwrap();
+//             borrow_index = numerator + borrow_index;
+//             assert_eq!(Loans::borrow_index(Token(DOT)), borrow_index);
+//         }
+//         assert_eq!(total_borrows, 100000063926960646826);
+//         assert_eq!(total_reserves, 9589044097001);
+//         assert_eq!(borrow_index, Rate::from_inner(1000000639269606444));
+//         assert_eq!(Loans::exchange_rate(Token(DOT)), Rate::from_inner(20000005433791654));
 
-        // Calculate borrow accrued interest
-        let borrow_principal =
-            (borrow_index / borrow_snapshot.borrow_index).saturating_mul_int(borrow_snapshot.principal);
-        // TODO: Why subtract `million_unit(200)` here? Accruing interest doesn't fix this.
-        let supply_interest = Loans::exchange_rate(Token(DOT)).saturating_mul_int(total_supply) - million_unit(200);
-        assert_eq!(supply_interest, 54337916540000);
-        assert_eq!(borrow_principal, 100000063926960644400);
-        assert_eq!(total_borrows / 10000, borrow_principal / 10000);
-        assert_eq!(
-            (total_borrows - million_unit(100) - total_reserves) / 10000,
-            supply_interest / 10000
-        );
-    })
-}
+//         // Calculate borrow accrued interest
+//         let borrow_principal =
+//             (borrow_index / borrow_snapshot.borrow_index).saturating_mul_int(borrow_snapshot.principal);
+//         // TODO: Why subtract `million_unit(200)` here? Accruing interest doesn't fix this.
+//         let supply_interest = Loans::exchange_rate(Token(DOT)).saturating_mul_int(total_supply) - million_unit(200);
+//         assert_eq!(supply_interest, 54337916540000);
+//         assert_eq!(borrow_principal, 100000063926960644400);
+//         assert_eq!(total_borrows / 10000, borrow_principal / 10000);
+//         assert_eq!(
+//             (total_borrows - million_unit(100) - total_reserves) / 10000,
+//             supply_interest / 10000
+//         );
+//     })
+// }
 
-#[test]
-fn last_accrued_interest_time_should_be_update_correctly() {
-    new_test_ext().execute_with(|| {
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        assert_eq!(Loans::last_accrued_interest_time(Token(DOT)), 0);
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_eq!(Loans::last_accrued_interest_time(Token(DOT)), 6);
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000013318112633),);
-    })
-}
+// #[test]
+// fn last_accrued_interest_time_should_be_update_correctly() {
+//     new_test_ext().execute_with(|| {
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         assert_eq!(Loans::last_accrued_interest_time(Token(DOT)), 0);
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_eq!(Loans::last_accrued_interest_time(Token(DOT)), 6);
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000013318112633),);
+//     })
+// }
 
-#[test]
-fn accrue_interest_works_after_mint() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000013318112633),);
-    })
-}
+// #[test]
+// fn accrue_interest_works_after_mint() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000013318112633),);
+//     })
+// }
 
-#[test]
-fn accrue_interest_works_after_borrow() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000003805175038),);
-    })
-}
+// #[test]
+// fn accrue_interest_works_after_borrow() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000003805175038),);
+//     })
+// }
 
-#[test]
-fn accrue_interest_works_after_redeem() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(10)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
+// #[test]
+// fn accrue_interest_works_after_redeem() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(10)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
 
-        let amount_to_redeem = unit(10);
-        assert_ok!(Loans::redeem(
-            RuntimeOrigin::signed(ALICE),
-            Token(DOT),
-            amount_to_redeem
-        ));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000004756468797),);
-        assert_eq!(
-            Loans::exchange_rate(Token(DOT))
-                .saturating_mul_int(Loans::account_deposits(Loans::lend_token_id(Token(DOT)).unwrap(), BOB)),
-            0,
-        );
-        assert_eq!(Tokens::balance(Token(DOT), &ALICE), 819999999999999);
-    })
-}
+//         let amount_to_redeem = unit(10);
+//         assert_ok!(Loans::redeem(
+//             RuntimeOrigin::signed(ALICE),
+//             Token(DOT),
+//             amount_to_redeem
+//         ));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000004756468797),);
+//         assert_eq!(
+//             Loans::exchange_rate(Token(DOT))
+//                 .saturating_mul_int(Loans::account_deposits(Loans::lend_token_id(Token(DOT)).unwrap(), BOB)),
+//             0,
+//         );
+//         assert_eq!(Tokens::balance(Token(DOT), &ALICE), 819999999999999);
+//     })
+// }
 
-#[test]
-fn accrue_interest_works_after_redeem_all() {
-    new_test_ext().execute_with(|| {
-        assert_eq!(Tokens::balance(Token(DOT), &BOB), 1000000000000000);
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), unit(20)));
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(10)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        assert_eq!(Tokens::balance(Token(DOT), &BOB), 980000000000000);
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::redeem_all(RuntimeOrigin::signed(BOB), Token(DOT)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000004669977168),);
-        assert_eq!(
-            Loans::exchange_rate(Token(DOT))
-                .saturating_mul_int(Loans::account_deposits(Loans::lend_token_id(Token(DOT)).unwrap(), BOB)),
-            0,
-        );
-        assert_eq!(Tokens::balance(Token(DOT), &BOB), 1000000000003608);
-        assert_eq!(Loans::free_lend_tokens(Token(DOT), &BOB).unwrap().is_zero(), true);
-        assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &BOB).unwrap().is_zero(), true);
-        assert!(!AccountDeposits::<Test>::contains_key(Token(DOT), &BOB))
-    })
-}
+// #[test]
+// fn accrue_interest_works_after_redeem_all() {
+//     new_test_ext().execute_with(|| {
+//         assert_eq!(Tokens::balance(Token(DOT), &BOB), 1000000000000000);
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), unit(20)));
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(10)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         assert_eq!(Tokens::balance(Token(DOT), &BOB), 980000000000000);
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::redeem_all(RuntimeOrigin::signed(BOB), Token(DOT)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000004669977168),);
+//         assert_eq!(
+//             Loans::exchange_rate(Token(DOT))
+//                 .saturating_mul_int(Loans::account_deposits(Loans::lend_token_id(Token(DOT)).unwrap(), BOB)),
+//             0,
+//         );
+//         assert_eq!(Tokens::balance(Token(DOT), &BOB), 1000000000003608);
+//         assert_eq!(Loans::free_lend_tokens(Token(DOT), &BOB).unwrap().is_zero(), true);
+//         assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &BOB).unwrap().is_zero(), true);
+//         assert!(!AccountDeposits::<Test>::contains_key(Token(DOT), &BOB))
+//     })
+// }
 
-#[test]
-fn accrue_interest_works_after_repay() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(20)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::repay_borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(10)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000005707762557),);
-    })
-}
+// #[test]
+// fn accrue_interest_works_after_repay() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(20)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::repay_borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(10)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000005707762557),);
+//     })
+// }
 
-#[test]
-fn accrue_interest_works_after_repay_all() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(KSM), unit(200)));
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::repay_borrow_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000008561643835),);
-        assert_eq!(Tokens::balance(Token(KSM), &ALICE), 999999999571918);
-        let borrow_snapshot = Loans::account_borrows(Token(KSM), ALICE);
-        assert_eq!(borrow_snapshot.principal, 0);
-        assert_eq!(borrow_snapshot.borrow_index, Loans::borrow_index(Token(KSM)));
-    })
-}
+// #[test]
+// fn accrue_interest_works_after_repay_all() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(KSM), unit(200)));
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::repay_borrow_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000008561643835),);
+//         assert_eq!(Tokens::balance(Token(KSM), &ALICE), 999999999571918);
+//         let borrow_snapshot = Loans::account_borrows(Token(KSM), ALICE);
+//         assert_eq!(borrow_snapshot.principal, 0);
+//         assert_eq!(borrow_snapshot.borrow_index, Loans::borrow_index(Token(KSM)));
+//     })
+// }
 
-#[test]
-fn accrue_interest_works_after_liquidate_borrow() {
-    new_test_ext().execute_with(|| {
-        // Bob deposits 200 KSM
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(KSM), unit(200)));
-        // Alice deposits 300 DOT as collateral
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(300)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        // Alice borrows 100 KSM and 50 DOT
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(100)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(50)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        // Adjust KSM price to make shortfall
-        CurrencyConvert::convert.mock_safe(with_price(Some((Token(KSM), 2.into()))));
-        // BOB repay the KSM loan and get DOT callateral from ALICE
-        assert_ok!(Loans::liquidate_borrow(
-            RuntimeOrigin::signed(BOB),
-            ALICE,
-            Token(KSM),
-            unit(50),
-            Token(DOT)
-        ));
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000013318112633),);
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000006976141552),);
-    })
-}
+// #[test]
+// fn accrue_interest_works_after_liquidate_borrow() {
+//     new_test_ext().execute_with(|| {
+//         // Bob deposits 200 KSM
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(KSM), unit(200)));
+//         // Alice deposits 300 DOT as collateral
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(300)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         // Alice borrows 100 KSM and 50 DOT
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(100)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(50)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         // Adjust KSM price to make shortfall
+//         CurrencyConvert::convert.mock_safe(with_price(Some((Token(KSM), 2.into()))));
+//         // BOB repay the KSM loan and get DOT callateral from ALICE
+//         assert_ok!(Loans::liquidate_borrow(
+//             RuntimeOrigin::signed(BOB),
+//             ALICE,
+//             Token(KSM),
+//             unit(50),
+//             Token(DOT)
+//         ));
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000013318112633),);
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000006976141552),);
+//     })
+// }
 
-#[test]
-fn accrue_interest_works_after_recompute_collateral_amount() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(KSM), unit(200)));
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::recompute_collateral_amount(&Amount::<Test>::new(
-            1234,
-            Token(KSM)
-        )));
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000008561643835),);
-    })
-}
+// #[test]
+// fn accrue_interest_works_after_recompute_collateral_amount() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(KSM), unit(200)));
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::recompute_collateral_amount(&Amount::<Test>::new(
+//             1234,
+//             Token(KSM)
+//         )));
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000008561643835),);
+//     })
+// }
 
-#[test]
-fn accrue_interest_works_after_recompute_underlying_amount() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(KSM), unit(200)));
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::recompute_underlying_amount(
-            &Loans::free_lend_tokens(Token(KSM), &ALICE).unwrap()
-        ));
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000008561643835),);
-    })
-}
+// #[test]
+// fn accrue_interest_works_after_recompute_underlying_amount() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(KSM), unit(200)));
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(50)));
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::recompute_underlying_amount(
+//             &Loans::free_lend_tokens(Token(KSM), &ALICE).unwrap()
+//         ));
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000008561643835),);
+//     })
+// }
 
-#[test]
-fn different_markets_can_accrue_interest_in_one_block() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(KSM), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(KSM)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(100)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000003805175038),);
-        assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000003805175038),);
-    })
-}
+// #[test]
+// fn different_markets_can_accrue_interest_in_one_block() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(KSM), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(KSM)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), unit(100)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000003805175038),);
+//         assert_eq!(Loans::borrow_index(Token(KSM)), Rate::from_inner(1000000003805175038),);
+//     })
+// }
 
-#[test]
-fn a_market_can_only_accrue_interest_once_in_a_block() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), unit(200)));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), Token(DOT)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
-        TimestampPallet::set_timestamp(12000);
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(BOB), Token(DOT), unit(100)));
-        assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000003805175038),);
-    })
-}
+// #[test]
+// fn a_market_can_only_accrue_interest_once_in_a_block() {
+//     new_test_ext().execute_with(|| {
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), Token(DOT)));
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), unit(200)));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), Token(DOT)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::one());
+//         TimestampPallet::set_timestamp(12000);
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(DOT), unit(100)));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(BOB), Token(DOT), unit(100)));
+//         assert_eq!(Loans::borrow_index(Token(DOT)), Rate::from_inner(1000000003805175038),);
+//     })
+// }
+

--- a/crates/loans/src/tests/lend_tokens.rs
+++ b/crates/loans/src/tests/lend_tokens.rs
@@ -31,210 +31,211 @@ pub fn reserved_balance(currency_id: CurrencyId, account_id: &AccountId) -> Bala
     )
 }
 
-#[test]
-fn trait_inspect_methods_works() {
-    new_test_ext().execute_with(|| {
-        // No Deposits can't not withdraw
-        assert_err!(
-            Loans::can_withdraw(LEND_KINT, &DAVE, 100).into_result(),
-            TokenError::NoFunds
-        );
-        assert_eq!(Loans::total_issuance(LEND_KINT), 0);
-        assert_eq!(Loans::total_issuance(LEND_KSM), 0);
+// #[test]
+// fn trait_inspect_methods_works() {
+//     new_test_ext().execute_with(|| {
+//         // No Deposits can't not withdraw
+//         assert_err!(
+//             Loans::can_withdraw(LEND_KINT, &DAVE, 100).into_result(),
+//             TokenError::NoFunds
+//         );
+//         assert_eq!(Loans::total_issuance(LEND_KINT), 0);
+//         assert_eq!(Loans::total_issuance(LEND_KSM), 0);
 
-        let minimum_balance = Loans::minimum_balance(LEND_KINT);
-        assert_eq!(minimum_balance, 0);
+//         let minimum_balance = Loans::minimum_balance(LEND_KINT);
+//         assert_eq!(minimum_balance, 0);
 
-        assert_eq!(Loans::balance(LEND_KINT, &DAVE), 0);
+//         assert_eq!(Loans::balance(LEND_KINT, &DAVE), 0);
 
-        // DAVE Deposit 100 KINT
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KINT, unit(100)));
-        assert_eq!(Tokens::balance(LEND_KINT, &DAVE), unit(100) * 50);
-        assert_eq!(Tokens::total_issuance(LEND_KINT), unit(100) * 50);
-        // Check entries from orml-tokens directly
-        assert_eq!(free_balance(LEND_KINT, &DAVE), unit(100) * 50);
-        assert_eq!(reserved_balance(LEND_KINT, &DAVE), 0);
+//         // DAVE Deposit 100 KINT
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KINT, unit(100)));
+//         assert_eq!(Tokens::balance(LEND_KINT, &DAVE), unit(100) * 50);
+//         assert_eq!(Tokens::total_issuance(LEND_KINT), unit(100) * 50);
+//         // Check entries from orml-tokens directly
+//         assert_eq!(free_balance(LEND_KINT, &DAVE), unit(100) * 50);
+//         assert_eq!(reserved_balance(LEND_KINT, &DAVE), 0);
 
-        // No collateral deposited yet, therefore no reducible balance
-        assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), 0);
+//         // No collateral deposited yet, therefore no reducible balance
+//         assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), 0);
 
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(DAVE), KINT));
-        assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), unit(100) * 50);
-        // Check entries from orml-tokens directly
-        assert_eq!(free_balance(LEND_KINT, &DAVE), 0);
-        assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(100) * 50);
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(DAVE), KINT));
+//         assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), unit(100) * 50);
+//         // Check entries from orml-tokens directly
+//         assert_eq!(free_balance(LEND_KINT, &DAVE), 0);
+//         assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(100) * 50);
 
-        // Borrow 25 KINT will reduce 25 KINT liquidity for collateral_factor is 50%
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(25)));
+//         // Borrow 25 KINT will reduce 25 KINT liquidity for collateral_factor is 50%
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(25)));
 
-        assert_eq!(
-            Loans::exchange_rate(KINT)
-                .saturating_mul_int(Loans::account_deposits(Loans::lend_token_id(KINT).unwrap(), DAVE)),
-            unit(100)
-        );
+//         assert_eq!(
+//             Loans::exchange_rate(KINT)
+//                 .saturating_mul_int(Loans::account_deposits(Loans::lend_token_id(KINT).unwrap(), DAVE)),
+//             unit(100)
+//         );
 
-        // DAVE Deposit 100 KINT, Borrow 25 KINT
-        // Liquidity KINT 25
-        // Formula: lend_tokens = liquidity / price(1) / collateral(0.5) / exchange_rate(0.02)
-        assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), unit(25) * 2 * 50);
+//         // DAVE Deposit 100 KINT, Borrow 25 KINT
+//         // Liquidity KINT 25
+//         // Formula: lend_tokens = liquidity / price(1) / collateral(0.5) / exchange_rate(0.02)
+//         assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), unit(25) * 2 * 50);
 
-        // Multi-asset case, additional deposit KBTC
-        // DAVE Deposit 100 KINT, 50 KBTC, Borrow 25 KINT
-        // Liquidity KINT = 25, KBTC = 25
-        // lend_tokens = dollar(25 + 25) / 1 / 0.5 / 0.02 = dollar(50) * 100
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KBTC, unit(50)));
-        assert_eq!(Tokens::balance(LEND_KBTC, &DAVE), unit(50) * 50);
-        // Check entries from orml-tokens directly
-        assert_eq!(free_balance(LEND_KBTC, &DAVE), unit(50) * 50);
-        assert_eq!(reserved_balance(LEND_KBTC, &DAVE), 0);
+//         // Multi-asset case, additional deposit KBTC
+//         // DAVE Deposit 100 KINT, 50 KBTC, Borrow 25 KINT
+//         // Liquidity KINT = 25, KBTC = 25
+//         // lend_tokens = dollar(25 + 25) / 1 / 0.5 / 0.02 = dollar(50) * 100
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KBTC, unit(50)));
+//         assert_eq!(Tokens::balance(LEND_KBTC, &DAVE), unit(50) * 50);
+//         // Check entries from orml-tokens directly
+//         assert_eq!(free_balance(LEND_KBTC, &DAVE), unit(50) * 50);
+//         assert_eq!(reserved_balance(LEND_KBTC, &DAVE), 0);
 
-        // `reducible_balance()` checks how much collateral can be withdrawn from the amount deposited.
-        // Since no collateral has been deposited yet, this value is zero.
-        assert_eq!(Loans::reducible_balance(LEND_KBTC, &DAVE, true), 0);
-        // enable KBTC collateral
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(DAVE), KBTC));
-        assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), unit(25 + 25) * 2 * 50);
-        assert_eq!(Loans::reducible_balance(LEND_KBTC, &DAVE, true), unit(50) * 50);
-        // Check entries from orml-tokens directly
-        assert_eq!(free_balance(LEND_KBTC, &DAVE), 0);
-        assert_eq!(reserved_balance(LEND_KBTC, &DAVE), unit(50) * 50);
+//         // `reducible_balance()` checks how much collateral can be withdrawn from the amount deposited.
+//         // Since no collateral has been deposited yet, this value is zero.
+//         assert_eq!(Loans::reducible_balance(LEND_KBTC, &DAVE, true), 0);
+//         // enable KBTC collateral
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(DAVE), KBTC));
+//         assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), unit(25 + 25) * 2 * 50);
+//         assert_eq!(Loans::reducible_balance(LEND_KBTC, &DAVE, true), unit(50) * 50);
+//         // Check entries from orml-tokens directly
+//         assert_eq!(free_balance(LEND_KBTC, &DAVE), 0);
+//         assert_eq!(reserved_balance(LEND_KBTC, &DAVE), unit(50) * 50);
 
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(50)));
-        assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), 0);
-        assert_eq!(Loans::reducible_balance(LEND_KBTC, &DAVE, true), 0);
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(50)));
+//         assert_eq!(Loans::reducible_balance(LEND_KINT, &DAVE, true), 0);
+//         assert_eq!(Loans::reducible_balance(LEND_KBTC, &DAVE, true), 0);
 
-        assert_eq!(Loans::total_issuance(LEND_KINT), unit(100) * 50);
-        assert_ok!(Loans::can_deposit(LEND_KINT, &DAVE, 100, true).into_result());
-        assert_ok!(Loans::can_withdraw(LEND_KINT, &DAVE, 1000).into_result());
-    })
-}
+//         assert_eq!(Loans::total_issuance(LEND_KINT), unit(100) * 50);
+//         assert_ok!(Loans::can_deposit(LEND_KINT, &DAVE, 100, true).into_result());
+//         assert_ok!(Loans::can_withdraw(LEND_KINT, &DAVE, 1000).into_result());
+//     })
+// }
 
-#[test]
-fn lend_token_unique_works() {
-    new_test_ext().execute_with(|| {
-        // lend_token_id already exists in `UnderlyingAssetId`
-        assert_noop!(
-            Loans::add_market(RuntimeOrigin::root(), ForeignAsset(1000000), market_mock(LEND_KINT)),
-            Error::<Test>::InvalidLendTokenId
-        );
+// #[test]
+// fn lend_token_unique_works() {
+//     new_test_ext().execute_with(|| {
+//         // lend_token_id already exists in `UnderlyingAssetId`
+//         assert_noop!(
+//             Loans::add_market(RuntimeOrigin::root(), ForeignAsset(1000000), market_mock(LEND_KINT)),
+//             Error::<Test>::InvalidLendTokenId
+//         );
 
-        // lend_token_id cannot as the same as the asset id in `Markets`
-        assert_noop!(
-            Loans::add_market(RuntimeOrigin::root(), ForeignAsset(1000000), market_mock(KSM)),
-            Error::<Test>::InvalidLendTokenId
-        );
-    })
-}
+//         // lend_token_id cannot as the same as the asset id in `Markets`
+//         assert_noop!(
+//             Loans::add_market(RuntimeOrigin::root(), ForeignAsset(1000000), market_mock(KSM)),
+//             Error::<Test>::InvalidLendTokenId
+//         );
+//     })
+// }
 
-#[test]
-fn transfer_lend_token_works() {
-    new_test_ext().execute_with(|| {
-        // DAVE Deposit 100 KINT
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KINT, unit(100)));
+// #[test]
+// fn transfer_lend_token_works() {
+//     new_test_ext().execute_with(|| {
+//         // DAVE Deposit 100 KINT
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KINT, unit(100)));
 
-        // DAVE KINT collateral: deposit = 100
-        // KINT: cash - deposit = 1000 - 100 = 900
-        assert_eq!(
-            Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &DAVE)),
-            unit(100)
-        );
+//         // DAVE KINT collateral: deposit = 100
+//         // KINT: cash - deposit = 1000 - 100 = 900
+//         assert_eq!(
+//             Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &DAVE)),
+//             unit(100)
+//         );
 
-        // ALICE KINT collateral: deposit = 0
-        assert_eq!(
-            Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &ALICE)),
-            unit(0)
-        );
+//         // ALICE KINT collateral: deposit = 0
+//         assert_eq!(
+//             Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &ALICE)),
+//             unit(0)
+//         );
 
-        // Transfer lend_tokens from DAVE to ALICE
-        Loans::transfer(LEND_KINT, &DAVE, &ALICE, unit(50) * 50, true).unwrap();
-        // Loans::transfer_lend_tokens(RuntimeOrigin::signed(DAVE), ALICE, KINT, dollar(50) * 50).unwrap();
+//         // Transfer lend_tokens from DAVE to ALICE
+//         Loans::transfer(LEND_KINT, &DAVE, &ALICE, unit(50) * 50, true).unwrap();
+//         // Loans::transfer_lend_tokens(RuntimeOrigin::signed(DAVE), ALICE, KINT, dollar(50) * 50).unwrap();
 
-        // DAVE KINT collateral: deposit = 50
-        assert_eq!(
-            Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &DAVE)),
-            unit(50)
-        );
-        // DAVE Redeem 51 KINT should cause InsufficientDeposit
-        assert_noop!(
-            Loans::redeem_allowed(KINT, &DAVE, unit(51) * 50),
-            Error::<Test>::InsufficientDeposit
-        );
+//         // DAVE KINT collateral: deposit = 50
+//         assert_eq!(
+//             Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &DAVE)),
+//             unit(50)
+//         );
+//         // DAVE Redeem 51 KINT should cause InsufficientDeposit
+//         assert_noop!(
+//             Loans::redeem_allowed(KINT, &DAVE, unit(51) * 50),
+//             Error::<Test>::InsufficientDeposit
+//         );
 
-        // ALICE KINT collateral: deposit = 50
-        assert_eq!(
-            Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &ALICE)),
-            unit(50)
-        );
-        // ALICE Redeem 50 KINT should be succeeded
-        assert_ok!(Loans::redeem_allowed(KINT, &ALICE, unit(50) * 50));
-    })
-}
+//         // ALICE KINT collateral: deposit = 50
+//         assert_eq!(
+//             Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &ALICE)),
+//             unit(50)
+//         );
+//         // ALICE Redeem 50 KINT should be succeeded
+//         assert_ok!(Loans::redeem_allowed(KINT, &ALICE, unit(50) * 50));
+//     })
+// }
 
-#[test]
-fn transfer_lend_tokens_under_collateral_does_not_work() {
-    new_test_ext().execute_with(|| {
-        // DAVE Deposit 100 KINT
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KINT, unit(100)));
-        // Check entries from orml-tokens directly
-        assert_eq!(free_balance(LEND_KINT, &DAVE), unit(100) * 50);
-        assert_eq!(reserved_balance(LEND_KINT, &DAVE), 0);
+// #[test]
+// fn transfer_lend_tokens_under_collateral_does_not_work() {
+//     new_test_ext().execute_with(|| {
+//         // DAVE Deposit 100 KINT
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KINT, unit(100)));
+//         // Check entries from orml-tokens directly
+//         assert_eq!(free_balance(LEND_KINT, &DAVE), unit(100) * 50);
+//         assert_eq!(reserved_balance(LEND_KINT, &DAVE), 0);
 
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(DAVE), KINT));
-        // Check entries from orml-tokens directly
-        assert_eq!(free_balance(LEND_KINT, &DAVE), 0);
-        assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(100) * 50);
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(DAVE), KINT));
+//         // Check entries from orml-tokens directly
+//         assert_eq!(free_balance(LEND_KINT, &DAVE), 0);
+//         assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(100) * 50);
 
-        // Borrow 50 KINT will reduce 50 KINT liquidity for collateral_factor is 50%
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(50)));
-        // Repay 40 KINT
-        assert_ok!(Loans::repay_borrow(RuntimeOrigin::signed(DAVE), KINT, unit(40)));
+//         // Borrow 50 KINT will reduce 50 KINT liquidity for collateral_factor is 50%
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(50)));
+//         // Repay 40 KINT
+//         assert_ok!(Loans::repay_borrow(RuntimeOrigin::signed(DAVE), KINT, unit(40)));
 
-        // Not allowed to redeem 20 lend_tokens because they are locked
-        assert_noop!(
-            Loans::redeem_allowed(KINT, &DAVE, unit(20) * 50),
-            Error::<Test>::LockedTokensCannotBeRedeemed
-        );
-        // Not allowed to transfer 20 lend_tokens because they are locked
-        assert_noop!(
-            Loans::transfer(LEND_KINT, &DAVE, &ALICE, unit(20) * 50, true),
-            Error::<Test>::InsufficientCollateral
-        );
-        // First, withdraw some tokens. Note that directly withdrawing part of the locked
-        // lend_tokens is not possible through extrinsics. Users can only withdraw the full
-        // amount for a currency via extrinsics, to enforce the collateral toggle.
-        assert_ok!(Loans::do_withdraw_collateral(&DAVE, LEND_KINT, unit(20) * 50));
-        // Check entries from orml-tokens directly
-        assert_eq!(free_balance(LEND_KINT, &DAVE), unit(20) * 50);
-        assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(80) * 50);
-        // Then transfer them
-        assert_ok!(Loans::transfer(LEND_KINT, &DAVE, &ALICE, unit(20) * 50, true),);
-        // Check entries from orml-tokens directly
-        assert_eq!(free_balance(LEND_KINT, &DAVE), 0);
-        assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(80) * 50);
-        assert_eq!(free_balance(LEND_KINT, &ALICE), unit(20) * 50);
+//         // Not allowed to redeem 20 lend_tokens because they are locked
+//         assert_noop!(
+//             Loans::redeem_allowed(KINT, &DAVE, unit(20) * 50),
+//             Error::<Test>::LockedTokensCannotBeRedeemed
+//         );
+//         // Not allowed to transfer 20 lend_tokens because they are locked
+//         assert_noop!(
+//             Loans::transfer(LEND_KINT, &DAVE, &ALICE, unit(20) * 50, true),
+//             Error::<Test>::InsufficientCollateral
+//         );
+//         // First, withdraw some tokens. Note that directly withdrawing part of the locked
+//         // lend_tokens is not possible through extrinsics. Users can only withdraw the full
+//         // amount for a currency via extrinsics, to enforce the collateral toggle.
+//         assert_ok!(Loans::do_withdraw_collateral(&DAVE, LEND_KINT, unit(20) * 50));
+//         // Check entries from orml-tokens directly
+//         assert_eq!(free_balance(LEND_KINT, &DAVE), unit(20) * 50);
+//         assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(80) * 50);
+//         // Then transfer them
+//         assert_ok!(Loans::transfer(LEND_KINT, &DAVE, &ALICE, unit(20) * 50, true),);
+//         // Check entries from orml-tokens directly
+//         assert_eq!(free_balance(LEND_KINT, &DAVE), 0);
+//         assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(80) * 50);
+//         assert_eq!(free_balance(LEND_KINT, &ALICE), unit(20) * 50);
 
-        // DAVE Deposit KINT = 100 - 20 = 80
-        // DAVE Borrow KINT = 0 + 50 - 40 = 10
-        // DAVE liquidity KINT = 80 * 0.5 - 10 = 30
-        assert_eq!(
-            Loans::exchange_rate(KINT)
-                .saturating_mul_int(Loans::account_deposits(Loans::lend_token_id(KINT).unwrap(), DAVE)),
-            unit(80)
-        );
-        // DAVE Borrow 31 KINT should cause InsufficientLiquidity
-        assert_noop!(
-            Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(31)),
-            Error::<Test>::InsufficientLiquidity
-        );
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(30)));
+//         // DAVE Deposit KINT = 100 - 20 = 80
+//         // DAVE Borrow KINT = 0 + 50 - 40 = 10
+//         // DAVE liquidity KINT = 80 * 0.5 - 10 = 30
+//         assert_eq!(
+//             Loans::exchange_rate(KINT)
+//                 .saturating_mul_int(Loans::account_deposits(Loans::lend_token_id(KINT).unwrap(), DAVE)),
+//             unit(80)
+//         );
+//         // DAVE Borrow 31 KINT should cause InsufficientLiquidity
+//         assert_noop!(
+//             Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(31)),
+//             Error::<Test>::InsufficientLiquidity
+//         );
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(DAVE), KINT, unit(30)));
 
-        // Assert ALICE Supply KINT 20
-        assert_eq!(
-            Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &ALICE)),
-            unit(20)
-        );
-        // ALICE Redeem 20 KINT should be succeeded
-        // Also means that transfer lend_token succeed
-        assert_ok!(Loans::redeem_allowed(KINT, &ALICE, unit(20) * 50,));
-    })
-}
+//         // Assert ALICE Supply KINT 20
+//         assert_eq!(
+//             Loans::exchange_rate(KINT).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KINT).unwrap(), &ALICE)),
+//             unit(20)
+//         );
+//         // ALICE Redeem 20 KINT should be succeeded
+//         // Also means that transfer lend_token succeed
+//         assert_ok!(Loans::redeem_allowed(KINT, &ALICE, unit(20) * 50,));
+//     })
+// }
+

--- a/crates/loans/src/tests/liquidate_borrow.rs
+++ b/crates/loans/src/tests/liquidate_borrow.rs
@@ -1,427 +1,428 @@
-use crate::{
-    mock::{
-        new_test_ext, with_price, CurrencyConvert, Loans, RuntimeOrigin, Test, Tokens, _run_to_block, market_mock,
-        new_test_ext_no_markets, ALICE, BOB, DEFAULT_WRAPPED_CURRENCY, LEND_KBTC, LEND_KSM,
-    },
-    tests::unit,
-    Amount, Error, Market, MarketState,
-};
-use currency::CurrencyConversion;
-use frame_support::{assert_noop, assert_ok, traits::fungibles::Inspect};
-use mocktopus::mocking::Mockable;
-use primitives::{
-    Balance,
-    CurrencyId::{self, Token},
-    Rate, Ratio, DOT as DOT_CURRENCY, KBTC as KBTC_CURRENCY, KSM as KSM_CURRENCY,
-};
-use sp_runtime::FixedPointNumber;
-use traits::LoansApi;
+// use crate::{
+//     mock::{
+//         new_test_ext, with_price, CurrencyConvert, Loans, RuntimeOrigin, Test, Tokens, _run_to_block, market_mock,
+//         new_test_ext_no_markets, ALICE, BOB, DEFAULT_WRAPPED_CURRENCY, LEND_KBTC, LEND_KSM,
+//     },
+//     tests::unit,
+//     Amount, Error, Market, MarketState,
+// };
+// use currency::CurrencyConversion;
+// use frame_support::{assert_noop, assert_ok, traits::fungibles::Inspect};
+// use mocktopus::mocking::Mockable;
+// use primitives::{
+//     Balance,
+//     CurrencyId::{self, Token},
+//     Rate, Ratio, DOT as DOT_CURRENCY, KBTC as KBTC_CURRENCY, KSM as KSM_CURRENCY,
+// };
+// use sp_runtime::FixedPointNumber;
+// use traits::LoansApi;
 
-const DOT: CurrencyId = Token(DOT_CURRENCY);
-const KSM: CurrencyId = Token(KSM_CURRENCY);
-const KBTC: CurrencyId = Token(KBTC_CURRENCY);
+// const DOT: CurrencyId = Token(DOT_CURRENCY);
+// const KSM: CurrencyId = Token(KSM_CURRENCY);
+// const KBTC: CurrencyId = Token(KBTC_CURRENCY);
 
-#[test]
-fn liquidate_borrow_allowed_works() {
-    new_test_ext().execute_with(|| {
-        // Borrower should have a positive shortfall
-        let dot_market = Loans::market(DOT).unwrap();
-        assert_noop!(
-            Loans::liquidate_borrow_allowed(&ALICE, DOT, 100, &dot_market),
-            Error::<Test>::InsufficientShortfall
-        );
-        initial_setup();
-        alice_borrows_100_ksm();
-        // Adjust KSM price to make shortfall
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
-        let ksm_market = Loans::market(KSM).unwrap();
-        // Here the balance sheet of Alice is:
-        // Collateral   Loans
-        // USDT $110    KSM $200
-        assert_noop!(
-            Loans::liquidate_borrow_allowed(&ALICE, KSM, unit(51), &ksm_market),
-            Error::<Test>::TooMuchRepay
-        );
-        assert_ok!(Loans::liquidate_borrow_allowed(&ALICE, KSM, unit(50), &ksm_market));
-    })
-}
+// #[test]
+// fn liquidate_borrow_allowed_works() {
+//     new_test_ext().execute_with(|| {
+//         // Borrower should have a positive shortfall
+//         let dot_market = Loans::market(DOT).unwrap();
+//         assert_noop!(
+//             Loans::liquidate_borrow_allowed(&ALICE, DOT, 100, &dot_market),
+//             Error::<Test>::InsufficientShortfall
+//         );
+//         initial_setup();
+//         alice_borrows_100_ksm();
+//         // Adjust KSM price to make shortfall
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+//         let ksm_market = Loans::market(KSM).unwrap();
+//         // Here the balance sheet of Alice is:
+//         // Collateral   Loans
+//         // USDT $110    KSM $200
+//         assert_noop!(
+//             Loans::liquidate_borrow_allowed(&ALICE, KSM, unit(51), &ksm_market),
+//             Error::<Test>::TooMuchRepay
+//         );
+//         assert_ok!(Loans::liquidate_borrow_allowed(&ALICE, KSM, unit(50), &ksm_market));
+//     })
+// }
 
-#[test]
-fn deposit_of_borrower_must_be_collateral() {
-    new_test_ext().execute_with(|| {
-        initial_setup();
-        alice_borrows_100_ksm();
-        // Adjust KSM price to make shortfall
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
-        let market = Loans::market(KSM).unwrap();
-        assert_noop!(
-            Loans::liquidate_borrow_allowed(&ALICE, KSM, unit(51), &market),
-            Error::<Test>::TooMuchRepay
-        );
+// #[test]
+// fn deposit_of_borrower_must_be_collateral() {
+//     new_test_ext().execute_with(|| {
+//         initial_setup();
+//         alice_borrows_100_ksm();
+//         // Adjust KSM price to make shortfall
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+//         let market = Loans::market(KSM).unwrap();
+//         assert_noop!(
+//             Loans::liquidate_borrow_allowed(&ALICE, KSM, unit(51), &market),
+//             Error::<Test>::TooMuchRepay
+//         );
 
-        assert_noop!(
-            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, 10, DOT),
-            Error::<Test>::DepositsAreNotCollateral
-        );
-    })
-}
+//         assert_noop!(
+//             Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, 10, DOT),
+//             Error::<Test>::DepositsAreNotCollateral
+//         );
+//     })
+// }
 
-#[test]
-fn collateral_value_must_be_greater_than_liquidation_value() {
-    new_test_ext().execute_with(|| {
-        initial_setup();
-        alice_borrows_100_ksm();
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, Rate::from_float(2000.0)))));
-        Loans::mutate_market(KSM, |market| {
-            market.liquidate_incentive = Rate::from_float(200.0);
-            market.clone()
-        })
-        .unwrap();
-        assert_noop!(
-            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(50), KBTC),
-            Error::<Test>::InsufficientCollateral
-        );
-    })
-}
+// #[test]
+// fn collateral_value_must_be_greater_than_liquidation_value() {
+//     new_test_ext().execute_with(|| {
+//         initial_setup();
+//         alice_borrows_100_ksm();
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, Rate::from_float(2000.0)))));
+//         Loans::mutate_market(KSM, |market| {
+//             market.liquidate_incentive = Rate::from_float(200.0);
+//             market.clone()
+//         })
+//         .unwrap();
+//         assert_noop!(
+//             Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(50), KBTC),
+//             Error::<Test>::InsufficientCollateral
+//         );
+//     })
+// }
 
-#[test]
-fn full_workflow_works_as_expected() {
-    new_test_ext().execute_with(|| {
-        initial_setup();
-        alice_borrows_100_ksm();
-        // adjust KSM price to make ALICE generate shortfall
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
-        // BOB repay the KSM borrow balance and get DOT from ALICE
-        assert_ok!(Loans::liquidate_borrow(
-            RuntimeOrigin::signed(BOB),
-            ALICE,
-            KSM,
-            unit(50),
-            KBTC
-        ));
+// #[test]
+// fn full_workflow_works_as_expected() {
+//     new_test_ext().execute_with(|| {
+//         initial_setup();
+//         alice_borrows_100_ksm();
+//         // adjust KSM price to make ALICE generate shortfall
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+//         // BOB repay the KSM borrow balance and get DOT from ALICE
+//         assert_ok!(Loans::liquidate_borrow(
+//             RuntimeOrigin::signed(BOB),
+//             ALICE,
+//             KSM,
+//             unit(50),
+//             KBTC
+//         ));
 
-        // KSM price = 2
-        // incentive = repay KSM value * 1.1 = (50 * 2) * 1.1 = 110
-        // Alice KBTC: cash - deposit = 1000 - 200 = 800
-        // Alice KBTC collateral: deposit - incentive = 200 - 110 = 90
-        // Alice KSM: cash + borrow = 1000 + 100 = 1100
-        // Alice KSM borrow balance: origin borrow balance - liquidate amount = 100 - 50 = 50
-        // Bob KSM: cash - deposit - repay = 1000 - 200 - 50 = 750
-        // Bob KBTC collateral: incentive = 110-(110/1.1*0.03)=107
-        assert_eq!(Tokens::balance(KBTC, &ALICE), unit(800),);
-        assert_eq!(
-            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KBTC).unwrap(), &ALICE)),
-            unit(90),
-        );
-        assert_eq!(Tokens::balance(KSM, &ALICE), unit(1100),);
-        assert_eq!(Loans::account_borrows(KSM, ALICE).principal, unit(50));
-        assert_eq!(Tokens::balance(KSM, &BOB), unit(750));
-        assert_eq!(
-            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KBTC).unwrap(), &BOB)),
-            unit(107),
-        );
-        // 3 dollar reserved in our incentive reward account
-        let incentive_reward_account = Loans::incentive_reward_account_id();
-        println!("incentive reserve account:{:?}", incentive_reward_account.clone());
-        assert_eq!(
-            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
-                Loans::lend_token_id(KBTC).unwrap(),
-                &incentive_reward_account.clone()
-            )),
-            unit(3),
-        );
-        assert_eq!(Tokens::balance(KBTC, &ALICE), unit(800),);
-        // reduce 2 dollar from incentive reserve to alice account
-        assert_ok!(Loans::reduce_incentive_reserves(
-            RuntimeOrigin::root(),
-            ALICE,
-            KBTC,
-            unit(2),
-        ));
-        // still 1 dollar left in reserve account
-        assert_eq!(
-            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
-                Loans::lend_token_id(KBTC).unwrap(),
-                &incentive_reward_account
-            )),
-            unit(1),
-        );
-        // 2 dollar transfer to alice
-        assert_eq!(Tokens::balance(KBTC, &ALICE), unit(800) + unit(2),);
-    })
-}
+//         // KSM price = 2
+//         // incentive = repay KSM value * 1.1 = (50 * 2) * 1.1 = 110
+//         // Alice KBTC: cash - deposit = 1000 - 200 = 800
+//         // Alice KBTC collateral: deposit - incentive = 200 - 110 = 90
+//         // Alice KSM: cash + borrow = 1000 + 100 = 1100
+//         // Alice KSM borrow balance: origin borrow balance - liquidate amount = 100 - 50 = 50
+//         // Bob KSM: cash - deposit - repay = 1000 - 200 - 50 = 750
+//         // Bob KBTC collateral: incentive = 110-(110/1.1*0.03)=107
+//         assert_eq!(Tokens::balance(KBTC, &ALICE), unit(800),);
+//         assert_eq!(
+//             Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KBTC).unwrap(), &ALICE)),
+//             unit(90),
+//         );
+//         assert_eq!(Tokens::balance(KSM, &ALICE), unit(1100),);
+//         assert_eq!(Loans::account_borrows(KSM, ALICE).principal, unit(50));
+//         assert_eq!(Tokens::balance(KSM, &BOB), unit(750));
+//         assert_eq!(
+//             Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(Loans::lend_token_id(KBTC).unwrap(), &BOB)),
+//             unit(107),
+//         );
+//         // 3 dollar reserved in our incentive reward account
+//         let incentive_reward_account = Loans::incentive_reward_account_id();
+//         println!("incentive reserve account:{:?}", incentive_reward_account.clone());
+//         assert_eq!(
+//             Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
+//                 Loans::lend_token_id(KBTC).unwrap(),
+//                 &incentive_reward_account.clone()
+//             )),
+//             unit(3),
+//         );
+//         assert_eq!(Tokens::balance(KBTC, &ALICE), unit(800),);
+//         // reduce 2 dollar from incentive reserve to alice account
+//         assert_ok!(Loans::reduce_incentive_reserves(
+//             RuntimeOrigin::root(),
+//             ALICE,
+//             KBTC,
+//             unit(2),
+//         ));
+//         // still 1 dollar left in reserve account
+//         assert_eq!(
+//             Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
+//                 Loans::lend_token_id(KBTC).unwrap(),
+//                 &incentive_reward_account
+//             )),
+//             unit(1),
+//         );
+//         // 2 dollar transfer to alice
+//         assert_eq!(Tokens::balance(KBTC, &ALICE), unit(800) + unit(2),);
+//     })
+// }
 
-#[test]
-fn withdrawing_incentive_reserve_accrues_interest() {
-    new_test_ext().execute_with(|| {
-        let incentive_reward_account = Loans::incentive_reward_account_id();
-        initial_setup();
-        alice_borrows_100_ksm();
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), KSM));
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(BOB), KBTC, unit(100)));
-        // adjust KSM price to make ALICE generate shortfall
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
-        // BOB repay the KSM borrow balance and get DOT from ALICE
-        assert_ok!(Loans::liquidate_borrow(
-            RuntimeOrigin::signed(BOB),
-            ALICE,
-            KSM,
-            unit(50),
-            KBTC
-        ));
-        assert_eq!(
-            Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
-                Loans::lend_token_id(KBTC).unwrap(),
-                &incentive_reward_account
-            )),
-            unit(3),
-        );
+// #[test]
+// fn withdrawing_incentive_reserve_accrues_interest() {
+//     new_test_ext().execute_with(|| {
+//         let incentive_reward_account = Loans::incentive_reward_account_id();
+//         initial_setup();
+//         alice_borrows_100_ksm();
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), KSM));
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(BOB), KBTC, unit(100)));
+//         // adjust KSM price to make ALICE generate shortfall
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+//         // BOB repay the KSM borrow balance and get DOT from ALICE
+//         assert_ok!(Loans::liquidate_borrow(
+//             RuntimeOrigin::signed(BOB),
+//             ALICE,
+//             KSM,
+//             unit(50),
+//             KBTC
+//         ));
+//         assert_eq!(
+//             Loans::exchange_rate(KBTC).saturating_mul_int(Tokens::balance(
+//                 Loans::lend_token_id(KBTC).unwrap(),
+//                 &incentive_reward_account
+//             )),
+//             unit(3),
+//         );
 
-        _run_to_block(10000);
+//         _run_to_block(10000);
 
-        // Can reduce more than 3 dollars because interest is accrued just before the reserve is withdrawn
-        assert_ok!(Loans::reduce_incentive_reserves(
-            RuntimeOrigin::root(),
-            ALICE,
-            KBTC,
-            3000169788955,
-        ));
-    })
-}
+//         // Can reduce more than 3 dollars because interest is accrued just before the reserve is withdrawn
+//         assert_ok!(Loans::reduce_incentive_reserves(
+//             RuntimeOrigin::root(),
+//             ALICE,
+//             KBTC,
+//             3000169788955,
+//         ));
+//     })
+// }
 
-#[test]
-fn liquidator_cannot_take_inactive_market_currency() {
-    new_test_ext().execute_with(|| {
-        initial_setup();
-        alice_borrows_100_ksm();
-        // Adjust KSM price to make shortfall
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
-        assert_ok!(Loans::mutate_market(DOT, |stored_market| {
-            stored_market.state = MarketState::Supervision;
-            stored_market.clone()
-        }));
-        assert_noop!(
-            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(50), DOT),
-            Error::<Test>::MarketNotActivated
-        );
-    })
-}
+// #[test]
+// fn liquidator_cannot_take_inactive_market_currency() {
+//     new_test_ext().execute_with(|| {
+//         initial_setup();
+//         alice_borrows_100_ksm();
+//         // Adjust KSM price to make shortfall
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+//         assert_ok!(Loans::mutate_market(DOT, |stored_market| {
+//             stored_market.state = MarketState::Supervision;
+//             stored_market.clone()
+//         }));
+//         assert_noop!(
+//             Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(50), DOT),
+//             Error::<Test>::MarketNotActivated
+//         );
+//     })
+// }
 
-#[test]
-fn liquidator_can_not_repay_more_than_the_close_factor_pct_multiplier() {
-    new_test_ext().execute_with(|| {
-        initial_setup();
-        alice_borrows_100_ksm();
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 20.into()))));
-        assert_noop!(
-            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(51), DOT),
-            Error::<Test>::TooMuchRepay
-        );
-    })
-}
+// #[test]
+// fn liquidator_can_not_repay_more_than_the_close_factor_pct_multiplier() {
+//     new_test_ext().execute_with(|| {
+//         initial_setup();
+//         alice_borrows_100_ksm();
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 20.into()))));
+//         assert_noop!(
+//             Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(51), DOT),
+//             Error::<Test>::TooMuchRepay
+//         );
+//     })
+// }
 
-#[test]
-fn repay_currency_auto_locking_works() {
-    new_test_ext().execute_with(|| {
-        initial_setup();
-        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), KBTC, 1));
-        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), KBTC));
-        alice_borrows_100_ksm();
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
-        let initial_borrower_locked_collateral =
-            Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
-        let initial_liquidator_locked_collateral =
-            Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &BOB), LEND_KBTC);
-        assert_ok!(Loans::liquidate_borrow(
-            RuntimeOrigin::signed(BOB),
-            ALICE,
-            KSM,
-            unit(50),
-            KBTC
-        ),);
-        let final_borrower_locked_collateral =
-            Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
-        let final_liquidator_locked_collateral =
-            Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &BOB), LEND_KBTC);
-        let actual_liquidator_reward = final_liquidator_locked_collateral
-            .checked_sub(&initial_liquidator_locked_collateral)
-            .unwrap();
-        let borrower_slash = initial_borrower_locked_collateral
-            .checked_sub(&final_borrower_locked_collateral)
-            .unwrap();
-        let Market {
-            liquidate_incentive,
-            liquidate_incentive_reserved_factor,
-            ..
-        } = Loans::market(KSM).unwrap();
-        let reserved_reward = liquidate_incentive_reserved_factor
-            .mul_floor(borrower_slash.checked_div(&liquidate_incentive).unwrap().amount());
-        // The amount received by the liquidator should be whatever is slashed
-        // from the borrower minus the reserve's share.
-        let expected_liquidator_reward = borrower_slash.amount() - reserved_reward;
+// #[test]
+// fn repay_currency_auto_locking_works() {
+//     new_test_ext().execute_with(|| {
+//         initial_setup();
+//         assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), KBTC, 1));
+//         assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), KBTC));
+//         alice_borrows_100_ksm();
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+//         let initial_borrower_locked_collateral =
+//             Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
+//         let initial_liquidator_locked_collateral =
+//             Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &BOB), LEND_KBTC);
+//         assert_ok!(Loans::liquidate_borrow(
+//             RuntimeOrigin::signed(BOB),
+//             ALICE,
+//             KSM,
+//             unit(50),
+//             KBTC
+//         ),);
+//         let final_borrower_locked_collateral =
+//             Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
+//         let final_liquidator_locked_collateral =
+//             Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &BOB), LEND_KBTC);
+//         let actual_liquidator_reward = final_liquidator_locked_collateral
+//             .checked_sub(&initial_liquidator_locked_collateral)
+//             .unwrap();
+//         let borrower_slash = initial_borrower_locked_collateral
+//             .checked_sub(&final_borrower_locked_collateral)
+//             .unwrap();
+//         let Market {
+//             liquidate_incentive,
+//             liquidate_incentive_reserved_factor,
+//             ..
+//         } = Loans::market(KSM).unwrap();
+//         let reserved_reward = liquidate_incentive_reserved_factor
+//             .mul_floor(borrower_slash.checked_div(&liquidate_incentive).unwrap().amount());
+//         // The amount received by the liquidator should be whatever is slashed
+//         // from the borrower minus the reserve's share.
+//         let expected_liquidator_reward = borrower_slash.amount() - reserved_reward;
 
-        assert_eq!(
-            actual_liquidator_reward.amount(),
-            expected_liquidator_reward,
-            "The entirety of the liquidator's reward should have been auto-locked as collateral"
-        );
-    })
-}
+//         assert_eq!(
+//             actual_liquidator_reward.amount(),
+//             expected_liquidator_reward,
+//             "The entirety of the liquidator's reward should have been auto-locked as collateral"
+//         );
+//     })
+// }
 
-#[test]
-fn liquidated_transfer_reduces_locked_collateral() {
-    new_test_ext().execute_with(|| {
-        initial_setup();
-        alice_borrows_100_ksm();
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
-        let amount_to_liquidate = Amount::<Test>::new(unit(50), KSM);
-        let initial_locked_collateral = Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
-        let initial_locked_underlying = Loans::recompute_underlying_amount(&initial_locked_collateral).unwrap();
-        assert_ok!(Loans::liquidate_borrow(
-            RuntimeOrigin::signed(BOB),
-            ALICE,
-            KSM,
-            amount_to_liquidate.amount(),
-            KBTC
-        ),);
-        let final_locked_collateral = Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
-        let final_locked_underlying = Loans::recompute_underlying_amount(&final_locked_collateral).unwrap();
-        // The total liquidated KSM includes the market's liquidation incentive
-        let liquidation_incentive = Loans::market(KSM).unwrap().liquidate_incentive;
-        let liquidated_ksm = amount_to_liquidate
-            .checked_fixed_point_mul(&liquidation_incentive)
-            .unwrap();
-        let liquidated_ksm_as_wrapped = liquidated_ksm.convert_to(DEFAULT_WRAPPED_CURRENCY).unwrap();
-        // The borrower's locked collateral (as tracked by the `AccountDeposits` storage item) must have been decreased
-        // by the liquidated amount.
-        let borrower_collateral_difference_as_wrapped = initial_locked_underlying
-            .checked_sub(&final_locked_underlying)
-            .unwrap()
-            .convert_to(DEFAULT_WRAPPED_CURRENCY)
-            .unwrap();
-        assert_eq!(liquidated_ksm_as_wrapped, borrower_collateral_difference_as_wrapped);
-    })
-}
+// #[test]
+// fn liquidated_transfer_reduces_locked_collateral() {
+//     new_test_ext().execute_with(|| {
+//         initial_setup();
+//         alice_borrows_100_ksm();
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+//         let amount_to_liquidate = Amount::<Test>::new(unit(50), KSM);
+//         let initial_locked_collateral = Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
+//         let initial_locked_underlying = Loans::recompute_underlying_amount(&initial_locked_collateral).unwrap();
+//         assert_ok!(Loans::liquidate_borrow(
+//             RuntimeOrigin::signed(BOB),
+//             ALICE,
+//             KSM,
+//             amount_to_liquidate.amount(),
+//             KBTC
+//         ),);
+//         let final_locked_collateral = Amount::<Test>::new(Loans::account_deposits(LEND_KBTC, &ALICE), LEND_KBTC);
+//         let final_locked_underlying = Loans::recompute_underlying_amount(&final_locked_collateral).unwrap();
+//         // The total liquidated KSM includes the market's liquidation incentive
+//         let liquidation_incentive = Loans::market(KSM).unwrap().liquidate_incentive;
+//         let liquidated_ksm = amount_to_liquidate
+//             .checked_fixed_point_mul(&liquidation_incentive)
+//             .unwrap();
+//         let liquidated_ksm_as_wrapped = liquidated_ksm.convert_to(DEFAULT_WRAPPED_CURRENCY).unwrap();
+//         // The borrower's locked collateral (as tracked by the `AccountDeposits` storage item) must have been decreased
+//         // by the liquidated amount.
+//         let borrower_collateral_difference_as_wrapped = initial_locked_underlying
+//             .checked_sub(&final_locked_underlying)
+//             .unwrap()
+//             .convert_to(DEFAULT_WRAPPED_CURRENCY)
+//             .unwrap();
+//         assert_eq!(liquidated_ksm_as_wrapped, borrower_collateral_difference_as_wrapped);
+//     })
+// }
 
-#[test]
-fn close_factor_may_require_multiple_liquidations_to_clear_bad_debt() {
-    new_test_ext_no_markets().execute_with(|| {
-        fn conservative_mock_market(lend_token: CurrencyId) -> Market<Balance> {
-            Market {
-                collateral_factor: Ratio::from_percent(40),
-                liquidation_threshold: Ratio::from_percent(45),
-                ..market_mock(lend_token)
-            }
-        }
-        Loans::add_market(RuntimeOrigin::root(), KSM, conservative_mock_market(LEND_KSM)).unwrap();
-        Loans::activate_market(RuntimeOrigin::root(), KSM).unwrap();
-        Loans::add_market(RuntimeOrigin::root(), KBTC, conservative_mock_market(LEND_KBTC)).unwrap();
-        Loans::activate_market(RuntimeOrigin::root(), KBTC).unwrap();
-        // Market setup:
-        // secure ratio        = 40%
-        // liquidation ratio   = 45%
-        // liquidation premium = 110%
-        // close factor        = 50%
-        initial_setup();
-        assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, unit(80)));
-        // Step 1.
-        // Collateral = 200 KBTC (worth 200 reference units)
-        // Debt       =  80 KSM  (worth  80 reference units)
-        // Collateral ratio = 40%
-        CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
+// #[test]
+// fn close_factor_may_require_multiple_liquidations_to_clear_bad_debt() {
+//     new_test_ext_no_markets().execute_with(|| {
+//         fn conservative_mock_market(lend_token: CurrencyId) -> Market<Balance> {
+//             Market {
+//                 collateral_factor: Ratio::from_percent(40),
+//                 liquidation_threshold: Ratio::from_percent(45),
+//                 ..market_mock(lend_token)
+//             }
+//         }
+//         Loans::add_market(RuntimeOrigin::root(), KSM, conservative_mock_market(LEND_KSM)).unwrap();
+//         Loans::activate_market(RuntimeOrigin::root(), KSM).unwrap();
+//         Loans::add_market(RuntimeOrigin::root(), KBTC, conservative_mock_market(LEND_KBTC)).unwrap();
+//         Loans::activate_market(RuntimeOrigin::root(), KBTC).unwrap();
+//         // Market setup:
+//         // secure ratio        = 40%
+//         // liquidation ratio   = 45%
+//         // liquidation premium = 110%
+//         // close factor        = 50%
+//         initial_setup();
+//         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, unit(80)));
+//         // Step 1.
+//         // Collateral = 200 KBTC (worth 200 reference units)
+//         // Debt       =  80 KSM  (worth  80 reference units)
+//         // Collateral ratio = 40%
+//         CurrencyConvert::convert.mock_safe(with_price(Some((KSM, 2.into()))));
 
-        // Step 2.
-        // Collateral = 200 KBTC (worth 200 reference units)
-        // Debt       =  80 KSM  (worth 160 reference units)
-        // Collateral ratio = 80% (unhealthy)
-        assert_noop!(
-            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(41), KBTC),
-            Error::<Test>::TooMuchRepay
-        );
-        assert_ok!(Loans::liquidate_borrow(
-            RuntimeOrigin::signed(BOB),
-            ALICE,
-            KSM,
-            unit(40),
-            KBTC
-        ),);
-        // There is still shortfall in spite of liquidating the max available amount
-        let shortfall = Loans::get_account_liquidation_threshold_liquidity(&ALICE)
-            .unwrap()
-            .shortfall();
-        assert!(
-            !shortfall.is_zero(),
-            "Shortfall should be greater than zero, because the close factor limited the max liquidatable amount"
-        );
+//         // Step 2.
+//         // Collateral = 200 KBTC (worth 200 reference units)
+//         // Debt       =  80 KSM  (worth 160 reference units)
+//         // Collateral ratio = 80% (unhealthy)
+//         assert_noop!(
+//             Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, unit(41), KBTC),
+//             Error::<Test>::TooMuchRepay
+//         );
+//         assert_ok!(Loans::liquidate_borrow(
+//             RuntimeOrigin::signed(BOB),
+//             ALICE,
+//             KSM,
+//             unit(40),
+//             KBTC
+//         ),);
+//         // There is still shortfall in spite of liquidating the max available amount
+//         let shortfall = Loans::get_account_liquidation_threshold_liquidity(&ALICE)
+//             .unwrap()
+//             .shortfall();
+//         assert!(
+//             !shortfall.is_zero(),
+//             "Shortfall should be greater than zero, because the close factor limited the max liquidatable amount"
+//         );
 
-        // Step 3.
-        // Collateral = 112 KBTC (worth 112 reference units)
-        // Debt       =  40 KSM  (worth 80 reference units)
-        // Collateral ratio = 71% (unhealthy)
-        assert_ok!(Loans::liquidate_borrow(
-            RuntimeOrigin::signed(BOB),
-            ALICE,
-            KSM,
-            unit(20),
-            KBTC
-        ),);
+//         // Step 3.
+//         // Collateral = 112 KBTC (worth 112 reference units)
+//         // Debt       =  40 KSM  (worth 80 reference units)
+//         // Collateral ratio = 71% (unhealthy)
+//         assert_ok!(Loans::liquidate_borrow(
+//             RuntimeOrigin::signed(BOB),
+//             ALICE,
+//             KSM,
+//             unit(20),
+//             KBTC
+//         ),);
 
-        // Step 4.
-        // Collateral =  68 KBTC (worth 68 reference units)
-        // Debt       =  20 KSM  (worth 40 reference units)
-        // Collateral ratio = 59% (unhealthy)
-        assert_ok!(Loans::liquidate_borrow(
-            RuntimeOrigin::signed(BOB),
-            ALICE,
-            KSM,
-            unit(10),
-            KBTC
-        ),);
+//         // Step 4.
+//         // Collateral =  68 KBTC (worth 68 reference units)
+//         // Debt       =  20 KSM  (worth 40 reference units)
+//         // Collateral ratio = 59% (unhealthy)
+//         assert_ok!(Loans::liquidate_borrow(
+//             RuntimeOrigin::signed(BOB),
+//             ALICE,
+//             KSM,
+//             unit(10),
+//             KBTC
+//         ),);
 
-        // Step 5.
-        // Collateral =  24 KBTC (worth 24 reference units)
-        // Debt       =  10 KSM  (worth 10 reference units)
-        // Collateral ratio = 42% (healthy)
-        // At this point the debt is healthy, cannot liquidate even one planck
-        assert_noop!(
-            Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, 1, KBTC),
-            Error::<Test>::InsufficientShortfall
-        );
-        let shortfall_final = Loans::get_account_liquidation_threshold_liquidity(&ALICE)
-            .unwrap()
-            .shortfall();
-        assert!(
-            shortfall_final.is_zero(),
-            "The borrower should have no shortfall after repeated max liquidations"
-        );
+//         // Step 5.
+//         // Collateral =  24 KBTC (worth 24 reference units)
+//         // Debt       =  10 KSM  (worth 10 reference units)
+//         // Collateral ratio = 42% (healthy)
+//         // At this point the debt is healthy, cannot liquidate even one planck
+//         assert_noop!(
+//             Loans::liquidate_borrow(RuntimeOrigin::signed(BOB), ALICE, KSM, 1, KBTC),
+//             Error::<Test>::InsufficientShortfall
+//         );
+//         let shortfall_final = Loans::get_account_liquidation_threshold_liquidity(&ALICE)
+//             .unwrap()
+//             .shortfall();
+//         assert!(
+//             shortfall_final.is_zero(),
+//             "The borrower should have no shortfall after repeated max liquidations"
+//         );
 
-        // The borrower can take on no additional debt because they exceeded the 40% secure ratio
-        assert_noop!(
-            Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, 1),
-            Error::<Test>::InsufficientLiquidity
-        );
-    })
-}
+//         // The borrower can take on no additional debt because they exceeded the 40% secure ratio
+//         assert_noop!(
+//             Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, 1),
+//             Error::<Test>::InsufficientLiquidity
+//         );
+//     })
+// }
 
-#[test]
-fn liquidator_must_not_be_borrower() {
-    new_test_ext().execute_with(|| {
-        initial_setup();
-        assert_noop!(
-            Loans::liquidate_borrow(RuntimeOrigin::signed(ALICE), ALICE, KSM, 1, DOT),
-            Error::<Test>::LiquidatorIsBorrower
-        );
-    })
-}
+// #[test]
+// fn liquidator_must_not_be_borrower() {
+//     new_test_ext().execute_with(|| {
+//         initial_setup();
+//         assert_noop!(
+//             Loans::liquidate_borrow(RuntimeOrigin::signed(ALICE), ALICE, KSM, 1, DOT),
+//             Error::<Test>::LiquidatorIsBorrower
+//         );
+//     })
+// }
 
-fn alice_borrows_100_ksm() {
-    assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, unit(100)));
-}
+// fn alice_borrows_100_ksm() {
+//     assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), KSM, unit(100)));
+// }
 
-fn initial_setup() {
-    // Bob deposits 200 KSM
-    assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), KSM, unit(200)));
-    // Alice deposits 200 KBTC as collateral
-    assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), KBTC, unit(200)));
-    assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), KBTC));
-}
+// fn initial_setup() {
+//     // Bob deposits 200 KSM
+//     assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), KSM, unit(200)));
+//     // Alice deposits 200 KBTC as collateral
+//     assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), KBTC, unit(200)));
+//     assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(ALICE), KBTC));
+// }
+


### PR DESCRIPTION
Opening this to show why it's a bad idea to try and modify the `unit()` utility in the loans pallet (see `tests.rs`), it makes tests hard to reason about since exchange rates are expressed in the lowest denominations and it's easier for all currencies to use the same decimals in the unit tests.

I'll close https://github.com/interlay/interbtc/issues/804 due to this