### PR TITLE
Loans toggle migration

### DIFF
--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -61,6 +61,7 @@ pub use types::{BorrowSnapshot, EarnedSnapshot, Market, MarketState, RewardMarke
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+pub mod migration;
 
 #[cfg(test)]
 mod mock;

--- a/crates/loans/src/lib.rs
+++ b/crates/loans/src/lib.rs
@@ -437,10 +437,6 @@ pub mod pallet {
 
     #[pallet::hooks]
     impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
-        fn on_runtime_upgrade() -> frame_support::weights::Weight {
-            migration::collateral_toggle::Migration::<T>::on_runtime_upgrade()
-        }
-
         #[cfg(feature = "try-runtime")]
         fn post_upgrade(pre_upgrade_state: sp_std::vec::Vec<u8>) -> Result<(), &'static str> {
             frame_support::assert_ok!(migration::collateral_toggle::Migration::<T>::post_upgrade(

--- a/crates/loans/src/migration.rs
+++ b/crates/loans/src/migration.rs
@@ -1,31 +1,53 @@
 use super::*;
-use frame_support::{pallet_prelude::StorageVersion, traits::OnRuntimeUpgrade};
+use frame_support::traits::OnRuntimeUpgrade;
 
 // #[cfg(feature = "try-runtime")]
 use sp_std::{vec, vec::Vec};
+
+use currency::Amount;
 
 /// The log target.
 const TARGET: &'static str = "runtime::loans::migration";
 
 pub mod collateral_toggle {
     use super::*;
-    use frame_support::pallet_prelude::*;
 
-    type SignedFixedPoint<T> = <T as currency::Config>::SignedFixedPoint;
+    struct InconsistentBalance<T>
+    where
+        T: Config,
+    {
+        currency_id: CurrencyId<T>,
+        account_id: T::AccountId,
+        free_balance: BalanceOf<T>,
+    }
 
-    fn get_inconsistent_lend_token_balances<T: Config>() -> Vec<(CurrencyId<T>, T::AccountId, BalanceOf<T>)> {
+    fn get_inconsistent_lend_token_balances<T: Config>() -> (Vec<InconsistentBalance<T>>, u64) {
         // Iterating `AccountDeposits` should guarantee there are no other
-        let num_vaults = crate::AccountDeposits::<T>::iter()
-            .filter(|(currency_id, account_id, _collateral)| {
-                // Assumes the default is zero
-                let free_tokens =
-                    Pallet::<T>::free_lend_tokens(*currency_id, account_id).unwrap_or(Amount::<T>::zero(*currency_id));
-                let reserved_tokens = Pallet::<T>::reserved_lend_tokens(*currency_id, account_id)
-                    .unwrap_or(Amount::<T>::zero(*currency_id));
-                !free_tokens.is_zero() && !reserved_tokens.is_zero()
+        let mut reads = 0;
+        let inconsistent_balances = crate::AccountDeposits::<T>::iter()
+            .filter_map(|(currency_id, account_id, _collateral)| {
+                reads += 1;
+                let free_balance = Amount::<T>::new(
+                    orml_tokens::Pallet::<T>::free_balance(currency_id.clone(), &account_id),
+                    currency_id.clone(),
+                );
+
+                let reserved_balance = Amount::<T>::new(
+                    orml_tokens::Pallet::<T>::reserved_balance(currency_id.clone(), &account_id),
+                    currency_id.clone(),
+                );
+
+                if !free_balance.is_zero() && !reserved_balance.is_zero() {
+                    return Some(InconsistentBalance {
+                        currency_id: currency_id.clone(),
+                        account_id: account_id.clone(),
+                        free_balance: free_balance.amount(),
+                    });
+                }
+                None
             })
             .collect();
-        num_vaults
+        (inconsistent_balances, reads)
     }
 
     pub struct Migration<T>(sp_std::marker::PhantomData<T>);
@@ -33,36 +55,54 @@ pub mod collateral_toggle {
     impl<T: Config> OnRuntimeUpgrade for Migration<T> {
         #[cfg(feature = "try-runtime")]
         fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
-            let inconsistent_balances = get_inconsistent_lend_token_balances::<T>();
+            let (inconsistent_balances, _) = get_inconsistent_lend_token_balances::<T>();
+            ensure!(
+                inconsistent_balances.len() > 0,
+                "There are no inconsistent balances to migrate"
+            );
             log::info!(
                 target: TARGET,
-                "{} non-zero stake entries will be migrated",
+                "{} inconsistent lending collateral balances will be migrated",
                 inconsistent_balances.len()
             );
             Ok(vec![])
         }
 
         fn on_runtime_upgrade() -> Weight {
-            let mut reads = 0;
             let mut writes = 0;
-            let inconsistent_balances = get_inconsistent_lend_token_balances::<T>();
-
-            log::info!(
-                target: TARGET,
-                "{} non-zero stake entries will be migrated",
-                inconsistent_balances.len()
-            );
-
-            log::info!(
-                "{} non-zero stake entries will be migrated",
-                inconsistent_balances.len()
-            );
-            T::DbWeight::get().reads_writes(reads, reads * 2)
+            let (inconsistent_balances, mut reads) = get_inconsistent_lend_token_balances::<T>();
+            for b in inconsistent_balances {
+                reads += 1;
+                match Pallet::<T>::lock_if_account_deposited(&b.account_id, &Amount::new(b.free_balance, b.currency_id))
+                {
+                    Err(e) => log::warn!(
+                        target: TARGET,
+                        "Failed to lock collateral for account {:?}, collateral: {:?}. Error: {:?}",
+                        b.account_id,
+                        b.currency_id,
+                        e
+                    ),
+                    Ok(_) => {
+                        writes += 1;
+                        log::info!(
+                            target: TARGET,
+                            "Locked all free collateral for {:?}, in {:?}",
+                            b.account_id,
+                            b.currency_id,
+                        );
+                    }
+                }
+            }
+            T::DbWeight::get().reads_writes(reads, writes)
         }
 
         #[cfg(feature = "try-runtime")]
-        fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
-            let inconsistent_balances = get_inconsistent_lend_token_balances::<T>();
+        fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
+            let (inconsistent_balances, _) = get_inconsistent_lend_token_balances::<T>();
+            ensure!(
+                inconsistent_balances.len() == 0,
+                "There should be no inconsistent lending collateral balances left"
+            );
             Ok(())
         }
     }
@@ -72,6 +112,37 @@ pub mod collateral_toggle {
 #[cfg(feature = "try-runtime")]
 mod test {
     use super::*;
-    use crate::mock::*;
-    use frame_support::assert_ok;
+    use crate::{
+        mock::*,
+        tests::lend_tokens::{free_balance, reserved_balance},
+    };
+    use frame_support::{assert_err, assert_ok};
+
+    use primitives::{
+        CurrencyId::{self, Token},
+        KINT as KINT_CURRENCY,
+    };
+
+    const KINT: CurrencyId = Token(KINT_CURRENCY);
+
+    #[test]
+    fn inconsistent_balances_migration_works() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KINT, unit(100)));
+            assert_ok!(Loans::deposit_all_collateral(RuntimeOrigin::signed(DAVE), KINT));
+            assert_ok!(Loans::mint(RuntimeOrigin::signed(DAVE), KINT, unit(100)));
+            assert_err!(
+                Loans::deposit_all_collateral(RuntimeOrigin::signed(DAVE), KINT),
+                Error::<Test>::TokensAlreadyLocked
+            );
+            // Both `free` and `reserved` balances are nonzero at the same time,
+            // ẉhich is an invalid state
+            assert_eq!(free_balance(LEND_KINT, &DAVE), unit(100) * 50);
+            assert_eq!(reserved_balance(LEND_KINT, &DAVE), unit(100) * 50);
+
+            let state = collateral_toggle::Migration::<Test>::pre_upgrade().unwrap();
+            let _w = collateral_toggle::Migration::<Test>::on_runtime_upgrade();
+            collateral_toggle::Migration::<Test>::post_upgrade(state).unwrap();
+        });
+    }
 }

--- a/crates/loans/src/migration.rs
+++ b/crates/loans/src/migration.rs
@@ -1,0 +1,77 @@
+use super::*;
+use frame_support::{pallet_prelude::StorageVersion, traits::OnRuntimeUpgrade};
+
+// #[cfg(feature = "try-runtime")]
+use sp_std::{vec, vec::Vec};
+
+/// The log target.
+const TARGET: &'static str = "runtime::loans::migration";
+
+pub mod collateral_toggle {
+    use super::*;
+    use frame_support::pallet_prelude::*;
+
+    type SignedFixedPoint<T> = <T as currency::Config>::SignedFixedPoint;
+
+    fn get_inconsistent_lend_token_balances<T: Config>() -> Vec<(CurrencyId<T>, T::AccountId, BalanceOf<T>)> {
+        // Iterating `AccountDeposits` should guarantee there are no other
+        let num_vaults = crate::AccountDeposits::<T>::iter()
+            .filter(|(currency_id, account_id, _collateral)| {
+                // Assumes the default is zero
+                let free_tokens =
+                    Pallet::<T>::free_lend_tokens(*currency_id, account_id).unwrap_or(Amount::<T>::zero(*currency_id));
+                let reserved_tokens = Pallet::<T>::reserved_lend_tokens(*currency_id, account_id)
+                    .unwrap_or(Amount::<T>::zero(*currency_id));
+                !free_tokens.is_zero() && !reserved_tokens.is_zero()
+            })
+            .collect();
+        num_vaults
+    }
+
+    pub struct Migration<T>(sp_std::marker::PhantomData<T>);
+
+    impl<T: Config> OnRuntimeUpgrade for Migration<T> {
+        #[cfg(feature = "try-runtime")]
+        fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+            let inconsistent_balances = get_inconsistent_lend_token_balances::<T>();
+            log::info!(
+                target: TARGET,
+                "{} non-zero stake entries will be migrated",
+                inconsistent_balances.len()
+            );
+            Ok(vec![])
+        }
+
+        fn on_runtime_upgrade() -> Weight {
+            let mut reads = 0;
+            let mut writes = 0;
+            let inconsistent_balances = get_inconsistent_lend_token_balances::<T>();
+
+            log::info!(
+                target: TARGET,
+                "{} non-zero stake entries will be migrated",
+                inconsistent_balances.len()
+            );
+
+            log::info!(
+                "{} non-zero stake entries will be migrated",
+                inconsistent_balances.len()
+            );
+            T::DbWeight::get().reads_writes(reads, reads * 2)
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
+            let inconsistent_balances = get_inconsistent_lend_token_balances::<T>();
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "try-runtime")]
+mod test {
+    use super::*;
+    use crate::mock::*;
+    use frame_support::assert_ok;
+}

--- a/crates/loans/src/mock.rs
+++ b/crates/loans/src/mock.rs
@@ -135,6 +135,9 @@ impl orml_tokens::Config for Test {
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;
+    #[cfg(feature = "try-runtime")]
+    type CurrencyHooks = ();
+    #[cfg(not(feature = "try-runtime"))]
     type CurrencyHooks = CurrencyHooks<Test>;
     type MaxLocks = MaxLocks;
     type DustRemovalWhitelist = Everything;

--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -17,7 +17,7 @@
 
 mod edge_cases;
 mod interest_rate;
-mod lend_tokens;
+pub mod lend_tokens;
 mod liquidate_borrow;
 mod market;
 

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -661,6 +661,7 @@ parameter_type_with_key! {
     };
 }
 
+// TODO!: Set `OnSlash`, and Pre/Post hooks before the lending launch on interlay
 pub struct CurrencyHooks<T>(PhantomData<T>);
 impl<T: orml_tokens::Config> MutationHooks<T::AccountId, T::CurrencyId, T::Balance> for CurrencyHooks<T>
 where

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -23,6 +23,7 @@ use frame_system::{
     limits::{BlockLength, BlockWeights},
     EnsureRoot, RawOrigin,
 };
+use loans::{OnSlashHook, PostDeposit, PostTransfer, PreDeposit, PreTransfer};
 use orml_asset_registry::SequentialId;
 use orml_traits::{currency::MutationHooks, parameter_type_with_key};
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
@@ -673,7 +674,8 @@ parameter_type_with_key! {
 }
 
 pub struct CurrencyHooks<T>(PhantomData<T>);
-impl<T: orml_tokens::Config> MutationHooks<T::AccountId, T::CurrencyId, T::Balance> for CurrencyHooks<T>
+impl<T: orml_tokens::Config + loans::Config>
+    MutationHooks<T::AccountId, T::CurrencyId, <T as currency::Config>::Balance> for CurrencyHooks<T>
 where
     T::AccountId: From<sp_runtime::AccountId32>,
 {

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -678,11 +678,11 @@ where
     T::AccountId: From<sp_runtime::AccountId32>,
 {
     type OnDust = orml_tokens::TransferDust<T, FeeAccount>;
-    type OnSlash = ();
-    type PreDeposit = ();
-    type PostDeposit = ();
-    type PreTransfer = ();
-    type PostTransfer = ();
+    type OnSlash = OnSlashHook<T>;
+    type PreDeposit = PreDeposit<T>;
+    type PostDeposit = PostDeposit<T>;
+    type PreTransfer = PreTransfer<T>;
+    type PostTransfer = PostTransfer<T>;
     type OnNewTokenAccount = ();
     type OnKilledTokenAccount = ();
 }

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("kintsugi-parachain"),
     impl_name: create_runtime_str!("kintsugi-parachain"),
     authoring_version: 1,
-    spec_version: 1023002,
+    spec_version: 1023003,
     impl_version: 1,
     transaction_version: 3, // added preimage
     apis: RUNTIME_API_VERSIONS,
@@ -1283,8 +1283,14 @@ pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, RuntimeCall, 
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
 /// Executive: handles dispatch to the various modules.
-pub type Executive =
-    frame_executive::Executive<Runtime, Block, frame_system::ChainContext<Runtime>, Runtime, AllPalletsWithSystem>;
+pub type Executive = frame_executive::Executive<
+    Runtime,
+    Block,
+    frame_system::ChainContext<Runtime>,
+    Runtime,
+    AllPalletsWithSystem,
+    loans::migration::collateral_toggle::Migration<Runtime>,
+>;
 
 #[cfg(not(feature = "disable-runtime-api"))]
 impl_runtime_apis! {


### PR DESCRIPTION
- Migrates inconsistent lend-token storage (both `free` and `reserved`) if any is found, by manually calling `lock_if_account_deposited(...)` (what the missing hooks were supposed to do)
- Sets orml-token hooks for `loans` in the Kintsugi runtime ~~(I assume this only fixes for a new genesis though - how do I set the config of a live runtime?)~~
- Bumps Kintsugi spec from `1023002` to `1023003`
- Adds TODO for setting the orml-tokens hooks before the interlay launch. Maybe easier to track as a GitHub issue in the Interlay DeFi Hub milestone?
- Tested using `try-runtime` on Kintsugi mainnet (`RUST_LOG=info target/release/interbtc-parachain try-runtime --wasm-execution=compiled --chain=kintsugi-latest --runtime target/release/wbuild/kintsugi-runtime-parachain/kintsugi_runtime_parachain.wasm on-runtime-upgrade live --uri 'wss://api-kusama.interlay.io:443/parachain'`)
- One issue I'm having is that even though the `Debug` trait is implemented by the `AccountId` and `CurrencyId` types, the logs show empty values: `Locked all free collateral for , in <wasm:stripped>` (should be `Locked all free collateral for [account_id], in [currency_id]`).