### PR TITLE
[BREAKING] refactor!: deposit all tokens in farming pallet

### DIFF
--- a/crates/farming/src/benchmarking.rs
+++ b/crates/farming/src/benchmarking.rs
@@ -46,11 +46,10 @@ fn create_default_reward_schedule<T: Config>() -> (CurrencyId, CurrencyId) {
 }
 
 fn deposit_lp_tokens<T: Config>(pool_currency_id: CurrencyId, account_id: &T::AccountId, amount: BalanceOf<T>) {
-    assert_ok!(T::MultiCurrency::deposit(pool_currency_id, account_id, amount,));
+    assert_ok!(T::MultiCurrency::deposit(pool_currency_id, account_id, amount));
     assert_ok!(Farming::<T>::deposit(
         RawOrigin::Signed(account_id.clone()).into(),
         pool_currency_id,
-        amount,
     ));
 }
 
@@ -95,14 +94,13 @@ benchmarks! {
     deposit {
         let origin: T::AccountId = account("Origin", 0, 0);
         let (pool_currency_id, _) = create_default_reward_schedule::<T>();
-        let amount = 100u32.into();
         assert_ok!(T::MultiCurrency::deposit(
             pool_currency_id,
             &origin,
-            amount,
+            100u32.into(),
         ));
 
-    }: _(RawOrigin::Signed(origin), pool_currency_id, amount)
+    }: _(RawOrigin::Signed(origin), pool_currency_id)
 
     withdraw {
         let origin: T::AccountId = account("Origin", 0, 0);

--- a/crates/farming/src/lib.rs
+++ b/crates/farming/src/lib.rs
@@ -284,14 +284,11 @@ pub mod pallet {
         #[pallet::call_index(2)]
         #[pallet::weight(T::WeightInfo::deposit())]
         #[transactional]
-        pub fn deposit(
-            origin: OriginFor<T>,
-            pool_currency_id: CurrencyIdOf<T>,
-            amount: BalanceOf<T>,
-        ) -> DispatchResult {
+        pub fn deposit(origin: OriginFor<T>, pool_currency_id: CurrencyIdOf<T>) -> DispatchResult {
             let who = ensure_signed(origin)?;
 
             // reserve lp tokens to prevent spending
+            let amount = T::MultiCurrency::free_balance(pool_currency_id.clone(), &who);
             T::MultiCurrency::reserve(pool_currency_id.clone(), &who, amount)?;
 
             // deposit lp tokens as stake

--- a/crates/farming/src/tests.rs
+++ b/crates/farming/src/tests.rs
@@ -140,11 +140,7 @@ fn mint_and_deposit(account_id: AccountId, amount: Balance) {
         0
     ));
 
-    assert_ok!(Farming::deposit(
-        RuntimeOrigin::signed(account_id),
-        POOL_CURRENCY_ID,
-        amount
-    ));
+    assert_ok!(Farming::deposit(RuntimeOrigin::signed(account_id), POOL_CURRENCY_ID,));
 }
 
 #[test]


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Since it is not possible to determine the exact number of LP tokens acquired when adding liquidity in order to bundle `Farming::deposit` we should reserve the entire "free" balance.