### PR TITLE
feat: vault threshold events

### DIFF
--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -783,7 +783,7 @@ impl<T: Config> Pallet<T> {
             );
             Self::deposit_event(Event::<T>::CustomThreshold {
                 vault_id: vault_id,
-                currency_pair: currency_pair,
+                currency_pair: vault_id.currencies,
                 threshold_amount: some_new_threshold,
             });
         }

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -265,11 +265,6 @@ pub mod pallet {
             let vault_id = VaultId::new(account_id, currency_pair.collateral, currency_pair.wrapped);
             Self::try_set_vault_custom_secure_threshold(&vault_id, custom_threshold)?;
             PoolManager::<T>::on_vault_settings_change(&vault_id)?;
-            Self::deposit_event(Event::<T>::CustomThreshold {
-                vault_id: vault_id,
-                currency_pair: currency_pair,
-                threshold_amount: custom_threshold.unwrap(),
-            });
             Ok(().into())
         }
 
@@ -786,6 +781,11 @@ impl<T: Config> Pallet<T> {
                 some_new_threshold.gt(&global_threshold),
                 Error::<T>::ThresholdNotAboveGlobalThreshold
             );
+            Self::deposit_event(Event::<T>::CustomThreshold {
+                vault_id: vault_id,
+                currency_pair: currency_pair,
+                threshold_amount: some_new_threshold,
+            });
         }
         let mut vault = Self::get_rich_vault_from_id(&vault_id)?;
         vault.set_custom_secure_threshold(new_threshold)

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -41,7 +41,7 @@ use crate::types::{
 use crate::types::DefaultVaultCurrencyPair;
 #[doc(inline)]
 pub use crate::types::{
-    BtcPublicKey, CurrencySource, DefaultVault, DefaultVaultId, SystemVault, Vault, VaultId, VaultStatus,
+    BtcPublicKey, CurrencySource, DefaultVault, DefaultVaultId, SystemVault, ThresholdType, Vault, VaultId, VaultStatus,
 };
 use bitcoin::types::Value;
 use codec::FullCodec;
@@ -509,6 +509,11 @@ pub mod pallet {
         BanVault {
             vault_id: DefaultVaultId<T>,
             banned_until: T::BlockNumber,
+        },
+        ThresholdChange {
+            threshold_type: ThresholdType,
+            currency_pair: DefaultVaultCurrencyPair<T>,
+            threshold_amount: UnsignedFixedPoint<T>,
         },
     }
 
@@ -1543,10 +1548,20 @@ impl<T: Config> Pallet<T> {
         threshold: UnsignedFixedPoint<T>,
     ) {
         SecureCollateralThreshold::<T>::insert(currency_pair, threshold);
+        Self::deposit_event(Event::<T>::ThresholdChange {
+            threshold_type: ThresholdType::SecureCollateralThreshold,
+            currency_pair: currency_pair,
+            threshold_amount: threshold,
+        });
     }
 
     pub fn _set_premium_redeem_threshold(currency_pair: DefaultVaultCurrencyPair<T>, threshold: UnsignedFixedPoint<T>) {
         PremiumRedeemThreshold::<T>::insert(currency_pair, threshold);
+        Self::deposit_event(Event::<T>::ThresholdChange {
+            threshold_type: ThresholdType::PremiumRedeemThreshold,
+            currency_pair: currency_pair,
+            threshold_amount: threshold,
+        });
     }
 
     pub fn _set_liquidation_collateral_threshold(
@@ -1554,6 +1569,11 @@ impl<T: Config> Pallet<T> {
         threshold: UnsignedFixedPoint<T>,
     ) {
         LiquidationCollateralThreshold::<T>::insert(currency_pair, threshold);
+        Self::deposit_event(Event::<T>::ThresholdChange {
+            threshold_type: ThresholdType::LiquidationCollateralThreshold,
+            currency_pair: currency_pair,
+            threshold_amount: threshold,
+        });
     }
 
     /// return (collateral * Numerator) / denominator, used when dealing with liquidated vaults

--- a/crates/vault-registry/src/lib.rs
+++ b/crates/vault-registry/src/lib.rs
@@ -265,6 +265,11 @@ pub mod pallet {
             let vault_id = VaultId::new(account_id, currency_pair.collateral, currency_pair.wrapped);
             Self::try_set_vault_custom_secure_threshold(&vault_id, custom_threshold)?;
             PoolManager::<T>::on_vault_settings_change(&vault_id)?;
+            Self::deposit_event(Event::<T>::CustomThreshold {
+                vault_id: vault_id,
+                currency_pair: currency_pair,
+                threshold_amount: custom_threshold.unwrap(),
+            });
             Ok(().into())
         }
 
@@ -510,8 +515,13 @@ pub mod pallet {
             vault_id: DefaultVaultId<T>,
             banned_until: T::BlockNumber,
         },
-        ThresholdChange {
+        GlobalThreshold {
             threshold_type: ThresholdType,
+            currency_pair: DefaultVaultCurrencyPair<T>,
+            threshold_amount: UnsignedFixedPoint<T>,
+        },
+        CustomThreshold {
+            vault_id: DefaultVaultId<T>,
             currency_pair: DefaultVaultCurrencyPair<T>,
             threshold_amount: UnsignedFixedPoint<T>,
         },

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -56,6 +56,12 @@ pub enum CurrencySource<T: frame_system::Config + orml_tokens::Config> {
     LiquidationVault(DefaultVaultCurrencyPair<T>),
 }
 
+pub enum ThresholdType {
+    SecureCollateralThreshold,
+    PremiumRedeemThreshold,
+    LiquidationCollateralThreshold,
+}
+
 #[cfg_attr(test, mockable)]
 impl<T: Config> CurrencySource<T> {
     pub fn account_id(&self) -> <T as frame_system::Config>::AccountId {


### PR DESCRIPTION
Dom would like me to track threshold details for vaults in the squid and it would be much more efficient if I had an event to listen too instead of querying state.
https://github.com/interlay/interbtc-squid/pull/77#issuecomment-1464837804
 