### PR TITLE
Single-block loans via batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5144,6 +5144,7 @@ dependencies = [
  "orml-tokens",
  "orml-traits",
  "pallet-timestamp",
+ "pallet-utility",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/crates/loans/Cargo.toml
+++ b/crates/loans/Cargo.toml
@@ -26,6 +26,7 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false, optional = true }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false, optional = true }
 
 # Parachain dependencies
 currency = { path = "../currency", default-features = false }
@@ -59,6 +60,7 @@ std = [
 	"frame-system/std",
 	"frame-benchmarking/std",
 	"pallet-timestamp/std",
+	"pallet-utility/std",
 
 	"currency/std",
 	"traits/std",
@@ -73,6 +75,7 @@ runtime-benchmarks = [
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
+	"pallet-utility/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]
 integration-tests = [

--- a/crates/loans/src/mock.rs
+++ b/crates/loans/src/mock.rs
@@ -47,6 +47,7 @@ construct_runtime!(
         TimestampPallet: pallet_timestamp::{Pallet, Call, Storage, Inherent},
         Tokens: orml_tokens::{Pallet, Call, Storage, Config<T>, Event<T>},
         Currency: currency::{Pallet},
+        Utility: pallet_utility,
     }
 );
 
@@ -179,6 +180,13 @@ impl currency::Config for Test {
     type GetRelayChainCurrencyId = GetCollateralCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
     type CurrencyConversion = CurrencyConvert;
+}
+
+impl pallet_utility::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeCall = RuntimeCall;
+    type PalletsOrigin = OriginCaller;
+    type WeightInfo = ();
 }
 
 parameter_types! {

--- a/crates/loans/src/tests/edge_cases.rs
+++ b/crates/loans/src/tests/edge_cases.rs
@@ -4,7 +4,7 @@ use currency::Amount;
 use frame_support::{assert_err, assert_ok};
 use primitives::{
     CurrencyId::{ForeignAsset, Token},
-    DOT, KSM,
+    DOT, KSM, IBTC
 };
 use sp_runtime::FixedPointNumber;
 
@@ -262,5 +262,37 @@ fn new_transferred_collateral_is_not_auto_deposited_if_not_collateral() {
             unit(10011)
         );
         assert_eq!(Loans::reserved_lend_tokens(Token(DOT), &ALICE).unwrap().is_zero(), true);
+    })
+}
+
+#[test]
+fn small_loans_have_interest_truncated_to_zero() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(IBTC), unit(100)));
+        assert_ok!(Loans::mint(RuntimeOrigin::signed(BOB), Token(DOT), unit(100)));
+        assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(BOB), Token(DOT)));
+
+        let initial_block = 2;
+        _run_to_block(initial_block);
+
+        // Borrow 0.1 BTC
+        assert_ok!(Loans::borrow(RuntimeOrigin::signed(BOB), Token(IBTC), 10_000_000));
+        
+        // After 25 blocks, there is still no accrued interest.
+        _run_to_block(initial_block + 25);
+        Loans::accrue_interest(Token(IBTC)).unwrap();
+        assert_eq!(Loans::current_borrow_balance(&BOB, Token(IBTC)).unwrap(), 10_000_000);
+
+        // Repay to clear debt and any rounded out interest
+        assert_ok!(Loans::repay_borrow_all(RuntimeOrigin::signed(BOB), Token(IBTC)));
+
+        // Borrow 0.1 BTC again
+        _run_to_block(initial_block + 26);
+        assert_ok!(Loans::borrow(RuntimeOrigin::signed(BOB), Token(IBTC), 10_000_000));
+        
+        // After another 25 blocks, there is still no accrued interest.
+        _run_to_block(initial_block + 51);
+        Loans::accrue_interest(Token(IBTC)).unwrap();
+        assert_eq!(Loans::current_borrow_balance(&BOB, Token(IBTC)).unwrap(), 10_000_000);
     })
 }


### PR DESCRIPTION
There is currently zero interest that is applied to a loan that is paid back in the same block, because interest is only accrued in the first lending transaction of a block. This has other implications and probably needs to change.

This lag in accruing also allows for taking interest-free loans if they are batched after a very small one (until someone else triggers an interest rate accrual in the market).