### PR TITLE
fix: properly remove key in the sudo migration

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -1272,8 +1272,8 @@ struct SudoMigrationCheck;
 
 impl OnRuntimeUpgrade for SudoMigrationCheck {
     fn on_runtime_upgrade() -> Weight {
-        use frame_support::storage::migration::put_storage_value;
-        put_storage_value(b"Sudo", b"Key", &[], Option::<AccountId>::None);
+        use frame_support::storage::migration::take_storage_value;
+        take_storage_value::<AccountId>(b"Sudo", b"Key", &[]);
         Default::default()
     }
     #[cfg(feature = "try-runtime")]

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1272,8 +1272,8 @@ struct SudoMigrationCheck;
 
 impl OnRuntimeUpgrade for SudoMigrationCheck {
     fn on_runtime_upgrade() -> Weight {
-        use frame_support::storage::migration::put_storage_value;
-        put_storage_value(b"Sudo", b"Key", &[], Option::<AccountId>::None);
+        use frame_support::storage::migration::take_storage_value;
+        take_storage_value::<AccountId>(b"Sudo", b"Key", &[]);
         Default::default()
     }
     #[cfg(feature = "try-runtime")]

--- a/standalone/runtime/tests/test_governance.rs
+++ b/standalone/runtime/tests/test_governance.rs
@@ -940,9 +940,9 @@ fn test_sudo_is_disabled_if_key_is_none() {
         })
         .dispatch(origin_of(account_of(ALICE))),);
 
-        use frame_support::storage::migration::put_storage_value;
+        use frame_support::storage::migration::take_storage_value;
         assert!(!pallet_sudo::Pallet::<Runtime>::key().is_none());
-        put_storage_value(b"Sudo", b"Key", &[], Option::<AccountId>::None);
+        take_storage_value::<AccountId>(b"Sudo", b"Key", &[]);
         assert!(pallet_sudo::Pallet::<Runtime>::key().is_none());
 
         // assert that sudo does not work when key is none


### PR DESCRIPTION
The storage value is defined like this:
```
pub(super) type Key<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
```

The `OptionQuery` means that if you use the normal `get()` function, you get an Option. However, underlying storage is `T::AccountId` rather than `Option<T::AccountId>`. As such, the migration was incorrect - it put a value of incorrect length. It's not a huge deal since `get()` would still return `None` after failing to decode, but better to fix it properly.