### PR TITLE
refactor: remove reserves accounting

### DIFF
--- a/crates/loans/src/interest.rs
+++ b/crates/loans/src/interest.rs
@@ -35,12 +35,17 @@ impl<T: Config> Pallet<T> {
             return Ok(());
         }
 
-        let (borrow_rate, supply_rate, exchange_rate, util, total_borrows_new, total_reserves_new, borrow_index_new) =
+        let (borrow_rate, supply_rate, exchange_rate, util, total_borrows_new, reserve_interest, borrow_index_new) =
             Self::get_market_status(asset_id)?;
 
         Self::update_last_accrued_interest_time(asset_id, now)?;
+
+        reserve_interest
+            .transfer(&Self::account_id(), &T::Treasury::get())
+            .map_err(|_| Error::<T>::InsufficientCash)?;
+
         TotalBorrows::<T>::insert(asset_id, total_borrows_new);
-        TotalReserves::<T>::insert(asset_id, total_reserves_new);
+
         BorrowIndex::<T>::insert(asset_id, borrow_index_new);
 
         //save redundant storage right now.
@@ -53,7 +58,7 @@ impl<T: Config> Pallet<T> {
         Self::deposit_event(Event::<T>::InterestAccrued {
             underlying_currency_id: asset_id,
             total_borrows: total_borrows_new,
-            total_reserves: total_reserves_new,
+            total_reserves: reserve_interest.amount(), // note: breaking change
             borrow_index: borrow_index_new,
             utilization_ratio: util,
             borrow_rate,
@@ -66,16 +71,15 @@ impl<T: Config> Pallet<T> {
 
     pub fn get_market_status(
         asset_id: CurrencyId<T>,
-    ) -> Result<(Rate, Rate, Rate, Ratio, BalanceOf<T>, BalanceOf<T>, FixedU128), DispatchError> {
+    ) -> Result<(Rate, Rate, Rate, Ratio, BalanceOf<T>, Amount<T>, FixedU128), DispatchError> {
         let market = Self::market(asset_id)?;
         let total_supply = Self::total_supply(asset_id)?;
         let total_cash = Self::get_total_cash(asset_id);
         let mut total_borrows = Self::total_borrows(asset_id);
-        let mut total_reserves = Self::total_reserves(asset_id);
         let borrow_index = Self::borrow_index(asset_id);
         let mut borrow_index_new = borrow_index;
 
-        let util = Self::calc_utilization_ratio(&total_cash, &total_borrows, &total_reserves)?;
+        let util = Self::calc_utilization_ratio(&total_cash, &total_borrows)?;
         let borrow_rate = market
             .rate_model
             .get_borrow_rate(util)
@@ -84,7 +88,9 @@ impl<T: Config> Pallet<T> {
 
         let now = T::UnixTime::now().as_secs();
         let last_accrued_interest_time = Self::last_accrued_interest_time(asset_id);
-        if now > last_accrued_interest_time {
+        let reserve_interest = if now <= last_accrued_interest_time {
+            Amount::zero(asset_id)
+        } else {
             let delta_time = now
                 .checked_sub(last_accrued_interest_time)
                 .ok_or(ArithmeticError::Underflow)?;
@@ -103,12 +109,10 @@ impl<T: Config> Pallet<T> {
                 Rounding::Down,
             )?;
             let interest_accummulated = total_borrows.checked_sub(&total_borrows_old)?;
-            total_reserves = interest_accummulated
-                .map(|x| market.reserve_factor.mul_floor(x))
-                .checked_add(&total_reserves)?;
-        }
+            interest_accummulated.map(|x| market.reserve_factor.mul_floor(x))
+        };
 
-        let exchange_rate = Self::calculate_exchange_rate(&total_supply, &total_cash, &total_borrows, &total_reserves)?;
+        let exchange_rate = Self::calculate_exchange_rate(&total_supply, &total_cash, &total_borrows)?;
 
         Ok((
             borrow_rate,
@@ -116,7 +120,7 @@ impl<T: Config> Pallet<T> {
             exchange_rate,
             util,
             total_borrows.amount(),
-            total_reserves.amount(),
+            reserve_interest,
             borrow_index_new,
         ))
     }
@@ -128,24 +132,19 @@ impl<T: Config> Pallet<T> {
         let total_supply = Self::total_supply(asset_id)?;
         let total_cash = Self::get_total_cash(asset_id);
         let total_borrows = Self::total_borrows(asset_id);
-        let total_reserves = Self::total_reserves(asset_id);
 
-        Self::calculate_exchange_rate(&total_supply, &total_cash, &total_borrows, &total_reserves)
+        Self::calculate_exchange_rate(&total_supply, &total_cash, &total_borrows)
     }
 
     /// Calculate the borrowing utilization ratio of the specified market
     ///
-    /// utilizationRatio = totalBorrows / (totalCash + totalBorrows − totalReserves)
-    pub(crate) fn calc_utilization_ratio(
-        cash: &Amount<T>,
-        borrows: &Amount<T>,
-        reserves: &Amount<T>,
-    ) -> Result<Ratio, DispatchError> {
+    /// utilizationRatio = totalBorrows / (totalCash + totalBorrows)
+    pub(crate) fn calc_utilization_ratio(cash: &Amount<T>, borrows: &Amount<T>) -> Result<Ratio, DispatchError> {
         // utilization ratio is 0 when there are no borrows
         if borrows.is_zero() {
             return Ok(Ratio::zero());
         }
-        let total = cash.checked_add(&borrows)?.checked_sub(&reserves)?;
+        let total = cash.checked_add(&borrows)?;
 
         Ok(Ratio::from_rational(borrows.amount(), total.amount()))
     }
@@ -188,16 +187,14 @@ impl<T: Config> Pallet<T> {
         total_supply: &Amount<T>,
         total_cash: &Amount<T>,
         total_borrows: &Amount<T>,
-        total_reserves: &Amount<T>,
     ) -> Result<Rate, DispatchError> {
         if total_supply.is_zero() {
             return Ok(Self::min_exchange_rate());
         }
 
-        let cash_plus_borrows_minus_reserves = total_cash.checked_add(total_borrows)?.checked_sub(total_reserves)?;
-        let exchange_rate =
-            Rate::checked_from_rational(cash_plus_borrows_minus_reserves.amount(), total_supply.amount())
-                .ok_or(ArithmeticError::Underflow)?;
+        let cash_plus_borrows = total_cash.checked_add(total_borrows)?;
+        let exchange_rate = Rate::checked_from_rational(cash_plus_borrows.amount(), total_supply.amount())
+            .ok_or(ArithmeticError::Underflow)?;
         Self::ensure_valid_exchange_rate(exchange_rate)?;
 
         Ok(exchange_rate)

--- a/crates/traits/src/loans.rs
+++ b/crates/traits/src/loans.rs
@@ -59,6 +59,5 @@ pub struct MarketStatus<Balance> {
     pub exchange_rate: Rate,
     pub utilization: Ratio,
     pub total_borrows: Balance,
-    pub total_reserves: Balance,
     pub borrow_index: FixedU128,
 }


### PR DESCRIPTION
The pallet compiles, but I did not update tests yet because I wanted feedback _on the general idea_ before I spend time doing that. What this pr does, is to remove all references to the `Reserves`. Instead, we just transfer accumulated interest directly to the treasury, thus removing the need to keep explicit bookkeeping.