### PR TITLE
fix(loans): Use compound interest formula

### DIFF
--- a/crates/loans/src/tests/edge_cases.rs
+++ b/crates/loans/src/tests/edge_cases.rs
@@ -36,16 +36,24 @@ fn repay_borrow_all_no_underflow() {
         // Alice borrow only 1/1e5 KSM which is hard to accrue total borrows interest in 100 seconds
         assert_ok!(Loans::borrow(RuntimeOrigin::signed(ALICE), Token(KSM), 10_u128.pow(7)));
 
-        accrue_interest_per_block(Token(KSM), 100, 9);
+        accrue_interest_per_block(Token(KSM), 100, 1000);
 
         assert_eq!(
             Loans::current_borrow_balance(&ALICE, Token(KSM)).unwrap().amount(),
             10000006
         );
-        // FIXME since total_borrows is too small and we accrue internal on it every 100 seconds
-        // accrue_interest fails every time
-        // as you can see the current borrow balance is not equal to total_borrows anymore
-        assert_eq!(Loans::total_borrows(Token(KSM)).amount(), 10000000);
+        // TODO: total_borrows is greater than current_borrow_balance because the former is accrued
+        // every block, which leads to compounding, while the latter is only accrued now.
+        // This check fails because we are using the simple interest formula instead of the compound
+        // interest one. It should not matter how often interest is accrued in a market.
+        // You can confirm that this is the case by changing the `accrue_interest_per_block`
+        // call above to run for 1000 blocks. The difference becomes much more notable:
+        //   left: `10000634`,
+        //  right: `10000006`'
+        assert_eq!(
+            Loans::total_borrows(Token(KSM)).amount(),
+            Loans::current_borrow_balance(&ALICE, Token(KSM)).unwrap().amount()
+        );
 
         // Alice repay all borrow balance. total_borrows = total_borrows.saturating_sub(10000006) = 0.
         assert_ok!(Loans::repay_borrow_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
@@ -84,7 +92,7 @@ fn redeem_all_should_be_accurate() {
 
         // let exchange_rate greater than 0.02
         accrue_interest_per_block(Token(KSM), 6, 2);
-        assert_eq!(Loans::exchange_rate(Token(KSM)), Rate::from_inner(20000000036387000));
+        assert_eq!(Loans::exchange_rate(Token(KSM)), Rate::from_inner(20000000036387100));
 
         assert_ok!(Loans::repay_borrow_all(RuntimeOrigin::signed(ALICE), Token(KSM)));
         // It failed with InsufficientLiquidity before #839

--- a/crates/loans/src/tests/interest_rate.rs
+++ b/crates/loans/src/tests/interest_rate.rs
@@ -75,6 +75,7 @@ fn interest_rate_model_works() {
         let mut total_reserves: u128 = 0;
 
         // Interest accrued from blocks 1 to 49
+        // TODO: Change to match the current implementation
         for i in 1..49 {
             let delta_time = 6u128;
             TimestampPallet::set_timestamp(6000 * (i + 1));

--- a/crates/loans/src/types.rs
+++ b/crates/loans/src/types.rs
@@ -14,6 +14,12 @@ pub enum AccountLiquidity<T: Config> {
     Shortfall(Amount<T>),
 }
 
+#[derive(Eq, PartialEq, Clone, RuntimeDebug)]
+pub enum RoundingMode {
+    Up,
+    Down,
+}
+
 impl<T: Config> AccountLiquidity<T> {
     pub fn from_collateral_and_debt(
         collateral_value: Amount<T>,


### PR DESCRIPTION
Found a better fix that initially planned for https://github.com/interlay/interbtc/issues/902, which also closes https://github.com/interlay/interbtc/issues/901.

- `accrued_interest` can be removed altogether by reusing the interest accrual function for total borrows. Using `saturating_sub` instead of `checked_sub` [here](https://github.com/interlay/interbtc/blob/ba7b2344503afdff6c003ebc03737309772d1990/crates/loans/src/lib.rs#L1533) is actually correct, because if `total_borrows` is always rounded up then it will exceed the sum of all debt owed by borrowers. This is undesirable because it would cause the internal exchange rate to be more generous to lenders than it should, because lend tokens could be redeemed for more cash than the protocol has (or will have after debt repayment). By rounding down, the exchange rate increases more slowly than it should while loans are active, but it catches up with its "true value" as repayments are made because more cash becomes available in the protocol than `total_borrows` approximated.
    - It revealed a bigger problem though, caused by using the simple interest formula instead of the compound interest one. Since the borrow snapshot only gets updated when a user borrows or repays, but the total borrow index gets updated on each market interaction (possibly every block), the latter gets compounded while the former does not, reducing the debt a borrower actually needs to repay. 
- replaces usage of simple interest formula by the compound interest formula, to fix the above. Note that this causes several hardcoded values in the tests to increase because interest is now correctly compounded. Without this, the less frequent a market is interacted with, the less interest borrowers owe.

Closes https://github.com/interlay/interbtc/issues/901
Closes https://github.com/interlay/interbtc/issues/902