### PR TITLE
feat(loans): add mutation testing decorations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,6 +4511,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
 name = "jsonrpsee"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5535,6 +5541,7 @@ dependencies = [
  "frame-system",
  "interbtc-primitives",
  "mocktopus",
+ "mutagen",
  "num-traits",
  "orml-oracle",
  "orml-tokens",
@@ -5952,6 +5959,39 @@ dependencies = [
  "pin-project",
  "smallvec",
  "unsigned-varint",
+]
+
+[[package]]
+name = "mutagen"
+version = "0.2.0"
+source = "git+https://github.com/llogiq/mutagen#a6377c4c3f360afeb7a287c1c17e4b69456d5f53"
+dependencies = [
+ "mutagen-core",
+ "mutagen-transform",
+]
+
+[[package]]
+name = "mutagen-core"
+version = "0.2.0"
+source = "git+https://github.com/llogiq/mutagen#a6377c4c3f360afeb7a287c1c17e4b69456d5f53"
+dependencies = [
+ "anyhow",
+ "json",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "mutagen-transform"
+version = "0.2.0"
+source = "git+https://github.com/llogiq/mutagen#a6377c4c3f360afeb7a287c1c17e4b69456d5f53"
+dependencies = [
+ "mutagen-core",
+ "proc-macro2",
 ]
 
 [[package]]

--- a/crates/loans/Cargo.toml
+++ b/crates/loans/Cargo.toml
@@ -43,6 +43,7 @@ orml-oracle = { git = "https://github.com/open-web3-stack/open-runtime-module-li
 mocktopus = "0.8.0"
 visibility = { version = "0.0.1" }
 currency = { path = "../currency", features = ["testing-utils"] }
+mutagen = { git = "https://github.com/llogiq/mutagen" }
 
 [features]
 default = ["std"]

--- a/crates/loans/src/farming.rs
+++ b/crates/loans/src/farming.rs
@@ -24,10 +24,12 @@ impl<T: Config> Pallet<T> {
         T::PalletId::get().into_sub_account_truncating(REWARD_SUB_ACCOUNT)
     }
 
+    #[cfg_attr(test, mutate)]
     fn reward_scale() -> u128 {
         10_u128.pow(12)
     }
 
+    #[cfg_attr(test, mutate)]
     fn calculate_reward_delta_index(
         delta_block: T::BlockNumber,
         reward_speed: BalanceOf<T>,
@@ -47,6 +49,7 @@ impl<T: Config> Pallet<T> {
         Ok(delta_index)
     }
 
+    #[cfg_attr(test, mutate)]
     fn calculate_reward_delta(
         share: BalanceOf<T>,
         reward_delta_index: u128,
@@ -60,6 +63,7 @@ impl<T: Config> Pallet<T> {
         Ok(reward_delta)
     }
 
+    #[cfg_attr(test, mutate)]
     pub(crate) fn update_reward_supply_index(asset_id: CurrencyId<T>) -> DispatchResult {
         let current_block_number = <frame_system::Pallet<T>>::block_number();
         RewardSupplyState::<T>::try_mutate(asset_id, |supply_state| -> DispatchResult {
@@ -82,6 +86,7 @@ impl<T: Config> Pallet<T> {
         })
     }
 
+    #[cfg_attr(test, mutate)]
     pub(crate) fn update_reward_borrow_index(asset_id: CurrencyId<T>) -> DispatchResult {
         let current_block_number = <frame_system::Pallet<T>>::block_number();
         RewardBorrowState::<T>::try_mutate(asset_id, |borrow_state| -> DispatchResult {
@@ -106,6 +111,7 @@ impl<T: Config> Pallet<T> {
         })
     }
 
+    #[cfg_attr(test, mutate)]
     pub(crate) fn distribute_supplier_reward(asset_id: CurrencyId<T>, supplier: &T::AccountId) -> DispatchResult {
         RewardSupplierIndex::<T>::try_mutate(asset_id, supplier, |supplier_index| -> DispatchResult {
             let supply_state = RewardSupplyState::<T>::get(asset_id);
@@ -137,6 +143,7 @@ impl<T: Config> Pallet<T> {
         })
     }
 
+    #[cfg_attr(test, mutate)]
     pub(crate) fn distribute_borrower_reward(asset_id: CurrencyId<T>, borrower: &T::AccountId) -> DispatchResult {
         RewardBorrowerIndex::<T>::try_mutate(asset_id, borrower, |borrower_index| -> DispatchResult {
             let borrow_state = RewardBorrowState::<T>::get(asset_id);
@@ -166,6 +173,7 @@ impl<T: Config> Pallet<T> {
         })
     }
 
+    #[cfg_attr(test, mutate)]
     pub(crate) fn collect_market_reward(asset_id: CurrencyId<T>, user: &T::AccountId) -> DispatchResult {
         Self::update_reward_supply_index(asset_id)?;
         Self::distribute_supplier_reward(asset_id, user)?;
@@ -176,6 +184,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
+    #[cfg_attr(test, mutate)]
     pub(crate) fn pay_reward(user: &T::AccountId) -> DispatchResult {
         let pool_account = Self::reward_account_id();
         let reward_asset = T::RewardAssetId::get();

--- a/crates/loans/src/rate_model.rs
+++ b/crates/loans/src/rate_model.rs
@@ -30,6 +30,7 @@ pub enum InterestRateModel {
 }
 
 impl Default for InterestRateModel {
+    #[cfg_attr(test, mutate)]
     fn default() -> Self {
         Self::new_jump_model(
             Rate::saturating_from_rational(2, 100),
@@ -41,14 +42,17 @@ impl Default for InterestRateModel {
 }
 
 impl InterestRateModel {
+    #[cfg_attr(test, mutate)]
     pub fn new_jump_model(base_rate: Rate, jump_rate: Rate, full_rate: Rate, jump_utilization: Ratio) -> Self {
         Self::Jump(JumpModel::new_model(base_rate, jump_rate, full_rate, jump_utilization))
     }
 
+    #[cfg_attr(test, mutate)]
     pub fn new_curve_model(base_rate: Rate) -> Self {
         Self::Curve(CurveModel::new_model(base_rate))
     }
 
+    #[cfg_attr(test, mutate)]
     pub fn check_model(&self) -> bool {
         match self {
             Self::Jump(jump) => jump.check_model(),
@@ -57,6 +61,7 @@ impl InterestRateModel {
     }
 
     /// Calculates the current borrow interest rate
+    #[cfg_attr(test, mutate)]
     pub fn get_borrow_rate(&self, utilization: Ratio) -> Option<Rate> {
         match self {
             Self::Jump(jump) => jump.get_borrow_rate(utilization),
@@ -65,6 +70,7 @@ impl InterestRateModel {
     }
 
     /// Calculates the current supply interest rate
+    #[cfg_attr(test, mutate)]
     pub fn get_supply_rate(borrow_rate: Rate, util: Ratio, reserve_factor: Ratio) -> Rate {
         // ((1 - reserve_factor) * borrow_rate) * utilization
         let one_minus_reserve_factor = Ratio::one().saturating_sub(reserve_factor);
@@ -94,6 +100,7 @@ impl JumpModel {
     pub const MAX_FULL_RATE: Rate = Rate::from_inner(500_000_000_000_000_000); // 50%
 
     /// Create a new rate model
+    #[cfg_attr(test, mutate)]
     pub fn new_model(base_rate: Rate, jump_rate: Rate, full_rate: Rate, jump_utilization: Ratio) -> JumpModel {
         Self {
             base_rate,
@@ -104,6 +111,7 @@ impl JumpModel {
     }
 
     /// Check the jump model for sanity
+    #[cfg_attr(test, mutate)]
     pub fn check_model(&self) -> bool {
         if self.base_rate > Self::MAX_BASE_RATE
             || self.jump_rate > Self::MAX_JUMP_RATE
@@ -119,6 +127,7 @@ impl JumpModel {
     }
 
     /// Calculates the borrow interest rate of jump model
+    #[cfg_attr(test, mutate)]
     pub fn get_borrow_rate(&self, utilization: Ratio) -> Option<Rate> {
         if utilization <= self.jump_utilization {
             // utilization * (jump_rate - zero_rate) / jump_utilization + zero_rate
@@ -156,16 +165,19 @@ impl CurveModel {
     pub const MAX_BASE_RATE: Rate = Rate::from_inner(100_000_000_000_000_000); // 10%
 
     /// Create a new curve model
+    #[cfg_attr(test, mutate)]
     pub fn new_model(base_rate: Rate) -> CurveModel {
         Self { base_rate }
     }
 
     /// Check the curve model for sanity
+    #[cfg_attr(test, mutate)]
     pub fn check_model(&self) -> bool {
         self.base_rate <= Self::MAX_BASE_RATE
     }
 
     /// Calculates the borrow interest rate of curve model
+    #[cfg_attr(test, mutate)]
     pub fn get_borrow_rate(&self, utilization: Ratio) -> Option<Rate> {
         const NINE: usize = 9;
         let utilization_rate: Rate = utilization.into();

--- a/crates/loans/src/types.rs
+++ b/crates/loans/src/types.rs
@@ -4,6 +4,9 @@ use frame_support::pallet_prelude::*;
 use primitives::{CurrencyId, Liquidity, Rate, Ratio, Shortfall};
 use scale_info::TypeInfo;
 
+#[cfg(test)]
+use mutagen::mutate;
+
 // TODO: `cargo doc` crashes on this type, remove the `hidden` macro
 // when upgrading rustc in case that fixes it
 /// Container for account liquidity information
@@ -15,6 +18,7 @@ pub enum AccountLiquidity<T: Config> {
 }
 
 impl<T: Config> AccountLiquidity<T> {
+    #[cfg_attr(test, mutate)]
     pub fn from_collateral_and_debt(
         collateral_value: Amount<T>,
         borrow_value: Amount<T>,
@@ -27,12 +31,14 @@ impl<T: Config> AccountLiquidity<T> {
         Ok(account_liquidity)
     }
 
+    #[cfg_attr(test, mutate)]
     pub fn currency(&self) -> CurrencyId {
         match &self {
             AccountLiquidity::Liquidity(x) | AccountLiquidity::Shortfall(x) => x.currency(),
         }
     }
 
+    #[cfg_attr(test, mutate)]
     pub fn liquidity(&self) -> Amount<T> {
         if let AccountLiquidity::Liquidity(x) = &self {
             return x.clone();
@@ -40,6 +46,7 @@ impl<T: Config> AccountLiquidity<T> {
         Amount::<T>::zero(self.currency())
     }
 
+    #[cfg_attr(test, mutate)]
     pub fn shortfall(&self) -> Amount<T> {
         if let AccountLiquidity::Shortfall(x) = &self {
             return x.clone();
@@ -47,6 +54,7 @@ impl<T: Config> AccountLiquidity<T> {
         Amount::<T>::zero(self.currency())
     }
 
+    #[cfg_attr(test, mutate)]
     pub fn to_rpc_tuple(&self) -> Result<(Liquidity, Shortfall), DispatchError> {
         Ok((
             self.liquidity().to_unsigned_fixed_point()?,


### PR DESCRIPTION
Decorates all functions in the loans pallet with `#[cfg_attr(test, mutate)]`, so `mutagen` can mutate them and check if the unit tests break, "killing" the mutations. Only unit tests are used when checking, so some of the surviving mutants exist because they're tested in an integration test.

Most surviving mutants just remove the `deposit_event` call, however some logic in the interest rate model should actually be better tested. This is the output about surviving mutants: [SURVIVED.txt](https://github.com/interlay/interbtc/files/11003404/SURVIVED.txt)

The `mutagen` dependency uses the latest master on their GitHub, because version `2.x` wasn't released to crates.io for some reason.
