### PR TITLE
[BREAKING] feat!: add separate event for cancelled proposal

### DIFF
--- a/crates/democracy/src/lib.rs
+++ b/crates/democracy/src/lib.rs
@@ -301,6 +301,8 @@ pub mod pallet {
         NotPassed { ref_index: ReferendumIndex },
         /// A referendum has been cancelled.
         Cancelled { ref_index: ReferendumIndex },
+        /// A proposal has been cancelled.
+        CancelledProposal { prop_index: PropIndex },
     }
 
     #[pallet::error]
@@ -582,6 +584,7 @@ pub mod pallet {
                     T::Currency::unreserve(&who, amount);
                 }
             }
+            Self::deposit_event(Event::<T>::CancelledProposal { prop_index });
 
             Ok(())
         }


### PR DESCRIPTION
So OpenSquare can update when proposals are cancelled