### PR TITLE
chore: prevent creating stable pool when a=0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12530,6 +12530,7 @@ dependencies = [
  "dex-swap-router",
  "escrow",
  "escrow-rpc-runtime-api",
+ "farming",
  "fee",
  "frame-benchmarking",
  "frame-executive",

--- a/crates/dex-stable/src/base_pool.rs
+++ b/crates/dex-stable/src/base_pool.rs
@@ -28,6 +28,7 @@ impl<T: Config> Pallet<T> {
             currency_ids.len() == currency_decimals.len(),
             Error::<T>::MismatchParameter
         );
+        ensure!(!a.is_zero(), Error::<T>::ZeroA);
         ensure!(a < MAX_A, Error::<T>::ExceedMaxA);
         ensure!(fee <= MAX_SWAP_FEE, Error::<T>::ExceedMaxFee);
         ensure!(admin_fee <= MAX_ADMIN_FEE, Error::<T>::ExceedMaxAdminFee);

--- a/crates/dex-stable/src/base_pool_tests.rs
+++ b/crates/dex-stable/src/base_pool_tests.rs
@@ -65,13 +65,13 @@ fn create_pool_with_incorrect_parameter_should_not_work() {
         assert_eq!(StableAmm::next_pool_id(), 0);
         assert_eq!(StableAmm::pools(0), None);
 
-        //create mismatch parameter should not work
+        // create mismatch parameter should not work
         assert_noop!(
             StableAmm::create_base_pool(
                 RawOrigin::Root.into(),
                 vec![Token(TOKEN1_SYMBOL), Token(TOKEN2_SYMBOL), Token(TOKEN3_SYMBOL),],
                 vec![TOKEN1_DECIMAL, TOKEN2_DECIMAL, TOKEN3_DECIMAL, TOKEN4_DECIMAL],
-                0,
+                INITIAL_A_VALUE,
                 0,
                 0,
                 ALICE,
@@ -93,7 +93,7 @@ fn create_pool_with_incorrect_parameter_should_not_work() {
                     Token(TOKEN4_SYMBOL)
                 ],
                 vec![TOKEN1_DECIMAL, TOKEN2_DECIMAL, TOKEN3_DECIMAL, TOKEN4_DECIMAL],
-                0,
+                INITIAL_A_VALUE,
                 0,
                 0,
                 ALICE,
@@ -110,7 +110,7 @@ fn create_pool_with_incorrect_parameter_should_not_work() {
                 RawOrigin::Root.into(),
                 vec![Token(TOKEN1_SYMBOL), Token(TOKEN2_SYMBOL), Token(TOKEN3_SYMBOL),],
                 vec![TOKEN1_DECIMAL, 20, TOKEN3_DECIMAL],
-                0,
+                INITIAL_A_VALUE,
                 0,
                 0,
                 ALICE,
@@ -137,7 +137,7 @@ fn create_pool_with_parameters_exceed_threshold_should_not_work() {
                     Token(TOKEN4_SYMBOL)
                 ],
                 vec![TOKEN1_DECIMAL, TOKEN2_DECIMAL, TOKEN3_DECIMAL, TOKEN4_DECIMAL],
-                0,
+                INITIAL_A_VALUE,
                 (MAX_SWAP_FEE + 1).into(),
                 0,
                 ALICE,
@@ -159,7 +159,7 @@ fn create_pool_with_parameters_exceed_threshold_should_not_work() {
                     Token(TOKEN4_SYMBOL)
                 ],
                 vec![TOKEN1_DECIMAL, TOKEN2_DECIMAL, TOKEN3_DECIMAL, TOKEN4_DECIMAL],
-                0,
+                INITIAL_A_VALUE,
                 (MAX_SWAP_FEE).into(),
                 (MAX_ADMIN_FEE + 1).into(),
                 ALICE,

--- a/crates/dex-stable/src/lib.rs
+++ b/crates/dex-stable/src/lib.rs
@@ -274,11 +274,13 @@ pub mod pallet {
         ExceedMaxAChange,
         /// The ramping A of this pool is already stopped.
         AlreadyStoppedRampA,
-        /// The fee parameter exceeds MAX_SWAP_FEE when create pool.
+        /// The fee parameter exceeds MAX_SWAP_FEE when creating the pool.
         ExceedMaxFee,
-        /// The admin fee parameter exceeds MAX_ADMIN_FEE when create pool.
+        /// The admin fee parameter exceeds MAX_ADMIN_FEE when creating the pool.
         ExceedMaxAdminFee,
-        /// The A parameter exceed MAX_A when create pool.
+        /// The A parameter cannot be zero when creating the pool.
+        ZeroA,
+        /// The A parameter exceed MAX_A when creating the pool.
         ExceedMaxA,
         /// The lp currency id is already used when create pool.
         LpCurrencyAlreadyUsed,

--- a/crates/dex-stable/src/meta_pool_tests.rs
+++ b/crates/dex-stable/src/meta_pool_tests.rs
@@ -145,7 +145,7 @@ fn create_meta_pool_with_incorrect_parameter_should_not_work() {
         assert_eq!(StableAmm::next_pool_id(), 1);
         assert_eq!(StableAmm::pools(1), None);
 
-        //create mismatch parameter should not work
+        // create mismatch parameter should not work
         assert_noop!(
             StableAmm::create_base_pool(
                 RawOrigin::Root.into(),
@@ -191,7 +191,7 @@ fn create_meta_pool_with_incorrect_parameter_should_not_work() {
                 RawOrigin::Root.into(),
                 vec![Token(TOKEN1_SYMBOL), Token(TOKEN2_SYMBOL), base_pool_lp_currency,],
                 vec![TOKEN1_DECIMAL, 20, TOKEN3_DECIMAL],
-                0,
+                INITIAL_A_VALUE,
                 0,
                 0,
                 ALICE,
@@ -219,7 +219,7 @@ fn create_meta_pool_with_parameters_exceed_threshold_should_not_work() {
                     base_lp_currency
                 ],
                 vec![TOKEN1_DECIMAL, TOKEN2_DECIMAL, TOKEN3_DECIMAL, STABLE_LP_DECIMAL],
-                0,
+                INITIAL_A_VALUE,
                 (MAX_SWAP_FEE + 1).into(),
                 0,
                 ALICE,
@@ -241,7 +241,7 @@ fn create_meta_pool_with_parameters_exceed_threshold_should_not_work() {
                     base_lp_currency
                 ],
                 vec![TOKEN1_DECIMAL, TOKEN2_DECIMAL, TOKEN3_DECIMAL, STABLE_LP_DECIMAL],
-                0,
+                INITIAL_A_VALUE,
                 (MAX_SWAP_FEE).into(),
                 (MAX_ADMIN_FEE + 1).into(),
                 ALICE,


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Errors occur here:
https://github.com/interlay/interbtc/blob/1f7533459a654d745002d1e519cf4fe9ecc4dfe2/crates/dex-stable/src/utils.rs#L41-L53
https://github.com/interlay/interbtc/blob/1f7533459a654d745002d1e519cf4fe9ecc4dfe2/crates/dex-stable/src/utils.rs#L90-L95

Same issue in Acala implementation: https://github.com/nutsfinance/stable-asset/blob/9a60645bc60e1c3452e8313de43179c4ba9b6e36/lib/stable-asset/src/lib.rs#L844

Related: https://github.com/saber-hq/stable-swap/blob/c621f5950e8071aaa595bc9ad674e970fccebdb2/stable-swap-math/src/curve.rs#L22