### PR TITLE
refactor: fixedpoint math refactoring

### DIFF
--- a/crates/currency/src/lib.rs
+++ b/crates/currency/src/lib.rs
@@ -33,7 +33,7 @@ pub use pallet::*;
 
 mod types;
 use types::*;
-pub use types::{CurrencyConversion, CurrencyId};
+pub use types::{CurrencyConversion, CurrencyId, Rounding};
 
 pub struct CurrencyConvert<T, Oracle, Loans>(PhantomData<(T, Oracle, Loans)>);
 impl<T, Oracle, Loans> CurrencyConversion<Amount<T>, CurrencyId<T>> for CurrencyConvert<T, Oracle, Loans>

--- a/crates/currency/src/tests.rs
+++ b/crates/currency/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, Amount};
+use crate::{mock::*, Amount, Rounding};
 use sp_runtime::FixedPointNumber;
 
 #[test]
@@ -49,7 +49,7 @@ fn test_checked_fixed_point_mul() {
         ];
 
         for (amount, percent, expected) in tests {
-            let actual = amount.checked_fixed_point_mul(&percent).unwrap();
+            let actual = amount.checked_mul(&percent).unwrap();
             assert_eq!(actual, expected);
         }
     })
@@ -78,7 +78,7 @@ fn test_checked_fixed_point_rounded_mul() {
         ];
 
         for (amount, percent, expected) in tests {
-            let actual = amount.rounded_mul(percent.clone()).unwrap();
+            let actual = amount.checked_rounded_mul(&percent, Rounding::NearestPrefUp).unwrap();
             assert_eq!(actual, expected);
         }
     })
@@ -122,7 +122,7 @@ fn test_checked_fixed_point_mul_rounded_up() {
         ];
 
         for (amount, percent, expected) in tests {
-            let actual = amount.checked_fixed_point_mul_rounded_up(&percent).unwrap();
+            let actual = amount.checked_rounded_mul(&percent, Rounding::Up).unwrap();
             assert_eq!(actual, expected);
         }
     })

--- a/crates/currency/src/types.rs
+++ b/crates/currency/src/types.rs
@@ -3,6 +3,8 @@ use sp_runtime::FixedPointNumber;
 
 use crate::Config;
 
+pub use sp_runtime::Rounding;
+
 pub type CurrencyId<T> = <T as orml_tokens::Config>::CurrencyId;
 
 pub(crate) type BalanceOf<T> = <T as Config>::Balance;

--- a/crates/fee/src/lib.rs
+++ b/crates/fee/src/lib.rs
@@ -26,7 +26,7 @@ extern crate mocktopus;
 use mocktopus::macros::mockable;
 
 use codec::{Decode, Encode, EncodeLike};
