### PR TITLE
feat: add rpc to estimate total farming rewards

### DIFF
--- a/crates/farming/src/lib.rs
+++ b/crates/farming/src/lib.rs
@@ -349,6 +349,12 @@ impl<T: Config> Pallet<T> {
         T::FarmingPalletId::get().into_sub_account_truncating(pool_currency_id)
     }
 
+    pub fn total_rewards(pool_currency_id: &CurrencyIdOf<T>, reward_currency_id: &CurrencyIdOf<T>) -> BalanceOf<T> {
+        RewardSchedules::<T>::get(pool_currency_id, reward_currency_id)
+            .total()
+            .unwrap_or_default()
+    }
+
     #[transactional]
     fn try_distribute_reward(
         pool_currency_id: CurrencyIdOf<T>,

--- a/crates/reward/rpc/runtime-api/src/lib.rs
+++ b/crates/reward/rpc/runtime-api/src/lib.rs
@@ -27,6 +27,9 @@ sp_api::decl_runtime_apis! {
         /// Estimate staking reward rate for a one year period
         fn estimate_escrow_reward_rate(account_id: AccountId, amount: Option<Balance>, lock_time: Option<BlockNumber>) -> Result<UnsignedFixedPoint, DispatchError>;
 
+        /// Estimate farming rewards for remaining incentives
+        fn estimate_farming_reward(account_id: AccountId, pool_currency_id: CurrencyId, reward_currency_id: CurrencyId) -> Result<BalanceWrapper<Balance>, DispatchError>;
+
         /// Estimate vault reward rate for a one year period
         fn estimate_vault_reward_rate(vault_id: VaultId) -> Result<UnsignedFixedPoint, DispatchError>;
     }

--- a/crates/reward/rpc/src/lib.rs
+++ b/crates/reward/rpc/src/lib.rs
@@ -63,6 +63,15 @@ where
         at: Option<BlockHash>,
     ) -> RpcResult<UnsignedFixedPoint>;
 
+    #[method(name = "reward_estimateFarmingReward")]
+    fn estimate_farming_reward(
+        &self,
+        account_id: AccountId,
+        pool_currency_id: CurrencyId,
+        reward_currency_id: CurrencyId,
+        at: Option<BlockHash>,
+    ) -> RpcResult<BalanceWrapper<Balance>>;
+
     #[method(name = "reward_estimateVaultRewardRate")]
     fn estimate_vault_reward_rate(&self, vault_id: VaultId, at: Option<BlockHash>) -> RpcResult<UnsignedFixedPoint>;
 }
@@ -170,6 +179,22 @@ where
 
         handle_response(
             api.estimate_escrow_reward_rate(&at, account_id, amount, lock_time),
+            "Unable to estimate the current reward".into(),
+        )
+    }
+
+    fn estimate_farming_reward(
+        &self,
+        account_id: AccountId,
+        pool_currency_id: CurrencyId,
+        reward_currency_id: CurrencyId,
+        at: Option<<Block as BlockT>::Hash>,
+    ) -> RpcResult<BalanceWrapper<Balance>> {
+        let api = self.client.runtime_api();
+        let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
+
+        handle_response(
+            api.estimate_farming_reward(&at, account_id, pool_currency_id, reward_currency_id),
             "Unable to estimate the current reward".into(),
         )
     }

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1713,6 +1713,14 @@ impl_runtime_apis! {
             Ok(UnsignedFixedPoint::checked_from_rational(received, total_locked).unwrap_or_default())
         }
 
