### PR TITLE
feat(dex-general): use BoundedBTreeMap

### DIFF
--- a/crates/dex-general/src/fee/mock.rs
+++ b/crates/dex-general/src/fee/mock.rs
@@ -155,7 +155,8 @@ impl Config for Test {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = ConstU16<10>;
-    type MaxMapItems = ConstU32<1000>;
+    type MaxBootstrapRewards = ConstU32<1000>;
+    type MaxBootstrapLimits = ConstU32<1000>;
 }
 
 pub struct ExtBuilder;

--- a/crates/dex-general/src/fee/mock.rs
+++ b/crates/dex-general/src/fee/mock.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use frame_support::{parameter_types, traits::Contains, PalletId};
 use orml_traits::parameter_type_with_key;
-use sp_core::{ConstU16, H256};
+use sp_core::{ConstU16, ConstU32, H256};
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
@@ -155,6 +155,7 @@ impl Config for Test {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = ConstU16<10>;
+    type MaxMapItems = ConstU32<1000>;
 }
 
 pub struct ExtBuilder;

--- a/crates/dex-general/src/lib.rs
+++ b/crates/dex-general/src/lib.rs
@@ -88,7 +88,7 @@ pub mod pallet {
         #[pallet::constant]
         type MaxSwaps: Get<u16>;
 
-        /// The maximum number of swaps allowed in routes
+        /// The maximum number of items allowed in a bounded map
         #[pallet::constant]
         type MaxMapItems: Get<u32>;
     }

--- a/crates/dex-general/src/lib.rs
+++ b/crates/dex-general/src/lib.rs
@@ -21,9 +21,11 @@
 pub use pallet::*;
 
 use codec::{Decode, Encode, FullCodec};
-use frame_support::{inherent::Vec, pallet_prelude::*, traits::Get, PalletId, RuntimeDebug};
+use frame_support::{
+    inherent::Vec, pallet_prelude::*, storage::bounded_btree_map::BoundedBTreeMap, traits::Get, PalletId, RuntimeDebug,
+};
 use orml_traits::MultiCurrency;
-use sp_core::U256;
+use sp_core::{ConstU16, U256};
 use sp_runtime::traits::{AccountIdConversion, Hash, MaybeSerializeDeserialize, One, StaticLookup, Zero};
 use sp_std::{collections::btree_map::BTreeMap, convert::TryInto, fmt::Debug, prelude::*, vec};
 
@@ -85,6 +87,10 @@ pub mod pallet {
         /// The maximum number of swaps allowed in routes
         #[pallet::constant]
         type MaxSwaps: Get<u16>;
+
+        /// The maximum number of swaps allowed in routes
+        #[pallet::constant]
+        type MaxMapItems: Get<u32>;
     }
 
     #[pallet::pallet]
@@ -143,13 +149,23 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn get_bootstrap_rewards)]
-    pub type BootstrapRewards<T: Config> =
-        StorageMap<_, Twox64Concat, (T::AssetId, T::AssetId), BTreeMap<T::AssetId, AssetBalance>, ValueQuery>;
+    pub type BootstrapRewards<T: Config> = StorageMap<
+        _,
+        Twox64Concat,
+        (T::AssetId, T::AssetId),
+        BoundedBTreeMap<T::AssetId, AssetBalance, T::MaxMapItems>,
+        ValueQuery,
+    >;
 
     #[pallet::storage]
     #[pallet::getter(fn get_bootstrap_limits)]
-    pub type BootstrapLimits<T: Config> =
-        StorageMap<_, Twox64Concat, (T::AssetId, T::AssetId), BTreeMap<T::AssetId, AssetBalance>, ValueQuery>;
+    pub type BootstrapLimits<T: Config> = StorageMap<
+        _,
+        Twox64Concat,
+        (T::AssetId, T::AssetId),
+        BoundedBTreeMap<T::AssetId, AssetBalance, T::MaxMapItems>,
+        ValueQuery,
+    >;
 
     #[pallet::genesis_config]
     /// Refer: https://github.com/Uniswap/uniswap-v2-core/blob/master/contracts/UniswapV2Pair.sol#L88