-use currency::{Amount, CurrencyId, OnSweep};
+use currency::{Amount, CurrencyId, OnSweep, Rounding};
 use frame_support::{
     dispatch::{DispatchError, DispatchResult},
     storage,
@@ -435,7 +435,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// * `amount` - issue amount in tokens
     pub fn get_issue_fee(amount: &Amount<T>) -> Result<Amount<T>, DispatchError> {
-        amount.rounded_mul(<IssueFee<T>>::get())
+        amount.checked_rounded_mul(&<IssueFee<T>>::get(), Rounding::NearestPrefUp)
     }
 
     /// Calculate the required issue griefing collateral.
@@ -444,7 +444,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// * `amount` - issue amount in collateral (at current exchange rate)
     pub fn get_issue_griefing_collateral(amount: &Amount<T>) -> Result<Amount<T>, DispatchError> {
-        amount.rounded_mul(<IssueGriefingCollateral<T>>::get())
+        amount.checked_rounded_mul(&<IssueGriefingCollateral<T>>::get(), Rounding::NearestPrefUp)
     }
 
     /// Calculate the required redeem fee in tokens. Upon execution, the
@@ -454,7 +454,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// * `amount` - redeem amount in tokens
     pub fn get_redeem_fee(amount: &Amount<T>) -> Result<Amount<T>, DispatchError> {
-        amount.rounded_mul(<RedeemFee<T>>::get())
+        amount.checked_rounded_mul(&<RedeemFee<T>>::get(), Rounding::NearestPrefUp)
     }
 
     /// Calculate the premium redeem fee in collateral for a user to get if redeeming
@@ -464,7 +464,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// * `amount` - amount in collateral (at current exchange rate)
     pub fn get_premium_redeem_fee(amount: &Amount<T>) -> Result<Amount<T>, DispatchError> {
-        amount.rounded_mul(<PremiumRedeemFee<T>>::get())
+        amount.checked_rounded_mul(&<PremiumRedeemFee<T>>::get(), Rounding::NearestPrefUp)
     }
 
     /// Calculate punishment fee for a Vault that fails to execute a redeem
@@ -474,7 +474,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// * `amount` - amount in collateral (at current exchange rate)
     pub fn get_punishment_fee(amount: &Amount<T>) -> Result<Amount<T>, DispatchError> {
-        amount.rounded_mul(<PunishmentFee<T>>::get())
+        amount.checked_rounded_mul(&<PunishmentFee<T>>::get(), Rounding::NearestPrefUp)
     }
 
     /// Calculate the required replace griefing collateral.
@@ -483,7 +483,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// * `amount` - replace amount in collateral (at current exchange rate)
     pub fn get_replace_griefing_collateral(amount: &Amount<T>) -> Result<Amount<T>, DispatchError> {
-        amount.rounded_mul(<ReplaceGriefingCollateral<T>>::get())
+        amount.checked_rounded_mul(&<ReplaceGriefingCollateral<T>>::get(), Rounding::NearestPrefUp)
     }
 
     pub fn compute_vault_rewards(
@@ -554,7 +554,7 @@ impl<T: Config> Pallet<T> {
         let full_amount = Amount::<T>::new(reward, currency_id);
 
         let commission_rate = Self::get_commission_rate(vault_id);
-        let commission = full_amount.checked_fixed_point_mul(&commission_rate)?;
+        let commission = full_amount.checked_mul(&commission_rate)?;
         commission.transfer(&Self::fee_pool_account_id(), &vault_id.account_id)?;
 
         let remainder = full_amount.checked_sub(&commission)?;

--- a/crates/loans/src/interest.rs
+++ b/crates/loans/src/interest.rs
@@ -100,7 +100,7 @@ impl<T: Config> Pallet<T> {
                 &borrow_index,
                 &borrow_index_new,
                 total_borrows,
-                RoundingMode::Down,
+                Rounding::Down,
             )?;
             let interest_accummulated = total_borrows.checked_sub(&total_borrows_old)?;
             total_reserves = interest_accummulated

--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -154,7 +154,7 @@ fn mint_must_return_err_when_overflows_occur() {
         // Verify token balance first
         assert_noop!(
             Loans::mint(RuntimeOrigin::signed(CHARLIE), DOT, OVERFLOW_DEPOSIT),
-            ArithmeticError::Underflow
+            ArithmeticError::Overflow
         );
 
         // Deposit OVERFLOW_DEPOSIT DOT for CHARLIE
@@ -170,7 +170,7 @@ fn mint_must_return_err_when_overflows_occur() {
         // Underflow is used here redeem could also be 0
         assert_noop!(
             Loans::mint(RuntimeOrigin::signed(CHARLIE), DOT, OVERFLOW_DEPOSIT),
-            ArithmeticError::Underflow
+            ArithmeticError::Overflow
         );
 
         // Assume a misconfiguration occurs
@@ -180,7 +180,7 @@ fn mint_must_return_err_when_overflows_occur() {
         // set to zero (default value for the type). The extrinsic should fail.
         assert_noop!(
             Loans::mint(RuntimeOrigin::signed(CHARLIE), DOT, 100),
-            ArithmeticError::Underflow
+            ArithmeticError::Overflow
         );
     })
 }
@@ -402,14 +402,14 @@ fn redeem_must_return_err_when_overflows_occur() {
         // Underflow is used here redeem could also be 0
         assert_noop!(
             Loans::redeem(RuntimeOrigin::signed(ALICE), DOT, u128::MAX),
-            ArithmeticError::Underflow,
+            ArithmeticError::Overflow,
         );
 
         // Assume a misconfiguration occurs
         MinExchangeRate::<Test>::put(Rate::zero());
         assert_noop!(
             Loans::redeem(RuntimeOrigin::signed(ALICE), DOT, 100),
-            ArithmeticError::Underflow
+            ArithmeticError::Overflow
         );
     })
 }

--- a/crates/loans/src/tests/liquidate_borrow.rs
+++ b/crates/loans/src/tests/liquidate_borrow.rs
@@ -289,9 +289,7 @@ fn liquidated_transfer_reduces_locked_collateral() {
         let final_locked_underlying = Loans::recompute_underlying_amount(&final_locked_collateral).unwrap();
         // The total liquidated KSM includes the market's liquidation incentive
         let liquidation_incentive = Loans::market(KSM).unwrap().liquidate_incentive;
-        let liquidated_ksm = amount_to_liquidate
-            .checked_fixed_point_mul(&liquidation_incentive)
-            .unwrap();
+        let liquidated_ksm = amount_to_liquidate.checked_mul(&liquidation_incentive).unwrap();
         let liquidated_ksm_as_wrapped = liquidated_ksm.convert_to(DEFAULT_WRAPPED_CURRENCY).unwrap();
         // The borrower's locked collateral (as tracked by the `AccountDeposits` storage item) must have been decreased
         // by the liquidated amount.

--- a/crates/loans/src/types.rs
+++ b/crates/loans/src/types.rs
@@ -14,12 +14,6 @@ pub enum AccountLiquidity<T: Config> {
     Shortfall(Amount<T>),
 }
 
-#[derive(Eq, PartialEq, Clone, RuntimeDebug)]
-pub enum RoundingMode {
-    Up,
-    Down,
-}
-
 impl<T: Config> AccountLiquidity<T> {
     pub fn from_collateral_and_debt(
         collateral_value: Amount<T>,

--- a/crates/vault-registry/src/benchmarking.rs
+++ b/crates/vault-registry/src/benchmarking.rs
@@ -7,6 +7,7 @@ use frame_system::RawOrigin;
 use oracle::Pallet as Oracle;
 use orml_traits::MultiCurrency;
 use primitives::CurrencyId;
+use sp_runtime::FixedPointNumber;
 use sp_std::prelude::*;
 
 type UnsignedFixedPoint<T> = <T as currency::Config>::UnsignedFixedPoint;

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -421,7 +421,7 @@ impl<T: Config> RichVault<T> {
     pub fn get_used_collateral(&self, threshold: UnsignedFixedPoint<T>) -> Result<Amount<T>, DispatchError> {
         let issued_tokens = self.backed_tokens()?;
         let issued_tokens_in_collateral = issued_tokens.convert_to(self.data.id.currencies.collateral)?;
-        let used_collateral = issued_tokens_in_collateral.checked_fixed_point_mul(&threshold)?;
+        let used_collateral = issued_tokens_in_collateral.checked_mul(&threshold)?;
         self.get_total_collateral()?.min(&used_collateral)
     }
 


### PR DESCRIPTION
This prevents more potential overflows of amounts being casted to FixedU128, and is a general cleanup