### PR TITLE
refactor: sort currency id in farming pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12530,6 +12530,7 @@ dependencies = [
  "dex-swap-router",
  "escrow",
  "escrow-rpc-runtime-api",
+ "farming",
  "fee",
  "frame-benchmarking",
  "frame-executive",

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -508,6 +508,17 @@ pub struct CustomMetadata {
 }
 
 impl CurrencyId {
+    pub fn sort(&mut self) {
+        match *self {
+            CurrencyId::LpToken(x, y) => {
+                if x > y {
+                    *self = CurrencyId::LpToken(y, x)
+                }
+            }
+            _ => {}
+        }
+    }
+
     pub fn is_lend_token(&self) -> bool {
         matches!(self, CurrencyId::LendToken(_))
     }


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Ensures that tokens are always deposited in the correct reward schedule.

See: https://github.com/interlay/interbtc/blob/1f7533459a654d745002d1e519cf4fe9ecc4dfe2/crates/dex-general/src/swap/mod.rs#L34-L40