### PR TITLE
[BREAKING] Refactor/dex general fees

### DIFF
--- a/crates/dex-general/src/benchmarking.rs
+++ b/crates/dex-general/src/benchmarking.rs
@@ -51,7 +51,7 @@ benchmarks! {
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_0.into(), &caller, 1000 * UNIT));
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_1.into(), &caller, 1000 * UNIT));
 
-    } : _(RawOrigin::Root, ASSET_0.into(), ASSET_1.into())
+    } : _(RawOrigin::Root, ASSET_0.into(), ASSET_1.into(), DEFAULT_FEE_RATE)
 
     bootstrap_create {
         let reward: Vec<T::AssetId> =  vec![ASSET_0.into()];
@@ -215,7 +215,7 @@ benchmarks! {
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_0.into(), &caller, 1000 * UNIT));
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_1.into(), &caller, 1000 * UNIT));
 
-        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_0.into(), ASSET_1.into()));
+        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_0.into(), ASSET_1.into(), DEFAULT_FEE_RATE));
 
         assert_ok!(DexGeneral::<T>::set_fee_receiver((RawOrigin::Root).into(), lookup_of_account::<T>(caller.clone()).into()));
 
@@ -226,7 +226,7 @@ benchmarks! {
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_0.into(), &caller, 1000 * UNIT));
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_1.into(), &caller, 1000 * UNIT));
 
-        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_0.into(), ASSET_1.into()));
+        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_0.into(), ASSET_1.into(), DEFAULT_FEE_RATE));
 
         assert_ok!(DexGeneral::<T>::set_fee_receiver((RawOrigin::Root).into(), lookup_of_account::<T>(caller.clone()).into()));
 
@@ -248,8 +248,8 @@ benchmarks! {
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_1.into(), &caller, 1000 * UNIT));
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_2.into(), &caller, 1000 * UNIT));
 
