### PR TITLE
[BREAKING] fix: allow vault to withdraw all collateral

### DIFF
--- a/crates/nomination/Cargo.toml
+++ b/crates/nomination/Cargo.toml
@@ -82,6 +82,7 @@ runtime-benchmarks = [
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
 
+  "traits/runtime-benchmarks",
   "vault-registry/runtime-benchmarks",
 
   "orml-tokens",

--- a/crates/nomination/src/benchmarking.rs
+++ b/crates/nomination/src/benchmarking.rs
@@ -184,7 +184,12 @@ pub mod benchmarks {
         let balance_before = <orml_tokens::Pallet<T>>::reserved_balance(collateral_currency, &vault_id.account_id);
 
         #[extrinsic_call]
-        _(RawOrigin::Signed(nominator.clone()), vault_id.clone(), amount, None);
+        _(
+            RawOrigin::Signed(nominator.clone()),
+            vault_id.clone(),
+            Some(amount),
+            None,
+        );
 
         let balance_after = <orml_tokens::Pallet<T>>::reserved_balance(collateral_currency, &vault_id.account_id);
         assert_eq!(balance_before - amount, balance_after);

--- a/crates/nomination/src/ext.rs
+++ b/crates/nomination/src/ext.rs
@@ -22,7 +22,7 @@ pub(crate) mod vault_registry {
 
     pub fn is_allowed_to_withdraw_collateral<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
-        amount: &Amount<T>,
+        amount: Option<Amount<T>>,
     ) -> Result<bool, DispatchError> {
         <vault_registry::Pallet<T>>::is_allowed_to_withdraw_collateral(vault_id, amount)
     }
@@ -55,10 +55,10 @@ pub(crate) mod vault_registry {
         pub fn withdraw_collateral<T: crate::Config>(
             vault_id: &DefaultVaultId<T>,
             nominator_id: &T::AccountId,
-            amount: &Amount<T>,
+            maybe_amount: Option<Amount<T>>,
             nonce: Option<<T as frame_system::Config>::Index>,
-        ) -> Result<(), DispatchError> {
-            <vault_registry::PoolManager<T>>::withdraw_collateral(vault_id, nominator_id, amount, nonce)
+        ) -> Result<Amount<T>, DispatchError> {
+            <vault_registry::PoolManager<T>>::withdraw_collateral(vault_id, nominator_id, maybe_amount, nonce)
         }
 
         pub fn kick_nominators<T: crate::Config>(vault_id: &DefaultVaultId<T>) -> Result<Amount<T>, DispatchError> {
@@ -77,6 +77,7 @@ pub(crate) mod staking {
     pub fn nonce<T: crate::Config>(vault_id: &DefaultVaultId<T>) -> T::Index {
         T::VaultStaking::nonce(vault_id)
     }
+
     pub fn compute_stake<T: vault_registry::Config>(
         vault_id: &DefaultVaultId<T>,
         nominator_id: &T::AccountId,

--- a/crates/nomination/src/tests.rs
+++ b/crates/nomination/src/tests.rs
@@ -2,6 +2,7 @@ use crate::{ext, mock::*};
 use currency::Amount;
 use frame_support::{assert_err, assert_ok};
 use mocktopus::mocking::*;
+use sp_arithmetic::FixedI128;
 
 #[test]
 fn should_not_deposit_against_invalid_vault() {
@@ -12,6 +13,7 @@ fn should_not_deposit_against_invalid_vault() {
         );
     })
 }
+
 fn collateral(amount: u128) -> Amount<Test> {
     Amount::new(amount, DEFAULT_COLLATERAL_CURRENCY)
 }
@@ -31,4 +33,55 @@ fn should_deposit_against_valid_vault() {
         ));
         assert_ok!(Nomination::_deposit_collateral(&ALICE, &BOB.account_id, 100));
     })
+}
+
+#[test]
+fn should_not_withdraw_collateral() {
+    use orml_traits::MultiCurrency;
+
+    run_test(|| {
+        assert_ok!(Tokens::deposit(
+            ALICE.currencies.collateral,
+            &ALICE.account_id,
+            24_609_778_406_619_232
+        ));
+        VaultRegistry::_set_system_collateral_ceiling(ALICE.currencies, u128::MAX);
+        assert_ok!(VaultRegistry::register_public_key(
+            RuntimeOrigin::signed(ALICE.account_id),
+            vault_registry::BtcPublicKey::dummy()
+        ));
+        assert_ok!(VaultRegistry::register_vault(
+            RuntimeOrigin::signed(ALICE.account_id),
+            ALICE.currencies,
+            24_609_778_406_619_232
+        ));
+
+        staking::SlashPerToken::<Test>::insert(0, ALICE, FixedI128::from_inner(25_210_223_519_649_666));
+        staking::SlashTally::<Test>::insert(
+            0,
+            (ALICE, ALICE.account_id),
+            FixedI128::from_inner(100_834_580_684_768_029_667_333_677_168),
+        );
+        staking::Stake::<Test>::insert(
+            0,
+            (ALICE, ALICE.account_id),
+            FixedI128::from_inner(3_999_749_570_096_999_994_120_799_432_121),
+        );
+        staking::TotalCurrentStake::<Test>::insert(
+            0,
+            ALICE,
+            FixedI128::from_inner(3_999_749_570_097_000_000_000_000_000_000),
+        );
+        staking::TotalStake::<Test>::insert(
+            0,
+            ALICE,
+            FixedI128::from_inner(3_999_749_570_096_999_994_120_799_432_121),
+        );
+
+        // should not withdraw all
+        assert_err!(
+            Nomination::_withdraw_collateral(&ALICE, &ALICE.account_id, 3999749570097, 0),
+            staking::Error::<Test>::InsufficientFunds
+        );
+    });
 }

