### PR TITLE
refactor: bound reward currencies

### DIFF
--- a/crates/farming/src/mock.rs
+++ b/crates/farming/src/mock.rs
@@ -105,6 +105,7 @@ impl reward::Config for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 parameter_types! {

--- a/crates/fee/src/mock.rs
+++ b/crates/fee/src/mock.rs
@@ -123,6 +123,7 @@ impl reward::Config<CapacityRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultRewardsInstance = reward::Instance2;
@@ -135,6 +136,7 @@ impl reward::Config<VaultRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 impl staking::Config for Test {

--- a/crates/issue/src/mock.rs
+++ b/crates/issue/src/mock.rs
@@ -134,6 +134,7 @@ impl reward::Config<CapacityRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultRewardsInstance = reward::Instance2;
@@ -146,6 +147,7 @@ impl reward::Config<VaultRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 impl staking::Config for Test {

--- a/crates/nomination/src/mock.rs
+++ b/crates/nomination/src/mock.rs
@@ -138,6 +138,7 @@ impl reward::Config<CapacityRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultRewardsInstance = reward::Instance2;
@@ -150,6 +151,7 @@ impl reward::Config<VaultRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 impl staking::Config for Test {

--- a/crates/redeem/src/mock.rs
+++ b/crates/redeem/src/mock.rs
@@ -193,6 +193,7 @@ impl reward::Config<CapacityRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultRewardsInstance = reward::Instance2;
@@ -205,6 +206,7 @@ impl reward::Config<VaultRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 impl staking::Config for Test {

--- a/crates/replace/src/mock.rs
+++ b/crates/replace/src/mock.rs
@@ -134,6 +134,7 @@ impl reward::Config<CapacityRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultRewardsInstance = reward::Instance2;
@@ -146,6 +147,7 @@ impl reward::Config<VaultRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 impl staking::Config for Test {

--- a/crates/reward/src/lib.rs
+++ b/crates/reward/src/lib.rs
@@ -26,7 +26,7 @@ use sp_runtime::{
     traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, MaybeSerializeDeserialize, Saturating, Zero},
     ArithmeticError,
 };
-use sp_std::{cmp::PartialOrd, collections::btree_set::BTreeSet, convert::TryInto, fmt::Debug};
+use sp_std::{cmp::PartialOrd, convert::TryInto, fmt::Debug};
 
 pub(crate) type SignedFixedPoint<T, I = ()> = <T as Config<I>>::SignedFixedPoint;
 
@@ -35,7 +35,7 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
-    use frame_support::pallet_prelude::*;
+    use frame_support::{pallet_prelude::*, BoundedBTreeSet};
 
     /// ## Configuration
     /// The pallet's configuration trait.
@@ -61,6 +61,10 @@ pub mod pallet {
 
         #[pallet::constant]
         type GetWrappedCurrencyId: Get<Self::CurrencyId>;
+
+        /// The maximum number of reward currencies.
+        #[pallet::constant]
+        type MaxRewardCurrencies: Get<u32>;
     }
 
     // The pallet's events
@@ -97,21 +101,12 @@ pub mod pallet {
         InsufficientFunds,
         /// Cannot distribute rewards without stake.
         ZeroTotalStake,
+        /// Maximum rewards currencies reached.
+        MaxRewardCurrencies,
     }
 
     #[pallet::hooks]
-    impl<T: Config<I>, I: 'static> Hooks<T::BlockNumber> for Pallet<T, I> {
-        fn on_runtime_upgrade() -> Weight {
-            RewardPerToken::<T, I>::iter_keys().for_each(|(_currency_id, pool_id)| {
-                RewardCurrencies::<T, I>::mutate(pool_id, |reward_currencies| {
-                    reward_currencies.insert(T::GetNativeCurrencyId::get());
-                    reward_currencies.insert(T::GetWrappedCurrencyId::get());
-                });
-            });
-
-            Weight::zero()
-        }
-    }
+    impl<T: Config<I>, I: 'static> Hooks<T::BlockNumber> for Pallet<T, I> {}
 
     /// The total stake deposited to this reward pool.
     #[pallet::storage]
@@ -159,7 +154,7 @@ pub mod pallet {
     /// Track the currencies used for rewards.
     #[pallet::storage]
     pub type RewardCurrencies<T: Config<I>, I: 'static = ()> =
-        StorageMap<_, Blake2_128Concat, T::PoolId, BTreeSet<T::CurrencyId>, ValueQuery>;
+        StorageMap<_, Blake2_128Concat, T::PoolId, BoundedBTreeSet<T::CurrencyId, T::MaxRewardCurrencies>, ValueQuery>;
 
     #[pallet::pallet]
     #[pallet::without_storage_info]
@@ -215,23 +210,6 @@ macro_rules! checked_sub_mut {
 
 // "Internal" functions, callable by code.
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
-    // TODO: remove this after the migration, I have added
-    // this because it's not clear whether the capacity migration
-    // will run before or after the pallet hook and we need to make
-    // sure these are included for any deposits / withdrawals
-    fn add_default_currencies(pool_id: &T::PoolId) {
-        let reward_currencies = RewardCurrencies::<T, I>::get(pool_id);
-        if reward_currencies.contains(&T::GetNativeCurrencyId::get())
-            && reward_currencies.contains(&T::GetWrappedCurrencyId::get())
-        {
-            return;
-        }
-        RewardCurrencies::<T, I>::mutate(pool_id, |reward_currencies| {
-            reward_currencies.insert(T::GetNativeCurrencyId::get());
-            reward_currencies.insert(T::GetWrappedCurrencyId::get());
-        });
-    }
-
     pub fn stake(pool_id: &T::PoolId, stake_id: &T::StakeId) -> SignedFixedPoint<T, I> {
         Stake::<T, I>::get((pool_id, stake_id))
     }
@@ -252,7 +230,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         checked_add_mut!(Stake<T, I>, (pool_id, stake_id), &amount);
         checked_add_mut!(TotalStake<T, I>, pool_id, &amount);
 
-        Self::add_default_currencies(pool_id);
         for currency_id in RewardCurrencies::<T, I>::get(pool_id) {
             <RewardTally<T, I>>::mutate(currency_id, (pool_id, stake_id), |reward_tally| {
                 let reward_per_token = Self::reward_per_token(currency_id, pool_id);
@@ -286,9 +263,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         ensure!(!total_stake.is_zero(), Error::<T, I>::ZeroTotalStake);
 
         // track currency for future deposits / withdrawals
-        RewardCurrencies::<T, I>::mutate(pool_id, |reward_currencies| {
-            reward_currencies.insert(currency_id);
-        });
+        RewardCurrencies::<T, I>::try_mutate(pool_id, |reward_currencies| {
+            reward_currencies
+                .try_insert(currency_id)
+                .map_err(|_| Error::<T, I>::MaxRewardCurrencies)
+        })?;
 
         let reward_div_total_stake = reward.checked_div(&total_stake).ok_or(ArithmeticError::Underflow)?;
         checked_add_mut!(RewardPerToken<T, I>, currency_id, pool_id, &reward_div_total_stake);
@@ -332,7 +311,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
         checked_sub_mut!(Stake<T, I>, (pool_id, stake_id), &amount);
         checked_sub_mut!(TotalStake<T, I>, pool_id, &amount);
 
-        Self::add_default_currencies(pool_id);
         for currency_id in RewardCurrencies::<T, I>::get(pool_id) {
             <RewardTally<T, I>>::mutate(currency_id, (pool_id, stake_id), |reward_tally| {
                 let reward_per_token = Self::reward_per_token(currency_id, pool_id);

--- a/crates/reward/src/migration.rs
+++ b/crates/reward/src/migration.rs
@@ -151,6 +151,39 @@ pub mod v1 {
     }
 }
 
+pub mod bound {
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use sp_std::collections::btree_set::BTreeSet;
+
+    #[frame_support::storage_alias]
+    pub type RewardCurrencies<T: Config<I>, I: 'static> = StorageMap<
+        Pallet<T, I>,
+        Blake2_128Concat,
+        <T as Config<I>>::PoolId,
+        BTreeSet<<T as Config<I>>::CurrencyId>,
+        ValueQuery,
+    >;
+
+    #[cfg(test)]
+    #[test]
+    fn test_decode_bounded_b_tree_set() {
+        use crate::mock::*;
+
+        crate::mock::run_test(|| {
+            let mut reward_currencies_before = BTreeSet::default();
+            reward_currencies_before.insert(Token(IBTC));
+            reward_currencies_before.insert(Token(INTR));
+            RewardCurrencies::<Test, ()>::insert((), reward_currencies_before);
+
+            let reward_currencies_after = crate::RewardCurrencies::<Test>::get(());
+            assert_eq!(reward_currencies_after.len(), 2);
+            assert!(reward_currencies_after.contains(&Token(IBTC)));
+            assert!(reward_currencies_after.contains(&Token(INTR)));
+        });
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "try-runtime")]
 mod test {

--- a/crates/reward/src/mock.rs
+++ b/crates/reward/src/mock.rs
@@ -1,6 +1,9 @@
 use crate as reward;
 use crate::{Config, Error};
-use frame_support::{parameter_types, traits::Everything};
+use frame_support::{
+    parameter_types,
+    traits::{ConstU32, Everything},
+};
 pub use primitives::{
     CurrencyId,
     CurrencyId::{ForeignAsset, Token},
@@ -63,7 +66,7 @@ impl frame_system::Config for Test {
     type SystemWeightInfo = ();
     type SS58Prefix = SS58Prefix;
     type OnSetCode = ();
-    type MaxConsumers = frame_support::traits::ConstU32<16>;
+    type MaxConsumers = ConstU32<16>;
 }
 
 parameter_types! {
@@ -79,6 +82,7 @@ impl Config for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 pub type TestError = Error<Test>;

--- a/crates/vault-registry/src/mock.rs
+++ b/crates/vault-registry/src/mock.rs
@@ -146,6 +146,7 @@ impl reward::Config<CapacityRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 pub(crate) type VaultRewardsInstance = reward::Instance2;
@@ -158,6 +159,7 @@ impl reward::Config<VaultRewardsInstance> for Test {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 impl staking::Config for Test {

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -877,6 +877,7 @@ impl reward::Config<EscrowRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultRewardsInstance = reward::Instance2;
@@ -889,6 +890,7 @@ impl reward::Config<VaultRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultCapacityInstance = reward::Instance3;
@@ -901,6 +903,7 @@ impl reward::Config<VaultCapacityInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 impl security::Config for Runtime {

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -889,6 +889,7 @@ impl reward::Config<EscrowRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultRewardsInstance = reward::Instance2;
@@ -901,6 +902,7 @@ impl reward::Config<VaultRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultCapacityInstance = reward::Instance3;
@@ -913,6 +915,7 @@ impl reward::Config<VaultCapacityInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type FarmingRewardsInstance = reward::Instance4;
@@ -925,6 +928,7 @@ impl reward::Config<FarmingRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 parameter_types! {

--- a/parachain/runtime/testnet-interlay/src/lib.rs
+++ b/parachain/runtime/testnet-interlay/src/lib.rs
@@ -861,6 +861,7 @@ impl reward::Config<EscrowRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultRewardsInstance = reward::Instance2;
@@ -873,6 +874,7 @@ impl reward::Config<VaultRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultCapacityInstance = reward::Instance3;
@@ -885,6 +887,7 @@ impl reward::Config<VaultCapacityInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type FarmingRewardsInstance = reward::Instance4;
@@ -897,6 +900,7 @@ impl reward::Config<FarmingRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 parameter_types! {

--- a/parachain/runtime/testnet-kintsugi/src/lib.rs
+++ b/parachain/runtime/testnet-kintsugi/src/lib.rs
@@ -859,6 +859,7 @@ impl reward::Config<EscrowRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultRewardsInstance = reward::Instance2;
@@ -871,6 +872,7 @@ impl reward::Config<VaultRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type VaultCapacityInstance = reward::Instance3;
@@ -883,6 +885,7 @@ impl reward::Config<VaultCapacityInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type FarmingRewardsInstance = reward::Instance4;
@@ -895,6 +898,7 @@ impl reward::Config<FarmingRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 parameter_types! {

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -785,6 +785,7 @@ impl reward::Config<EscrowRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 pub type VaultRewardsInstance = reward::Instance2;
@@ -797,6 +798,7 @@ impl reward::Config<VaultRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 pub type VaultCapacityInstance = reward::Instance3;
@@ -809,6 +811,7 @@ impl reward::Config<VaultCapacityInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 type FarmingRewardsInstance = reward::Instance4;
@@ -821,6 +824,7 @@ impl reward::Config<FarmingRewardsInstance> for Runtime {
     type CurrencyId = CurrencyId;
     type GetNativeCurrencyId = GetNativeCurrencyId;
     type GetWrappedCurrencyId = GetWrappedCurrencyId;
+    type MaxRewardCurrencies = ConstU32<10>;
 }
 
 parameter_types! {


### PR DESCRIPTION
Prevents this from endlessly growing, in benchmarking we should consider the max for the worst-case.