-        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_0.into(), ASSET_1.into()));
-        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_1.into(), ASSET_2.into()));
+        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_0.into(), ASSET_1.into(), DEFAULT_FEE_RATE));
+        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_1.into(), ASSET_2.into(), DEFAULT_FEE_RATE));
 
         assert_ok!(DexGeneral::<T>::add_liquidity(
             RawOrigin::Signed(caller.clone()).into(),
@@ -281,8 +281,8 @@ benchmarks! {
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_1.into(), &caller, 1000 * UNIT));
         assert_ok!(<T as Config>::MultiCurrency::deposit(ASSET_2.into(), &caller, 1000 * UNIT));
 
-        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_1.into(), ASSET_2.into()));
-        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_0.into(), ASSET_1.into()));
+        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_1.into(), ASSET_2.into(), DEFAULT_FEE_RATE));
+        assert_ok!(DexGeneral::<T>::create_pair((RawOrigin::Root).into(), ASSET_0.into(), ASSET_1.into(), DEFAULT_FEE_RATE));
 
         assert_ok!(DexGeneral::<T>::add_liquidity(
             RawOrigin::Signed(caller.clone()).into(),

--- a/crates/dex-general/src/fee/tests.rs
+++ b/crates/dex-general/src/fee/tests.rs
@@ -134,7 +134,6 @@ fn turn_on_protocol_fee_only_add_liquidity_no_fee_should_work() {
         let balance_dot = <Test as Config>::MultiCurrency::free_balance(DOT_ASSET_ID, &pair_dot_btc);
         let balance_btc = <Test as Config>::MultiCurrency::free_balance(BTC_ASSET_ID, &pair_dot_btc);
 
-        //println!("balance_DOT {}, balance_BTC {}", balance_dot, balance_btc);
         assert_eq!(balance_dot, 51000000000000000);
         assert_eq!(balance_btc, 5100000000);
         assert_eq!((balance_dot / DOT_UNIT), (balance_btc / BTC_UNIT));
@@ -257,7 +256,6 @@ fn turn_on_protocol_fee_remove_liquidity_should_work() {
         let balance_dot = <Test as Config>::MultiCurrency::free_balance(DOT_ASSET_ID, &pair_dot_btc);
         let balance_btc = <Test as Config>::MultiCurrency::free_balance(BTC_ASSET_ID, &pair_dot_btc);
 
-        //println!("balance_DOT {}, balance_BTC {}", balance_dot, balance_btc);
         assert_eq!(balance_dot, 51000000000000000);
         assert_eq!(balance_btc, 5100000000);
         assert_eq!((balance_dot / DOT_UNIT), (balance_btc / BTC_UNIT));
@@ -377,7 +375,6 @@ fn turn_on_protocol_fee_swap_have_fee_should_work() {
         let balance_dot = <Test as Config>::MultiCurrency::free_balance(DOT_ASSET_ID, &pair_dot_btc);
         let balance_btc = <Test as Config>::MultiCurrency::free_balance(BTC_ASSET_ID, &pair_dot_btc);
 
-        //println!("balance_DOT {}, balance_BTC {}", balance_dot, balance_btc);
         assert_eq!(balance_dot, 2000000000000000);
         assert_eq!(balance_btc, 50075113);
 
@@ -505,7 +502,7 @@ fn turn_on_protocol_fee_swap_have_fee_at_should_work() {
             <Test as Config>::MultiCurrency::free_balance(LP_DOT_BTC, &ALICE),
             lp_of_alice_0
         );
-        //println!("{:#?}", lp_of_alice_0);
+
         assert_eq!(<Test as Config>::MultiCurrency::free_balance(LP_DOT_BTC, &BOB), 0);
         assert_eq!(
             DexPallet::k_last(sorted_pair),
@@ -607,7 +604,7 @@ fn should_set_lower_custom_exchange_fee() {
             BTC_ASSET_ID,
         ));
 
-        // decrease exchange fee to 0.2%
+        // decrease exchange fee to 0.02%
         assert_ok!(DexPallet::set_exchange_fee(
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
@@ -691,16 +688,34 @@ fn should_set_higher_custom_exchange_fee() {
             BTC_ASSET_ID,
         ));
 
+        let total_supply_dot: u128 = 1_000_000 * DOT_UNIT;
+        let total_supply_btc: u128 = 1_000_000 * BTC_UNIT;
+
+        // less out with higher swap fee_rate
+        assert_eq!(
+            99999900,
+            get_amount_out(DOT_UNIT, total_supply_dot, total_supply_btc, 0)
+        );
+        assert_eq!(
+            69999951,
+            get_amount_out(DOT_UNIT, total_supply_dot, total_supply_btc, 3000)
+        );
+        assert_eq!(
+            49999975,
+            get_amount_out(DOT_UNIT, total_supply_dot, total_supply_btc, 5000)
+        );
+        assert_eq!(
+            29999991,
+            get_amount_out(DOT_UNIT, total_supply_dot, total_supply_btc, 7000)
+        );
+
         // increase exchange fee to 50%
         assert_ok!(DexPallet::set_exchange_fee(
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
-            500
+            5000
         ));
-
-        let total_supply_dot: u128 = 1_000_000 * DOT_UNIT;
-        let total_supply_btc: u128 = 1_000_000 * BTC_UNIT;
 
         assert_ok!(DexPallet::add_liquidity(
             RawOrigin::Signed(ALICE).into(),
@@ -744,7 +759,7 @@ fn should_set_higher_custom_exchange_fee() {
         assert_eq!(reserve_0, total_supply_dot + DOT_UNIT);
         assert_eq!(
             reserve_1,
-            total_supply_btc - get_amount_out(DOT_UNIT, total_supply_dot, total_supply_btc, 500)
+            total_supply_btc - get_amount_out(DOT_UNIT, total_supply_dot, total_supply_btc, 5000)
         );
     });
 }

--- a/crates/dex-general/src/fee/tests.rs
+++ b/crates/dex-general/src/fee/tests.rs
@@ -2,7 +2,7 @@
 // Licensed under Apache 2.0.
 
 use super::mock::*;
-use crate::FEE_ADJUSTMENT;
+use crate::{DEFAULT_FEE_RATE, FEE_ADJUSTMENT};
 use frame_support::{assert_noop, assert_ok, error::BadOrigin};
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
@@ -79,6 +79,7 @@ fn turn_on_protocol_fee_only_add_liquidity_no_fee_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         assert_ok!(DexPallet::add_liquidity(
@@ -201,6 +202,7 @@ fn turn_on_protocol_fee_remove_liquidity_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         assert_ok!(DexPallet::add_liquidity(
@@ -324,6 +326,7 @@ fn turn_on_protocol_fee_swap_have_fee_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         let total_supply_dot: u128 = 1 * DOT_UNIT;
@@ -458,6 +461,7 @@ fn turn_on_protocol_fee_swap_have_fee_at_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         let total_supply_dot: u128 = 1_000_000 * DOT_UNIT;
@@ -602,6 +606,7 @@ fn should_set_lower_custom_exchange_fee() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         // decrease exchange fee to 0.02%
@@ -686,6 +691,7 @@ fn should_set_higher_custom_exchange_fee() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         let total_supply_dot: u128 = 1_000_000 * DOT_UNIT;
@@ -792,6 +798,7 @@ fn should_set_max_fee_point() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         let total_supply_dot: u128 = 1_000_000 * DOT_UNIT;

--- a/crates/dex-general/src/lib.rs
+++ b/crates/dex-general/src/lib.rs
@@ -404,6 +404,7 @@ pub mod pallet {
         /// An integer y which satisfies the equation `1/x-1=y`
         /// where x is the percentage of the exchange fee
         /// e.g. 1/(1/6)-1=5, 1/(1/2)-1=1
+        /// See section 2.4 of the Uniswap v2 whitepaper
         #[pallet::call_index(1)]
         #[pallet::weight(T::WeightInfo::set_fee_point())]
         #[frame_support::transactional]
@@ -416,6 +417,17 @@ pub mod pallet {
         }
 
         /// Set the exchange fee rate.
+        ///
+        /// # Arguments
+        ///
+        /// - `asset_0`: Asset which makes up the pair
+        /// - `asset_1`: Asset which makes up the pair
+        /// - `fee_rate`:
+        /// Value denoting the trading fee taken from the amount paid in,
+        /// multiplied by the fee adjustment to simplify calculations.
+        /// e.g. 0.3% / 100 = 0.003
+        ///      0.003 * 10000 = 30
+        /// See section 3.2.1 of the Uniswap v2 whitepaper
         #[pallet::call_index(2)]
         #[pallet::weight(T::WeightInfo::set_fee_point())]
         #[frame_support::transactional]

--- a/crates/dex-general/src/primitives.rs
+++ b/crates/dex-general/src/primitives.rs
@@ -7,8 +7,8 @@ use scale_info::TypeInfo;
 pub type AssetBalance = u128;
 
 // 0.3% exchange fee rate
-pub const DEFAULT_FEE_RATE: u128 = 3;
-pub const FEE_ADJUSTMENT: u128 = 1000;
+pub const DEFAULT_FEE_RATE: u128 = 30;
+pub const FEE_ADJUSTMENT: u128 = 10000;
 
 pub trait AssetInfo {
     fn is_support(&self) -> bool;

--- a/crates/dex-general/src/swap/tests.rs
+++ b/crates/dex-general/src/swap/tests.rs
@@ -2,7 +2,7 @@
 // Licensed under Apache 2.0.
 
 use super::{mock::*, Error};
-use crate::primitives::PairStatus::Trading;
+use crate::{primitives::PairStatus::Trading, DEFAULT_FEE_RATE};
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
@@ -43,6 +43,7 @@ fn add_liquidity_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         let total_supply_dot: u128 = 1 * DOT_UNIT;
@@ -108,6 +109,7 @@ fn remove_liquidity_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         let total_supply_dot = 50 * DOT_UNIT;
@@ -161,6 +163,7 @@ fn foreign_get_in_price_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         let total_supply_dot = 10000 * DOT_UNIT;
@@ -219,6 +222,7 @@ fn foreign_get_out_price_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         let total_supply_dot = 1000000 * DOT_UNIT;
@@ -281,6 +285,7 @@ fn inner_swap_exact_assets_for_assets_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         assert_ok!(DexPallet::inner_add_liquidity(
@@ -363,6 +368,7 @@ fn inner_swap_exact_assets_for_assets_in_pairs_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         assert_ok!(DexPallet::inner_add_liquidity(
@@ -379,6 +385,7 @@ fn inner_swap_exact_assets_for_assets_in_pairs_should_work() {
             RawOrigin::Root.into(),
             ETH_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         assert_ok!(DexPallet::inner_add_liquidity(
@@ -452,6 +459,7 @@ fn inner_swap_assets_for_exact_assets_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         assert_ok!(DexPallet::inner_add_liquidity(
@@ -538,12 +546,14 @@ fn inner_swap_assets_for_exact_assets_in_pairs_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         assert_ok!(DexPallet::create_pair(
             RawOrigin::Root.into(),
             ETH_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         let supply_dot = 5000 * DOT_UNIT;
@@ -623,7 +633,7 @@ fn create_bootstrap_should_work() {
         ));
 
         assert_noop!(
-            DexPallet::create_pair(RawOrigin::Root.into(), ETH_ASSET_ID, DOT_ASSET_ID),
+            DexPallet::create_pair(RawOrigin::Root.into(), ETH_ASSET_ID, DOT_ASSET_ID, DEFAULT_FEE_RATE),
             Error::<Test>::PairAlreadyExists
         );
 
@@ -1059,6 +1069,7 @@ fn disable_bootstrap_removed_after_all_refund_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
     })
 }
@@ -1313,7 +1324,8 @@ fn create_pair_in_disable_bootstrap_should_work() {
         assert_ok!(DexPallet::create_pair(
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
-            BTC_ASSET_ID
+            BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
         assert_ok!(DexPallet::add_liquidity(
             RawOrigin::Signed(ALICE).into(),
@@ -1483,7 +1495,7 @@ fn create_pair_in_ongoing_bootstrap_should_not_work() {
             [].to_vec(),
         ));
         assert_noop!(
-            DexPallet::create_pair(RawOrigin::Root.into(), DOT_ASSET_ID, BTC_ASSET_ID,),
+            DexPallet::create_pair(RawOrigin::Root.into(), DOT_ASSET_ID, BTC_ASSET_ID, DEFAULT_FEE_RATE),
             Error::<Test>::PairAlreadyExists
         );
     })
@@ -1507,6 +1519,7 @@ fn liquidity_at_boundary_should_work() {
             RawOrigin::Root.into(),
             DOT_ASSET_ID,
             BTC_ASSET_ID,
+            DEFAULT_FEE_RATE,
         ));
 
         assert_ok!(DexPallet::add_liquidity(

--- a/crates/dex-swap-router/src/benchmarking.rs
+++ b/crates/dex-swap-router/src/benchmarking.rs
@@ -20,6 +20,7 @@ const UNIT: u128 = 1_000_000_000_000u128;
 const INITIAL_A_VALUE: u128 = 50;
 const SWAP_FEE: u128 = 10000000;
 const ADMIN_FEE: u128 = 0;
+const FEE_RATE: u128 = 30;
 
 const ASSET_0: u32 = 0;
 const ASSET_1: u32 = 1;
@@ -67,6 +68,7 @@ benchmarks! {
             (RawOrigin::Root).into(),
             ASSET_0.into(),
             ASSET_1.into(),
+            FEE_RATE,
         ));
 
 

--- a/crates/dex-swap-router/src/test.rs
+++ b/crates/dex-swap-router/src/test.rs
@@ -6,6 +6,7 @@ use super::{
     StableSwapMode::FromBase,
     *,
 };
+use dex_general::DEFAULT_FEE_RATE;
 use frame_support::{assert_noop, assert_ok};
 use frame_system::RawOrigin;
 
@@ -62,7 +63,8 @@ fn setup_pools() {
     assert_ok!(DexGeneral::create_pair(
         RawOrigin::Root.into(),
         TOKEN1_ASSET_ID,
-        TOKEN2_ASSET_ID
+        TOKEN2_ASSET_ID,
+        DEFAULT_FEE_RATE,
     ));
     assert_ok!(DexGeneral::add_liquidity(
         RawOrigin::Signed(USER1).into(),


### PR DESCRIPTION
This includes a few changes:
- removes `fee_point` upper bound and allows minting if zero
- increases granularity of `FEE_ADJUSTMENT` for minimum one basis point
- updates documentation to clarify protocol and swap fees
- adds `fee_rate` to `create_pair` call

See: https://github.com/zenlinkpro/Zenlink-DEX-Module/issues/62