### PR TITLE
fix: limit amm swap route length

### DIFF
--- a/crates/dex-swap-router/src/mock.rs
+++ b/crates/dex-swap-router/src/mock.rs
@@ -186,6 +186,10 @@ impl dex_general::Config for Test {
     type WeightInfo = ();
 }
 
+parameter_types! {
+    pub const MaxSwaps: u16 = 10;
+}
+
 impl Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type StablePoolId = PoolId;
@@ -193,6 +197,7 @@ impl Config for Test {
     type CurrencyId = CurrencyId;
     type NormalAmm = DexGeneral;
     type StableAMM = StableAMM;
+    type MaxSwaps = MaxSwaps;
     type WeightInfo = ();
 }
 

--- a/crates/dex-swap-router/src/test.rs
+++ b/crates/dex-swap-router/src/test.rs
@@ -213,5 +213,28 @@ fn test_validate_routes() {
             RouterPallet::validate_routes(&[Route::Normal(vec![Token(1), Token(4)]), Route::Normal(vec![])]),
             Error::<Test>::InvalidPath
         );
+
+        // sanity check that our test makes sense
+        assert_eq!(MaxSwaps::get(), 10);
+        // 10 swaps - still allowed
+        assert_ok!(RouterPallet::validate_routes(&[
+            Route::Normal(vec![Token(1), Token(2), Token(3)]),
+            stable(Token(3), Token(2)),
+            stable(Token(2), Token(1)),
+            Route::Normal(vec![Token(1), Token(2), Token(3), Token(4)]),
+            Route::Normal(vec![Token(4), Token(3), Token(2), Token(1)]),
+        ]));
+
+        // 11 swaps - not allowed
+        assert_noop!(
+            RouterPallet::validate_routes(&[
+                Route::Normal(vec![Token(1), Token(2), Token(3)]),
+                stable(Token(3), Token(2)),
+                stable(Token(2), Token(1)),
+                Route::Normal(vec![Token(1), Token(2), Token(3), Token(4)]),
+                Route::Normal(vec![Token(4), Token(3), Token(2), Token(1), Token(5)]),
+            ]),
+            Error::<Test>::ExceededSwapLimit
+        );
     })
 }

--- a/parachain/runtime/kintsugi/src/dex.rs
+++ b/parachain/runtime/kintsugi/src/dex.rs
@@ -3,6 +3,7 @@ use super::{
     PalletId, Rate, Ratio, Runtime, RuntimeEvent, RuntimeOrigin, StablePoolId, Timestamp, Tokens, Vec, Weight, KBTC,
     KINT, KSM,
 };
+use sp_core::ConstU16;
 use sp_runtime::{traits::Zero, FixedPointNumber};
 
 #[cfg(feature = "try-runtime")]
@@ -74,6 +75,7 @@ impl dex_swap_router::Config for Runtime {
     type CurrencyId = CurrencyId;
     type NormalAmm = DexGeneral;
     type StableAMM = DexStable;
+    type MaxSwaps = ConstU16<4>;
     type WeightInfo = ();
 }
 

--- a/parachain/runtime/testnet-interlay/src/dex.rs
+++ b/parachain/runtime/testnet-interlay/src/dex.rs
@@ -5,6 +5,7 @@ use super::{
 
 pub use dex_general::{AssetBalance, GenerateLpAssetId, PairInfo};
 pub use dex_stable::traits::{StablePoolLpCurrencyIdGenerate, ValidateCurrency};
+use sp_core::ConstU16;
 
 parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
@@ -69,5 +70,6 @@ impl dex_swap_router::Config for Runtime {
     type CurrencyId = CurrencyId;
     type NormalAmm = DexGeneral;
     type StableAMM = DexStable;
+    type MaxSwaps = ConstU16<4>;
     type WeightInfo = ();
 }

--- a/parachain/runtime/testnet-kintsugi/src/dex.rs
+++ b/parachain/runtime/testnet-kintsugi/src/dex.rs
@@ -5,6 +5,7 @@ use super::{
 
 pub use dex_general::{AssetBalance, GenerateLpAssetId, PairInfo};
 pub use dex_stable::traits::{StablePoolLpCurrencyIdGenerate, ValidateCurrency};
+use sp_core::ConstU16;
 
 parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
@@ -69,5 +70,6 @@ impl dex_swap_router::Config for Runtime {
     type CurrencyId = CurrencyId;
     type NormalAmm = DexGeneral;
     type StableAMM = DexStable;
+    type MaxSwaps = ConstU16<4>;
     type WeightInfo = ();
 }


### PR DESCRIPTION
Limits the route length in `swap_exact_token_for_tokens_through_stable_pool`. Longer term we might want to make the weight parametric over the route length. A slight complication is that to determine the number of swaps, you need to iterate over the `route` vector, so you'd be spending some computation prior to execution, which is not ideal. We could add an additional parameter containing the number of swaps to prevent that. But anyway for this fix will suffice  

Addresses https://github.com/interlay/srlabs-audit/issues/10