@@ -362,6 +378,8 @@ pub mod pallet {
         ChargeRewardParamsError,
         /// Exist some reward in bootstrap,
         ExistRewardsInBootstrap,
+        /// Failed to create bounded map
+        BoundedBTreeMapCreationFailed,
     }
 
     #[pallet::hooks]
@@ -735,15 +753,21 @@ pub mod pallet {
 
                         BootstrapRewards::<T>::insert(
                             pair,
-                            rewards
-                                .into_iter()
-                                .map(|asset_id| (asset_id, Zero::zero()))
-                                .collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                            BoundedBTreeMap::<T::AssetId, AssetBalance, T::MaxMapItems>::try_from(
+                                rewards
+                                    .into_iter()
+                                    .map(|asset_id| (asset_id, Zero::zero()))
+                                    .collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                            )
+                            .map_err(|_| Error::<T>::BoundedBTreeMapCreationFailed)?,
                         );
 
                         BootstrapLimits::<T>::insert(
                             pair,
-                            limits.into_iter().collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                            BoundedBTreeMap::<T::AssetId, AssetBalance, T::MaxMapItems>::try_from(
+                                limits.into_iter().collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                            )
+                            .map_err(|_| Error::<T>::BoundedBTreeMapCreationFailed)?,
                         );
 
                         Ok(())
@@ -762,15 +786,21 @@ pub mod pallet {
 
                     BootstrapRewards::<T>::insert(
                         pair,
-                        rewards
-                            .into_iter()
-                            .map(|asset_id| (asset_id, Zero::zero()))
-                            .collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                        BoundedBTreeMap::<T::AssetId, AssetBalance, T::MaxMapItems>::try_from(
+                            rewards
+                                .into_iter()
+                                .map(|asset_id| (asset_id, Zero::zero()))
+                                .collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                        )
+                        .map_err(|_| Error::<T>::BoundedBTreeMapCreationFailed)?,
                     );
 
                     BootstrapLimits::<T>::insert(
                         pair,
-                        limits.into_iter().collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                        BoundedBTreeMap::<T::AssetId, AssetBalance, T::MaxMapItems>::try_from(
+                            limits.into_iter().collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                        )
+                        .map_err(|_| Error::<T>::BoundedBTreeMapCreationFailed)?,
                     );
 
                     Ok(())
@@ -925,15 +955,21 @@ pub mod pallet {
 
                     BootstrapRewards::<T>::insert(
                         pair,
-                        rewards
-                            .into_iter()
-                            .map(|asset_id| (asset_id, Zero::zero()))
-                            .collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                        BoundedBTreeMap::<T::AssetId, AssetBalance, T::MaxMapItems>::try_from(
+                            rewards
+                                .into_iter()
+                                .map(|asset_id| (asset_id, Zero::zero()))
+                                .collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                        )
+                        .map_err(|_| Error::<T>::BoundedBTreeMapCreationFailed)?,
                     );
 
                     BootstrapLimits::<T>::insert(
                         pair,
-                        limits.into_iter().collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                        BoundedBTreeMap::<T::AssetId, AssetBalance, T::MaxMapItems>::try_from(
+                            limits.into_iter().collect::<BTreeMap<T::AssetId, AssetBalance>>(),
+                        )
+                        .map_err(|_| Error::<T>::BoundedBTreeMapCreationFailed)?,
                     );
 
                     Ok(())
@@ -996,7 +1032,9 @@ pub mod pallet {
                     T::MultiCurrency::transfer(*asset_id, &who, &Self::account_id(), *amount)?;
                     let new_charge_amount = already_charge_amount.checked_add(*amount).ok_or(Error::<T>::Overflow)?;
 
-                    rewards.insert(*asset_id, new_charge_amount);
+                    rewards
+                        .try_insert(*asset_id, new_charge_amount)
+                        .map_err(|_| Error::<T>::BoundedBTreeMapCreationFailed)?;
                 }
 
                 Self::deposit_event(Event::ChargeReward(pair.0, pair.1, who, charge_rewards));

--- a/crates/dex-general/src/swap/mock.rs
+++ b/crates/dex-general/src/swap/mock.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use frame_support::{parameter_types, traits::Contains, PalletId};
 use orml_traits::parameter_type_with_key;
-use sp_core::{ConstU16, H256};
+use sp_core::{ConstU16, ConstU32, H256};
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
@@ -142,6 +142,7 @@ impl Config for Test {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = ConstU16<10>;
+    type MaxMapItems = ConstU32<1000>;
 }
 
 pub type DexPallet = Pallet<Test>;

--- a/crates/dex-general/src/swap/mock.rs
+++ b/crates/dex-general/src/swap/mock.rs
@@ -142,7 +142,8 @@ impl Config for Test {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = ConstU16<10>;
-    type MaxMapItems = ConstU32<1000>;
+    type MaxBootstrapRewards = ConstU32<1000>;
+    type MaxBootstrapLimits = ConstU32<1000>;
 }
 
 pub type DexPallet = Pallet<Test>;

--- a/crates/dex-swap-router/src/mock.rs
+++ b/crates/dex-swap-router/src/mock.rs
@@ -192,12 +192,14 @@ impl dex_general::Config for Test {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = MaxSwaps;
-    type MaxMapItems = MaxMapItems;
+    type MaxBootstrapRewards = MaxBootstrapRewards;
+    type MaxBootstrapLimits = MaxBootstrapLimits;
 }
 
 parameter_types! {
     pub const MaxSwaps: u16 = 10;
-    pub const MaxMapItems: u16 = 1000;
+    pub const MaxBootstrapRewards: u32 = 1000;
+    pub const MaxBootstrapLimits:u32 = 1000;
 }
 
 impl Config for Test {

--- a/crates/dex-swap-router/src/mock.rs
+++ b/crates/dex-swap-router/src/mock.rs
@@ -192,10 +192,12 @@ impl dex_general::Config for Test {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = MaxSwaps;
+    type MaxMapItems = MaxMapItems;
 }
 
 parameter_types! {
     pub const MaxSwaps: u16 = 10;
+    pub const MaxMapItems: u16 = 1000;
 }
 
 impl Config for Test {

--- a/parachain/runtime/kintsugi/src/dex.rs
+++ b/parachain/runtime/kintsugi/src/dex.rs
@@ -13,6 +13,7 @@ parameter_types! {
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stbl");
     pub const StringLimit: u32 = 50;
     pub const MaxSwaps:u16 = 4;
+    pub const MaxMapItems: u16 = 1000;
 }
 
 pub struct PairLpIdentity;
@@ -30,6 +31,7 @@ impl dex_general::Config for Runtime {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = MaxSwaps;
+    type MaxMapItems = MaxMapItems;
 }
 
 pub struct PoolLpGenerate;

--- a/parachain/runtime/kintsugi/src/dex.rs
+++ b/parachain/runtime/kintsugi/src/dex.rs
@@ -3,7 +3,6 @@ use super::{
     Timestamp, Tokens,
 };
 use frame_support::traits::OnRuntimeUpgrade;
-use sp_core::ConstU16;
 
 pub use dex_general::{AssetBalance, GenerateLpAssetId, PairInfo};
 pub use dex_stable::traits::{StablePoolLpCurrencyIdGenerate, ValidateCurrency};
@@ -13,7 +12,8 @@ parameter_types! {
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stbl");
     pub const StringLimit: u32 = 50;
     pub const MaxSwaps:u16 = 4;
-    pub const MaxMapItems: u16 = 1000;
+    pub const MaxBootstrapRewards: u32 = 1000;
+    pub const MaxBootstrapLimits:u32 = 1000;
 }
 
 pub struct PairLpIdentity;
@@ -31,7 +31,8 @@ impl dex_general::Config for Runtime {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = MaxSwaps;
-    type MaxMapItems = MaxMapItems;
+    type MaxBootstrapRewards = MaxBootstrapRewards;
+    type MaxBootstrapLimits = MaxBootstrapLimits;
 }
 
 pub struct PoolLpGenerate;

--- a/parachain/runtime/testnet-interlay/src/dex.rs
+++ b/parachain/runtime/testnet-interlay/src/dex.rs
@@ -5,14 +5,14 @@ use super::{
 
 pub use dex_general::{AssetBalance, GenerateLpAssetId, PairInfo};
 pub use dex_stable::traits::{StablePoolLpCurrencyIdGenerate, ValidateCurrency};
-use sp_core::ConstU16;
 
 parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stab");
     pub const StringLimit: u32 = 50;
     pub const MaxSwaps:u16 = 4;
-    pub const MaxMapItems: u16 = 1000;
+    pub const MaxBootstrapRewards: u32 = 1000;
+    pub const MaxBootstrapLimits:u32 = 1000;
 }
 
 pub struct PairLpIdentity;
@@ -30,7 +30,8 @@ impl dex_general::Config for Runtime {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = MaxSwaps;
-    type MaxMapItems = MaxMapItems;
+    type MaxBootstrapRewards = MaxBootstrapRewards;
+    type MaxBootstrapLimits = MaxBootstrapLimits;
 }
 
 pub struct PoolLpGenerate;

--- a/parachain/runtime/testnet-interlay/src/dex.rs
+++ b/parachain/runtime/testnet-interlay/src/dex.rs
@@ -12,6 +12,7 @@ parameter_types! {
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stab");
     pub const StringLimit: u32 = 50;
     pub const MaxSwaps:u16 = 4;
+    pub const MaxMapItems: u16 = 1000;
 }
 
 pub struct PairLpIdentity;
@@ -29,6 +30,7 @@ impl dex_general::Config for Runtime {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = MaxSwaps;
+    type MaxMapItems = MaxMapItems;
 }
 
 pub struct PoolLpGenerate;

--- a/parachain/runtime/testnet-kintsugi/src/dex.rs
+++ b/parachain/runtime/testnet-kintsugi/src/dex.rs
@@ -5,14 +5,14 @@ use super::{
 
 pub use dex_general::{AssetBalance, GenerateLpAssetId, PairInfo};
 pub use dex_stable::traits::{StablePoolLpCurrencyIdGenerate, ValidateCurrency};
-use sp_core::ConstU16;
 
 parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stbl");
     pub const StringLimit: u32 = 50;
     pub const MaxSwaps:u16 = 4;
-    pub const MaxMapItems: u16 = 1000;
+    pub const MaxBootstrapRewards: u32 = 1000;
+    pub const MaxBootstrapLimits:u32 = 1000;
 }
 
 pub struct PairLpIdentity;
@@ -30,7 +30,8 @@ impl dex_general::Config for Runtime {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = MaxSwaps;
-    type MaxMapItems = MaxMapItems;
+    type MaxBootstrapRewards = MaxBootstrapRewards;
+    type MaxBootstrapLimits = MaxBootstrapLimits;
 }
 
 pub struct PoolLpGenerate;

--- a/parachain/runtime/testnet-kintsugi/src/dex.rs
+++ b/parachain/runtime/testnet-kintsugi/src/dex.rs
@@ -12,6 +12,7 @@ parameter_types! {
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stbl");
     pub const StringLimit: u32 = 50;
     pub const MaxSwaps:u16 = 4;
+    pub const MaxMapItems: u16 = 1000;
 }
 
 pub struct PairLpIdentity;
@@ -29,6 +30,7 @@ impl dex_general::Config for Runtime {
     type LpGenerate = PairLpIdentity;
     type WeightInfo = ();
     type MaxSwaps = MaxSwaps;
+    type MaxMapItems = MaxMapItems;
 }
 
 pub struct PoolLpGenerate;


### PR DESCRIPTION
- Replaces usage of `BTreeMap` with `BoundedBTreeMap`
- Adds `MaxBootstrapRewards` and `MaxBootstrapLimits` config items as map upper bounds, and sets each to `1000` in the runtimes