--- a/crates/nomination/src/tests.rs
+++ b/crates/nomination/src/tests.rs
@@ -80,8 +80,18 @@ fn should_not_withdraw_collateral() {
 
         // should not withdraw all
         assert_err!(
-            Nomination::_withdraw_collateral(&ALICE, &ALICE.account_id, 3999749570097, 0),
+            Nomination::_withdraw_collateral(&ALICE, &ALICE.account_id, Some(3999749570097), 0),
             staking::Error::<Test>::InsufficientFunds
+        );
+
+        // should withdraw all
+        assert_ok!(Nomination::_withdraw_collateral(&ALICE, &ALICE.account_id, None, 0));
+
+        // stake is now zero
+        assert_ok!(ext::staking::compute_stake::<Test>(&ALICE, &ALICE.account_id), 0);
+        assert_ok!(
+            VaultRegistry::get_backing_collateral(&ALICE),
+            Amount::new(0, ALICE.collateral_currency())
         );
     });
 }

--- a/crates/replace/src/ext.rs
+++ b/crates/replace/src/ext.rs
@@ -133,7 +133,7 @@ pub(crate) mod vault_registry {
 
     pub fn is_allowed_to_withdraw_collateral<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
-        amount: &Amount<T>,
+        amount: Option<Amount<T>>,
     ) -> Result<bool, DispatchError> {
         <vault_registry::Pallet<T>>::is_allowed_to_withdraw_collateral(vault_id, amount)
     }