+        fn estimate_farming_reward(
+            _account_id: AccountId,
+            _pool_currency_id: CurrencyId,
+            _reward_currency_id: CurrencyId,
+        ) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            Err(DispatchError::Other("RPC Endpoint Not Implemented"))
+        }
+
         fn estimate_vault_reward_rate(
             vault_id: VaultId,
         ) -> Result<UnsignedFixedPoint, DispatchError> {

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1607,6 +1607,14 @@ impl_runtime_apis! {
             Ok(UnsignedFixedPoint::checked_from_rational(received, total_locked).unwrap_or_default())
         }
 
+        fn estimate_farming_reward(
+            _account_id: AccountId,
+            _pool_currency_id: CurrencyId,
+            _reward_currency_id: CurrencyId,
+        ) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            Err(DispatchError::Other("RPC Endpoint Not Implemented"))
+        }
+
         fn estimate_vault_reward_rate(
             vault_id: VaultId,
         ) -> Result<UnsignedFixedPoint, DispatchError> {

--- a/parachain/runtime/testnet-interlay/Cargo.toml
+++ b/parachain/runtime/testnet-interlay/Cargo.toml
@@ -99,6 +99,7 @@ collator-selection = { path = "../../../crates/collator-selection", default-feat
 clients-info = { path = "../../../crates/clients-info", default-features = false }
 loans = { path = "../../../crates/loans", default-features = false }
 traits = { path = "../../../crates/traits", default-features = false }
+farming = { path = "../../../crates/farming", default-features = false }
 tx-pause = { path = "../../../crates/tx-pause", default-features = false }
 dex-general = { path = "../../../crates/dex-general", default-features = false }
 dex-stable = { path = "../../../crates/dex-stable", default-features = false }
@@ -226,6 +227,7 @@ std = [
   "clients-info/std",
   "loans/std",
   "traits/std",
+  "farming/std",
   "tx-pause/std",
   "dex-general/std",
   "dex-stable/std",
@@ -277,6 +279,7 @@ runtime-benchmarks = [
   "redeem/runtime-benchmarks",
   "replace/runtime-benchmarks",
   "vault-registry/runtime-benchmarks",
+  "farming/runtime-benchmarks",
   "tx-pause/runtime-benchmarks",
 ]
 disable-runtime-api = []
@@ -325,6 +328,7 @@ try-runtime = [
   "dex-general/try-runtime",
   "dex-stable/try-runtime",
   "dex-swap-router/try-runtime",
+  "farming/try-runtime",
   "pallet-collective/try-runtime",
   "pallet-membership/try-runtime",
   "pallet-treasury/try-runtime",

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -1613,6 +1613,18 @@ impl_runtime_apis! {
             Ok(UnsignedFixedPoint::checked_from_rational(received, total_locked).unwrap_or_default())
         }
 
+        fn estimate_farming_reward(
+            account_id: AccountId,
+            pool_currency_id: CurrencyId,
+            reward_currency_id: CurrencyId,
+        ) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            <FarmingRewards as reward::RewardsApi<CurrencyId, AccountId, Balance>>::withdraw_reward(&pool_currency_id, &account_id, reward_currency_id)?;
+            <FarmingRewards as reward::RewardsApi<CurrencyId, AccountId, Balance>>::distribute_reward(&pool_currency_id, reward_currency_id, Farming::total_rewards(&pool_currency_id, &reward_currency_id))?;
+            let amount = <FarmingRewards as reward::RewardsApi<CurrencyId, AccountId, Balance>>::compute_reward(&pool_currency_id, &account_id, reward_currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
+            Ok(balance)
+        }
+
         fn estimate_vault_reward_rate(
             vault_id: VaultId,
         ) -> Result<UnsignedFixedPoint, DispatchError> {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1552,6 +1552,18 @@ impl_runtime_apis! {
             Ok(UnsignedFixedPoint::checked_from_rational(received, total_locked).unwrap_or_default())
         }
 
+        fn estimate_farming_reward(
+            account_id: AccountId,
+            pool_currency_id: CurrencyId,
+            reward_currency_id: CurrencyId,
+        ) -> Result<BalanceWrapper<Balance>, DispatchError> {
+            <FarmingRewards as reward::RewardsApi<CurrencyId, AccountId, Balance>>::withdraw_reward(&pool_currency_id, &account_id, reward_currency_id)?;
+            <FarmingRewards as reward::RewardsApi<CurrencyId, AccountId, Balance>>::distribute_reward(&pool_currency_id, reward_currency_id, Farming::total_rewards(&pool_currency_id, &reward_currency_id))?;
+            let amount = <FarmingRewards as reward::RewardsApi<CurrencyId, AccountId, Balance>>::compute_reward(&pool_currency_id, &account_id, reward_currency_id)?;
+            let balance = BalanceWrapper::<Balance> { amount };
+            Ok(balance)
+        }
+
         fn estimate_vault_reward_rate(
             vault_id: VaultId,
         ) -> Result<UnsignedFixedPoint, DispatchError> {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Also adds farming pallets to testnet-interlay runtime