### PR TITLE
chore: avoid array indexing

### DIFF
--- a/crates/dex-general/src/lib.rs
+++ b/crates/dex-general/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
+#![feature(array_windows)]
 
 pub use pallet::*;
 


### PR DESCRIPTION
small refactoring to avoid array lookups. They were safe, but not immediately obviously so.