### PR TITLE
fix: limit number of swaps in dexGeneral

### DIFF
--- a/crates/dex-general/src/fee/mock.rs
+++ b/crates/dex-general/src/fee/mock.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use frame_support::{parameter_types, traits::Contains, PalletId};
 use orml_traits::parameter_type_with_key;
-use sp_core::H256;
+use sp_core::{ConstU16, H256};
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
@@ -142,6 +142,7 @@ impl Config for Test {
     type AssetId = CurrencyId;
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
+    type MaxSwaps = ConstU16<10>;
 }
 
 pub type DexPallet = Pallet<Test>;

--- a/crates/dex-general/src/lib.rs
+++ b/crates/dex-general/src/lib.rs
@@ -82,6 +82,9 @@ pub mod pallet {
         type LpGenerate: GenerateLpAssetId<Self::AssetId>;
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
+        /// The maximum number of swaps allowed in routes
+        #[pallet::constant]
+        type MaxSwaps: Get<u16>;
     }
 
     #[pallet::pallet]
@@ -631,6 +634,8 @@ pub mod pallet {
             #[pallet::compact] deadline: T::BlockNumber,
         ) -> DispatchResult {
             ensure!(path.iter().all(|id| id.is_support()), Error::<T>::UnsupportedAssetType);
+            ensure!(path.len() <= T::MaxSwaps::get().into(), Error::<T>::InvalidPath);
+
             let who = ensure_signed(origin)?;
             let recipient = T::Lookup::lookup(recipient)?;
             let now = frame_system::Pallet::<T>::block_number();
@@ -660,6 +665,7 @@ pub mod pallet {
             #[pallet::compact] deadline: T::BlockNumber,
         ) -> DispatchResult {
             ensure!(path.iter().all(|id| id.is_support()), Error::<T>::UnsupportedAssetType);
+            ensure!(path.len() <= T::MaxSwaps::get().into(), Error::<T>::InvalidPath);
             let who = ensure_signed(origin)?;
             let recipient = T::Lookup::lookup(recipient)?;
             let now = frame_system::Pallet::<T>::block_number();
@@ -971,6 +977,10 @@ pub mod pallet {
             asset_1: T::AssetId,
             charge_rewards: Vec<(T::AssetId, AssetBalance)>,
         ) -> DispatchResult {
+            ensure!(
+                charge_rewards.len() <= T::MaxSwaps::get().into(),
+                Error::<T>::ChargeRewardParamsError
+            );
             let pair = Self::sort_asset_id(asset_0, asset_1);
             let who = ensure_signed(origin)?;
 

--- a/crates/dex-general/src/swap/mock.rs
+++ b/crates/dex-general/src/swap/mock.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use frame_support::{parameter_types, traits::Contains, PalletId};
 use orml_traits::parameter_type_with_key;
-use sp_core::H256;
+use sp_core::{ConstU16, H256};
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
@@ -141,6 +141,7 @@ impl Config for Test {
     type AssetId = CurrencyId;
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
+    type MaxSwaps = ConstU16<10>;
 }
 
 pub type DexPallet = Pallet<Test>;

--- a/crates/dex-swap-router/src/mock.rs
+++ b/crates/dex-swap-router/src/mock.rs
@@ -184,6 +184,7 @@ impl dex_general::Config for Test {
     type AssetId = CurrencyId;
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
+    type MaxSwaps = MaxSwaps;
 }
 
 parameter_types! {

--- a/parachain/runtime/kintsugi/src/dex.rs
+++ b/parachain/runtime/kintsugi/src/dex.rs
@@ -11,6 +11,7 @@ parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stbl");
     pub const StringLimit: u32 = 50;
+    pub const MaxSwaps:u16 = 4;
 }
 
 pub struct PairLpIdentity;
@@ -27,6 +28,7 @@ impl dex_general::Config for Runtime {
     type AssetId = CurrencyId;
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
+    type MaxSwaps = MaxSwaps;
 }
 
 pub struct PoolLpGenerate;
@@ -70,6 +72,6 @@ impl dex_swap_router::Config for Runtime {
     type CurrencyId = CurrencyId;
     type NormalAmm = DexGeneral;
     type StableAMM = DexStable;
-    type MaxSwaps = ConstU16<4>;
+    type MaxSwaps = MaxSwaps;
     type WeightInfo = ();
 }

--- a/parachain/runtime/testnet-interlay/src/dex.rs
+++ b/parachain/runtime/testnet-interlay/src/dex.rs
@@ -11,6 +11,7 @@ parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stab");
     pub const StringLimit: u32 = 50;
+    pub const MaxSwaps:u16 = 4;
 }
 
 pub struct PairLpIdentity;
@@ -27,6 +28,7 @@ impl dex_general::Config for Runtime {
     type AssetId = CurrencyId;
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
+    type MaxSwaps = MaxSwaps;
 }
 
 pub struct PoolLpGenerate;
@@ -70,6 +72,6 @@ impl dex_swap_router::Config for Runtime {
     type CurrencyId = CurrencyId;
     type NormalAmm = DexGeneral;
     type StableAMM = DexStable;
-    type MaxSwaps = ConstU16<4>;
+    type MaxSwaps = MaxSwaps;
     type WeightInfo = ();
 }

--- a/parachain/runtime/testnet-kintsugi/src/dex.rs
+++ b/parachain/runtime/testnet-kintsugi/src/dex.rs
@@ -11,6 +11,7 @@ parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stbl");
     pub const StringLimit: u32 = 50;
+    pub const MaxSwaps:u16 = 4;
 }
 
 pub struct PairLpIdentity;
@@ -27,6 +28,7 @@ impl dex_general::Config for Runtime {
     type AssetId = CurrencyId;
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
+    type MaxSwaps = MaxSwaps;
 }
 
 pub struct PoolLpGenerate;
@@ -70,6 +72,6 @@ impl dex_swap_router::Config for Runtime {
     type CurrencyId = CurrencyId;
     type NormalAmm = DexGeneral;
     type StableAMM = DexStable;
-    type MaxSwaps = ConstU16<4>;
+    type MaxSwaps = MaxSwaps;
     type WeightInfo = ();
 }


### PR DESCRIPTION
Quick fix so we can close https://github.com/interlay/srlabs-audit/issues/10. Longer term we should switch the boundedvec, but that will be a breaking change 