--- a/crates/replace/src/lib.rs
+++ b/crates/replace/src/lib.rs
@@ -598,7 +598,7 @@ impl<T: Config> Pallet<T> {
         // if the new_vault locked additional collateral especially for this replace,
         // release it if it does not cause them to be undercollateralized
         if !ext::vault_registry::is_vault_liquidated::<T>(&new_vault_id)?
-            && ext::vault_registry::is_allowed_to_withdraw_collateral::<T>(&new_vault_id, &collateral)?
+            && ext::vault_registry::is_allowed_to_withdraw_collateral::<T>(&new_vault_id, Some(collateral.clone()))?
         {
             ext::vault_registry::force_withdraw_collateral::<T>(&new_vault_id, &collateral)?;
         }

--- a/crates/reward/src/lib.rs
+++ b/crates/reward/src/lib.rs
@@ -359,7 +359,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 pub trait RewardsApi<PoolId, StakeId, Balance>
 where
-    Balance: Saturating + PartialOrd,
+    Balance: Saturating + PartialOrd + Copy,
 {
     type CurrencyId;
 
@@ -389,8 +389,10 @@ where
     fn withdraw_stake(pool_id: &PoolId, stake_id: &StakeId, amount: Balance) -> DispatchResult;
 
     /// Withdraw all stake for an account.
-    fn withdraw_all_stake(pool_id: &PoolId, stake_id: &StakeId) -> DispatchResult {
-        Self::withdraw_stake(pool_id, stake_id, Self::get_stake(pool_id, stake_id)?)
+    fn withdraw_all_stake(pool_id: &PoolId, stake_id: &StakeId) -> Result<Balance, DispatchError> {
+        let amount = Self::get_stake(pool_id, stake_id)?;
+        Self::withdraw_stake(pool_id, stake_id, amount)?;
+        Ok(amount)
     }
 
     /// Return the stake associated with the `pool_id`.
@@ -418,7 +420,7 @@ impl<T, I, Balance> RewardsApi<T::PoolId, T::StakeId, Balance> for Pallet<T, I>
 where
     T: Config<I>,
     I: 'static,
-    Balance: BalanceToFixedPoint<SignedFixedPoint<T, I>> + Saturating + PartialOrd,
+    Balance: BalanceToFixedPoint<SignedFixedPoint<T, I>> + Saturating + PartialOrd + Copy,
     <T::SignedFixedPoint as FixedPointNumber>::Inner: TryInto<Balance>,
 {
     type CurrencyId = T::CurrencyId;
@@ -490,7 +492,7 @@ where
 
 impl<PoolId, StakeId, Balance> RewardsApi<PoolId, StakeId, Balance> for ()
 where
-    Balance: Saturating + PartialOrd + Default,
+    Balance: Saturating + PartialOrd + Default + Copy,
 {
     type CurrencyId = ();
 

--- a/crates/vault-registry/src/ext.rs
+++ b/crates/vault-registry/src/ext.rs
@@ -40,10 +40,16 @@ pub(crate) mod staking {
     pub fn withdraw_stake<T: crate::Config>(
         vault_id: &DefaultVaultId<T>,
         nominator_id: &T::AccountId,
-        amount: &Amount<T>,
+        maybe_amount: Option<Amount<T>>,
         nonce: Option<<T as frame_system::Config>::Index>,
-    ) -> DispatchResult {
-        T::VaultStaking::withdraw_stake(&(nonce, vault_id.clone()), nominator_id, amount.amount())
+    ) -> Result<Amount<T>, DispatchError> {
+        if let Some(amount) = maybe_amount {
+            T::VaultStaking::withdraw_stake(&(nonce, vault_id.clone()), nominator_id, amount.amount())?;
+            Ok(amount)
+        } else {
+            let balance = T::VaultStaking::withdraw_all_stake(&(nonce, vault_id.clone()), nominator_id)?;
+            Ok(Amount::new(balance, vault_id.collateral_currency()))
+        }
     }
 
     pub fn slash_stake<T: crate::Config>(vault_id: &DefaultVaultId<T>, amount: &Amount<T>) -> DispatchResult {

--- a/crates/vault-registry/src/pool_manager.rs
+++ b/crates/vault-registry/src/pool_manager.rs
@@ -19,14 +19,16 @@ impl<T: Config> PoolManager<T> {
     pub fn withdraw_collateral(
         vault_id: &DefaultVaultId<T>,
         nominator_id: &T::AccountId,
-        amount: &Amount<T>,
+        maybe_amount: Option<Amount<T>>,
         nonce: Option<<T as frame_system::Config>::Index>,
-    ) -> Result<(), DispatchError> {
+    ) -> Result<Amount<T>, DispatchError> {
         ext::fee::distribute_all_vault_rewards::<T>(vault_id)?;
-        ext::staking::withdraw_stake(vault_id, nominator_id, amount, nonce)?;
+        let amount = ext::staking::withdraw_stake(vault_id, nominator_id, maybe_amount, nonce)?;
 
         // also propagate to reward & capacity pools
-        Self::update_reward_stake(vault_id)
+        Self::update_reward_stake(vault_id)?;
+
+        Ok(amount)
     }
 
     pub fn slash_collateral(vault_id: &DefaultVaultId<T>, amount: &Amount<T>) -> Result<(), DispatchError> {

--- a/crates/vault-registry/src/tests.rs
+++ b/crates/vault-registry/src/tests.rs
@@ -202,17 +202,17 @@ fn should_check_withdraw_collateral() {
 
         // should allow withdraw all
         assert_ok!(
-            VaultRegistry::is_allowed_to_withdraw_collateral(&DEFAULT_ID, &amount(DEFAULT_COLLATERAL)),
+            VaultRegistry::is_allowed_to_withdraw_collateral(&DEFAULT_ID, Some(amount(DEFAULT_COLLATERAL))),
             true,
         );
         // should allow withdraw above minimum
         assert_ok!(
-            VaultRegistry::is_allowed_to_withdraw_collateral(&DEFAULT_ID, &amount(DEFAULT_COLLATERAL / 4)),
+            VaultRegistry::is_allowed_to_withdraw_collateral(&DEFAULT_ID, Some(amount(DEFAULT_COLLATERAL / 4))),
             true,
         );
         // should not allow withdraw above zero, below minimum
         assert_err!(
-            VaultRegistry::is_allowed_to_withdraw_collateral(&DEFAULT_ID, &amount(DEFAULT_COLLATERAL / 4 * 3)),
+            VaultRegistry::is_allowed_to_withdraw_collateral(&DEFAULT_ID, Some(amount(DEFAULT_COLLATERAL / 4 * 3))),
             TestError::InsufficientVaultCollateralAmount,
         );
     });

--- a/crates/vault-registry/src/types.rs
+++ b/crates/vault-registry/src/types.rs
@@ -538,8 +538,8 @@ impl<T: Config> RichVault<T> {
     pub(crate) fn slash_for_to_be_redeemed(&mut self, amount: &Amount<T>) -> DispatchResult {
         let vault_id = self.id();
         let collateral = self.get_vault_collateral()?.min(amount)?;
-        PoolManager::<T>::withdraw_collateral(&vault_id, &vault_id.account_id, &collateral, None)?;
         self.increase_liquidated_collateral(&collateral)?;
+        PoolManager::<T>::withdraw_collateral(&vault_id, &vault_id.account_id, Some(collateral), None)?;
         Ok(())
     }
 
@@ -554,7 +554,7 @@ impl<T: Config> RichVault<T> {
             .unwrap_or((amount.clone(), None));
 
         // "slash" vault first
-        PoolManager::<T>::withdraw_collateral(&vault_id, &vault_id.account_id, &to_withdraw, None)?;
+        PoolManager::<T>::withdraw_collateral(&vault_id, &vault_id.account_id, Some(to_withdraw), None)?;
         // take remainder from nominators
         if let Some(to_slash) = to_slash {
             PoolManager::<T>::slash_collateral(&vault_id, &to_slash)?;

--- a/parachain/runtime/runtime-tests/src/parachain/issue.rs
+++ b/parachain/runtime/runtime-tests/src/parachain/issue.rs
@@ -564,7 +564,7 @@ fn integration_test_withdraw_after_request_issue() {
         assert!(RuntimeCall::Nomination(NominationCall::withdraw_collateral {
             vault_id: vault_id.clone(),
             index: None,
-            amount: collateral_vault.amount()
+            amount: Some(collateral_vault.amount())
         })
         .dispatch(origin_of(account_of(vault)))
         .is_err());

--- a/parachain/runtime/runtime-tests/src/parachain/nomination.rs
+++ b/parachain/runtime/runtime-tests/src/parachain/nomination.rs
@@ -257,7 +257,7 @@ mod spec_based_tests {
             assert_noop!(
                 RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                     vault_id: vault_id.clone(),
-                    amount: 1,
+                    amount: Some(1),
                     index: None
                 })
                 .dispatch(origin_of(account_of(USER))),
@@ -267,7 +267,7 @@ mod spec_based_tests {
             assert_noop!(
                 RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                     vault_id: vault_id_of(CAROL, vault_id.collateral_currency()),
-                    amount: 1,
+                    amount: Some(1),
                     index: None
                 })
                 .dispatch(origin_of(account_of(USER))),
@@ -276,7 +276,7 @@ mod spec_based_tests {
             assert_noop!(
                 RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                     vault_id: vault_id.clone(),
-                    amount: 1,
+                    amount: Some(1),
                     index: None
                 })
                 .dispatch(origin_of(account_of(USER))),
@@ -286,7 +286,7 @@ mod spec_based_tests {
             assert_noop!(
                 RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                     vault_id: vault_id.clone(),
-                    amount: DEFAULT_BACKING_COLLATERAL,
+                    amount: Some(DEFAULT_BACKING_COLLATERAL),
                     index: None
                 })
                 .dispatch(origin_of(account_of(USER))),
@@ -302,7 +302,7 @@ mod spec_based_tests {
             assert_ok!(RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                 vault_id: vault_id.clone(),
                 index: None,
-                amount: 750000
+                amount: Some(750000)
             })
             .dispatch(origin_of(account_of(VAULT))));
             assert_nomination_opt_in(&vault_id);
@@ -510,7 +510,7 @@ fn integration_test_nominator_withdrawal_below_collateralization_threshold_fails
         assert_ok!(RuntimeCall::Nomination(NominationCall::withdraw_collateral {
             vault_id: vault_id.clone(),
             index: None,
-            amount: 750000
+            amount: Some(750000)
         })
         .dispatch(origin_of(account_of(VAULT))));
         assert_nomination_opt_in(&vault_id);

--- a/parachain/runtime/runtime-tests/src/parachain/vault_registry.rs
+++ b/parachain/runtime/runtime-tests/src/parachain/vault_registry.rs
@@ -194,7 +194,7 @@ mod withdraw_collateral_test {
 
             assert_ok!(RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                 vault_id: vault_id.clone(),
-                amount: amount.amount(),
+                amount: Some(amount.amount()),
                 index: None,
             })
             .dispatch(origin_of(account_of(VAULT))));
@@ -218,7 +218,7 @@ mod withdraw_collateral_test {
             assert_ok!(RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                 vault_id: vault_id.clone(),
                 index: None,
-                amount: amount.amount()
+                amount: Some(amount.amount())
             })
             .dispatch(origin_of(account_of(VAULT))));
 
@@ -244,7 +244,7 @@ mod withdraw_collateral_test {
                 RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                     vault_id: vault_id.clone(),
                     index: None,
-                    amount: amount
+                    amount: Some(amount)
                 })
                 .dispatch(origin_of(account_of(VAULT))),
                 NominationError::CannotWithdrawCollateral
@@ -270,7 +270,7 @@ mod withdraw_collateral_test {
                 RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                     vault_id: vault_id.clone(),
                     index: None,
-                    amount: amount.amount()
+                    amount: Some(amount.amount())
                 })
                 .dispatch(origin_of(account_of(VAULT))),
                 NominationError::CannotWithdrawCollateral
@@ -287,7 +287,7 @@ mod withdraw_collateral_test {
             assert_ok!(RuntimeCall::Nomination(NominationCall::withdraw_collateral {
                 vault_id: vault_id.clone(),
                 index: None,
-                amount: amount.amount()
+                amount: Some(amount.amount())
             })
             .dispatch(origin_of(account_of(VAULT))));
 

--- a/parachain/runtime/runtime-tests/src/utils/nomination_utils.rs
+++ b/parachain/runtime/runtime-tests/src/utils/nomination_utils.rs
@@ -78,7 +78,7 @@ pub fn withdraw_vault_collateral(vault_id: &VaultId, amount_collateral: Amount<R
     RuntimeCall::Nomination(NominationCall::withdraw_collateral {
         vault_id: vault_id.clone(),
         index: None,
-        amount: amount_collateral.amount(),
+        amount: Some(amount_collateral.amount()),
     })
     .dispatch(origin_of(vault_id.account_id.clone()))
 }
@@ -90,7 +90,7 @@ pub fn withdraw_nominator_collateral(
 ) -> DispatchResultWithPostInfo {
     RuntimeCall::Nomination(NominationCall::withdraw_collateral {
         vault_id: vault_id.clone(),
-        amount: amount_collateral.amount(),
+        amount: Some(amount_collateral.amount()),
         index: None,
     })
     .dispatch(origin_of(nominator_id))


### PR DESCRIPTION
Hacky fix to allow Vaults to withdraw all collateral since #974 unintentionally introduced a bug that prevents this. Specifically, due to a loss in precision the calculation in `withdraw_stake` (`apply_slash`) may produce a smaller amount than `TotalCurrentStake` which results in the `InsufficientFunds` error.