### PR TITLE
chore: bound number of pool currencies in dex-stable

### DIFF
--- a/crates/dex-general/src/lib.rs
+++ b/crates/dex-general/src/lib.rs
@@ -98,7 +98,6 @@ pub mod pallet {
     }
 
     #[pallet::pallet]
-    #[pallet::without_storage_info]
     #[pallet::generate_store(pub(super) trait Store)]
     pub struct Pallet<T>(_);
 

--- a/crates/dex-stable/src/base_pool.rs
+++ b/crates/dex-stable/src/base_pool.rs
@@ -14,7 +14,7 @@ impl<T: Config> Pallet<T> {
         lp_currency_symbol: Vec<u8>,
     ) -> Result<
         (
-            BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+            BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
             T::PoolId,
         ),
         DispatchError,
@@ -66,10 +66,11 @@ impl<T: Config> Pallet<T> {
 
         Ok((
             BasePool {
-                currency_ids: currency_ids.to_vec(),
+                currency_ids: BoundedVec::try_from(currency_ids.to_vec()).map_err(|_| Error::<T>::TooManyCurrencies)?,
                 lp_currency_id,
-                token_multipliers: rate,
-                balances: vec![Zero::zero(); currency_ids.len()],
+                token_multipliers: BoundedVec::try_from(rate).map_err(|_| Error::<T>::TooManyCurrencies)?,
+                balances: BoundedVec::try_from(vec![Zero::zero(); currency_ids.len()])
+                    .map_err(|_| Error::<T>::TooManyCurrencies)?,
                 fee,
                 admin_fee,
                 initial_a: a_with_precision,
@@ -88,7 +89,7 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn base_pool_add_liquidity(
         who: &T::AccountId,
         pool_id: T::PoolId,
-        pool: &mut BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &mut BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         amounts: &[Balance],
         min_mint_amount: Balance,
         to: &T::AccountId,
@@ -110,7 +111,7 @@ impl<T: Config> Pallet<T> {
             .ok_or(Error::<T>::Arithmetic)?;
         }
 
-        let mut new_balances = pool.balances.clone();
+        let mut new_balances = pool.balances.clone().to_vec();
 
         for i in 0..n_currencies {
             if lp_total_supply == Zero::zero() {
@@ -136,7 +137,7 @@ impl<T: Config> Pallet<T> {
 
         let mint_amount: Balance;
         if lp_total_supply.is_zero() {
-            pool.balances = new_balances;
+            pool.balances = BoundedVec::try_from(new_balances).map_err(|_| Error::<T>::TooManyCurrencies)?;
             mint_amount = d1;
         } else {
             (mint_amount, fees) = Self::calculate_base_mint_amount(
@@ -170,7 +171,7 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn base_pool_swap(
         who: &T::AccountId,
         pool_id: T::PoolId,
-        pool: &mut BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &mut BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         i: usize,
         j: usize,
         in_amount: Balance,
@@ -241,7 +242,7 @@ impl<T: Config> Pallet<T> {
 
     pub(crate) fn base_pool_remove_liquidity_one_currency(
         pool_id: T::PoolId,
-        pool: &mut BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &mut BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         who: &T::AccountId,
         lp_amount: Balance,
         index: u32,
@@ -290,7 +291,7 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn base_pool_remove_liquidity_imbalance(
         who: &T::AccountId,
         pool_id: T::PoolId,
-        pool: &mut BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &mut BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         amounts: &[Balance],
         max_burn_amount: Balance,
         to: &T::AccountId,
@@ -330,7 +331,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_base_virtual_price(
-        pool: &BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
     ) -> Option<Balance> {
         let d = Self::get_d(
             &Self::xp(&pool.balances, &pool.token_multipliers)?,
@@ -350,7 +351,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_base_remove_liquidity_imbalance(
-        pool: &mut BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &mut BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         amounts: &[Balance],
         total_supply: Balance,
     ) -> Option<(Balance, Vec<Balance>, Balance)> {
@@ -399,7 +400,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_base_remove_liquidity_one_token(
-        pool: &BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         token_amount: Balance,
         index: u32,
     ) -> Option<(Balance, Balance)> {
@@ -461,7 +462,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_base_swap_amount(
-        pool: &BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         i: usize,
         j: usize,
         in_balance: Balance,
@@ -491,7 +492,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_base_mint_amount(
-        pool: &mut BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &mut BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         new_balances: &mut [Balance],
         d0: Balance,
         d1: &mut Balance,
@@ -537,7 +538,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_base_remove_liquidity(
-        pool: &BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         amount: Balance,
     ) -> Option<Vec<Balance>> {
         let lp_total_supply = T::MultiCurrency::total_issuance(pool.lp_currency_id);
@@ -557,7 +558,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_base_currency_amount(
-        pool: &BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         amounts: Vec<Balance>,
         deposit: bool,
     ) -> Result<Balance, DispatchError> {

--- a/crates/dex-stable/src/base_pool_tests.rs
+++ b/crates/dex-stable/src/base_pool_tests.rs
@@ -221,20 +221,20 @@ fn create_pool_should_work() {
         assert_eq!(
             StableAmm::pools(0),
             Some(MockPool::Base(BasePool {
-                currency_ids: vec![
+                currency_ids: BoundedVec::truncate_from(vec![
                     Token(TOKEN1_SYMBOL),
                     Token(TOKEN2_SYMBOL),
                     Token(TOKEN3_SYMBOL),
                     Token(TOKEN4_SYMBOL),
-                ],
+                ]),
                 lp_currency_id,
-                token_multipliers: vec![
+                token_multipliers: BoundedVec::truncate_from(vec![
                     checked_pow(10, (POOL_TOKEN_COMMON_DECIMALS - TOKEN1_DECIMAL) as usize).unwrap(),
                     checked_pow(10, (POOL_TOKEN_COMMON_DECIMALS - TOKEN2_DECIMAL) as usize).unwrap(),
                     checked_pow(10, (POOL_TOKEN_COMMON_DECIMALS - TOKEN3_DECIMAL) as usize).unwrap(),
                     checked_pow(10, (POOL_TOKEN_COMMON_DECIMALS - TOKEN4_DECIMAL) as usize).unwrap(),
-                ],
-                balances: vec![Zero::zero(); 4],
+                ]),
+                balances: BoundedVec::truncate_from(vec![Zero::zero(); 4]),
                 fee: SWAP_FEE,
                 admin_fee: ADMIN_FEE,
                 initial_a: INITIAL_A_VALUE * (A_PRECISION as Balance),
@@ -243,8 +243,7 @@ fn create_pool_should_work() {
                 future_a_time: 0,
                 account: POOL0ACCOUNTID,
                 admin_fee_receiver: ALICE,
-                lp_currency_symbol: BoundedVec::<u8, PoolCurrencySymbolLimit>::try_from(Vec::from("stable_pool_lp"))
-                    .unwrap(),
+                lp_currency_symbol: BoundedVec::truncate_from(Vec::from("stable_pool_lp")),
                 lp_currency_decimal: 18,
             }))
         );
@@ -2018,8 +2017,8 @@ fn prepare_attack_context(new_a: Balance) -> AttackContext {
 
     AttackContext {
         initial_attacker_balances: attack_balances,
-        initial_pool_balances: pool.balances.clone(),
-        pool_currencies: pool.currency_ids.clone(),
+        initial_pool_balances: pool.balances.clone().to_vec(),
+        pool_currencies: pool.currency_ids.clone().to_vec(),
         attacker,
         pool_id,
     }
@@ -2116,7 +2115,7 @@ fn check_when_ramp_a_upwards_and_tokens_price_unequally() {
         assert_eq!(pool.balances[1], 3e18 as Balance);
 
         // rewrite pool balances
-        context.initial_pool_balances = pool.balances.clone();
+        context.initial_pool_balances = pool.balances.clone().to_vec();
 
         // Swap 1e18 of firstToken to secondToken, resolving imbalance in the pool
         assert_ok!(StableAmm::swap(
@@ -2273,7 +2272,7 @@ fn check_when_ramp_a_downwards_and_tokens_price_unequally() {
         assert_eq!(pool.balances[1], 3e18 as Balance);
 
         // rewrite pool balances
-        context.initial_pool_balances = pool.balances.clone();
+        context.initial_pool_balances = pool.balances.clone().to_vec();
 
         // Swap 1e18 of firstToken to secondToken, resolving imbalance in the pool
         assert_ok!(StableAmm::swap(
@@ -2348,7 +2347,7 @@ fn check_arithmetic_in_add_liquidity_should_successfully() {
 
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids,
+            pool.currency_ids.to_vec(),
             vec![1_000_000_000e18 as Balance, 1_000_000_000e18 as Balance],
         );
 
@@ -2409,7 +2408,7 @@ fn check_arithmetic_in_remove_liquidity_should_successfully() {
 
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -2506,7 +2505,7 @@ fn check_arithmetic_in_remove_liquidity_one_currency_should_successfully() {
         let pool = StableAmm::pools(pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -2598,7 +2597,7 @@ fn check_arithmetic_in_remove_liquidity_imbalance_should_successfully() {
         let pool = StableAmm::pools(pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -2697,7 +2696,7 @@ fn check_arithmetic_in_swap_should_successfully() {
         let pool = StableAmm::pools(pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -2808,7 +2807,7 @@ fn check_arithmetic_in_add_liquidity_with_admin_fee_should_successfully() {
         let pool = StableAmm::pools(pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -2857,7 +2856,7 @@ fn check_arithmetic_in_remove_liquidity_with_admin_fee_should_successfully() {
         let pool = StableAmm::pools(pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -2928,7 +2927,7 @@ fn check_arithmetic_in_remove_liquidity_one_currency_with_admin_fee_should_succe
         let pool = StableAmm::pools(pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3004,7 +3003,7 @@ fn check_arithmetic_in_remove_liquidity_imbalance_with_admin_fee_should_successf
         let pool = StableAmm::pools(pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3078,7 +3077,7 @@ fn check_arithmetic_in_swap_imbalance_with_admin_fee_should_successfully() {
         let pool = StableAmm::pools(pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 

--- a/crates/dex-stable/src/meta_pool.rs
+++ b/crates/dex-stable/src/meta_pool.rs
@@ -8,7 +8,13 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn meta_pool_add_liquidity(
         who: &T::AccountId,
         pool_id: T::PoolId,
-        meta_pool: &mut MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &mut MetaPool<
+            T::PoolId,
+            T::CurrencyId,
+            T::AccountId,
+            T::PoolCurrencyLimit,
+            T::PoolCurrencySymbolLimit,
+        >,
         amounts: &[Balance],
         min_mint_amount: Balance,
         to: &T::AccountId,
@@ -122,7 +128,13 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn meta_pool_swap(
         who: &T::AccountId,
         pool_id: T::PoolId,
-        meta_pool: &mut MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &mut MetaPool<
+            T::PoolId,
+            T::CurrencyId,
+            T::AccountId,
+            T::PoolCurrencyLimit,
+            T::PoolCurrencySymbolLimit,
+        >,
         i: usize,
         j: usize,
         in_amount: Balance,
@@ -173,7 +185,13 @@ impl<T: Config> Pallet<T> {
 
     pub(crate) fn meta_pool_remove_liquidity_one_currency(
         pool_id: T::PoolId,
-        meta_pool: &mut MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &mut MetaPool<
+            T::PoolId,
+            T::CurrencyId,
+            T::AccountId,
+            T::PoolCurrencyLimit,
+            T::PoolCurrencySymbolLimit,
+        >,
         who: &T::AccountId,
         lp_amount: Balance,
         index: u32,
@@ -230,7 +248,13 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn meta_pool_remove_liquidity_imbalance(
         who: &T::AccountId,
         pool_id: T::PoolId,
-        meta_pool: &mut MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &mut MetaPool<
+            T::PoolId,
+            T::CurrencyId,
+            T::AccountId,
+            T::PoolCurrencyLimit,
+            T::PoolCurrencySymbolLimit,
+        >,
         amounts: &[Balance],
         max_burn_amount: Balance,
         to: &T::AccountId,
@@ -276,7 +300,13 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn meta_pool_swap_underlying(
-        meta_pool: &mut MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &mut MetaPool<
+            T::PoolId,
+            T::CurrencyId,
+            T::AccountId,
+            T::PoolCurrencyLimit,
+            T::PoolCurrencySymbolLimit,
+        >,
         pool_id: T::PoolId,
         who: &T::AccountId,
         to: &T::AccountId,
@@ -448,7 +478,13 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn meta_pool_update_virtual_price(
-        meta_pool: &mut MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &mut MetaPool<
+            T::PoolId,
+            T::CurrencyId,
+            T::AccountId,
+            T::PoolCurrencyLimit,
+            T::PoolCurrencySymbolLimit,
+        >,
     ) -> Option<Balance> {
         let now = T::TimeProvider::now().as_secs();
         if now > (meta_pool.base_cache_last_updated + BASE_CACHE_EXPIRE_TIME) {
@@ -465,7 +501,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_meta_virtual_price(
-        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
     ) -> Option<Balance> {
         let base_virtual_price = Self::meta_pool_base_virtual_price(meta_pool)?;
         let normalized_balances = Self::meta_pool_xp(
@@ -497,7 +533,7 @@ impl<T: Config> Pallet<T> {
     }
 
     fn meta_pool_base_virtual_price(
-        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
     ) -> Option<Balance> {
         let now = T::TimeProvider::now().as_secs();
         if now > (meta_pool.base_cache_last_updated + BASE_CACHE_EXPIRE_TIME) {
@@ -511,7 +547,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_meta_remove_liquidity_one_currency(
-        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         token_amount: Balance,
         index: usize,
         total_supply: Balance,
@@ -596,7 +632,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_meta_currency_amount(
-        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         amounts: Vec<Balance>,
         deposit: bool,
     ) -> Result<Balance, DispatchError> {
@@ -643,7 +679,13 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_meta_remove_liquidity_imbalance(
-        meta_pool: &mut MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &mut MetaPool<
+            T::PoolId,
+            T::CurrencyId,
+            T::AccountId,
+            T::PoolCurrencyLimit,
+            T::PoolCurrencySymbolLimit,
+        >,
         amounts: &[Balance],
         total_supply: Balance,
         base_virtual_price: Balance,
@@ -699,7 +741,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_meta_swap_amount(
-        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        meta_pool: &MetaPool<T::PoolId, T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         i: usize,
         j: usize,
         in_amount: Balance,

--- a/crates/dex-stable/src/meta_pool_tests.rs
+++ b/crates/dex-stable/src/meta_pool_tests.rs
@@ -313,22 +313,22 @@ fn create_meta_pool_should_work() {
                 base_pool_id,
                 base_virtual_price,
                 base_cache_last_updated: now,
-                base_currencies: vec![Token(TOKEN1_SYMBOL), Token(TOKEN2_SYMBOL),],
+                base_currencies: BoundedVec::truncate_from(vec![Token(TOKEN1_SYMBOL), Token(TOKEN2_SYMBOL),]),
                 info: BasePool {
-                    currency_ids: vec![
+                    currency_ids: BoundedVec::truncate_from(vec![
                         Token(TOKEN1_SYMBOL),
                         Token(TOKEN2_SYMBOL),
                         Token(TOKEN3_SYMBOL),
                         base_pool_lp_currency,
-                    ],
+                    ]),
                     lp_currency_id: meta_pool_lp_currency,
-                    token_multipliers: vec![
+                    token_multipliers: BoundedVec::truncate_from(vec![
                         checked_pow(10, (POOL_TOKEN_COMMON_DECIMALS - TOKEN1_DECIMAL) as usize).unwrap(),
                         checked_pow(10, (POOL_TOKEN_COMMON_DECIMALS - TOKEN2_DECIMAL) as usize).unwrap(),
                         checked_pow(10, (POOL_TOKEN_COMMON_DECIMALS - TOKEN3_DECIMAL) as usize).unwrap(),
                         checked_pow(10, (POOL_TOKEN_COMMON_DECIMALS - STABLE_LP_DECIMAL) as usize).unwrap(),
-                    ],
-                    balances: vec![Zero::zero(); 4],
+                    ]),
+                    balances: BoundedVec::truncate_from(vec![Zero::zero(); 4]),
                     fee: SWAP_FEE,
                     admin_fee: ADMIN_FEE,
                     initial_a: INITIAL_A_VALUE * (A_PRECISION as Balance),
@@ -836,7 +836,7 @@ fn remove_liquidity_imbalance_in_meta_pool_with_max_burn_lp_token_amount_range_s
         let max_pool_token_amount_to_be_burned_negative_slippage = max_pool_token_amount_to_be_burned * 1001 / 1000;
         let max_pool_token_amount_to_be_burned_positive_slippage = max_pool_token_amount_to_be_burned * 999 / 1000;
 
-        let mut currency_ids = pool.currency_ids.clone();
+        let mut currency_ids = pool.currency_ids.clone().to_vec();
         currency_ids.push(pool.lp_currency_id);
 
         let balance_before = get_user_token_balances(&currency_ids, &BOB);
@@ -2556,8 +2556,8 @@ fn prepare_attack_meta_context(new_a: Balance) -> AttackContext {
 
     AttackContext {
         initial_attacker_balances: attack_balances,
-        initial_pool_balances: pool.balances.clone(),
-        pool_currencies: pool.currency_ids.clone(),
+        initial_pool_balances: pool.balances.clone().to_vec(),
+        pool_currencies: pool.currency_ids.clone().to_vec(),
         attacker,
         pool_id: meta_pool_id,
     }
@@ -2654,7 +2654,7 @@ fn meta_check_when_ramp_a_upwards_and_tokens_price_unequally() {
         assert_eq!(pool.balances[1], 3e18 as Balance);
 
         // rewrite pool balances
-        context.initial_pool_balances = pool.balances.clone();
+        context.initial_pool_balances = pool.balances.clone().to_vec();
 
         // Swap 1e18 of firstToken to secondToken, resolving imbalance in the pool
         assert_ok!(StableAmm::swap(
@@ -2811,7 +2811,7 @@ fn meta_check_when_ramp_a_downwards_and_tokens_price_unequally() {
         assert_eq!(pool.balances[1], 3e18 as Balance);
 
         // rewrite pool balances
-        context.initial_pool_balances = pool.balances.clone();
+        context.initial_pool_balances = pool.balances.clone().to_vec();
 
         // Swap 1e18 of firstToken to secondToken, resolving imbalance in the pool
         assert_ok!(StableAmm::swap(
@@ -2887,7 +2887,7 @@ fn meta_check_arithmetic_in_add_liquidity_should_successfully() {
 
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids,
+            pool.currency_ids.to_vec(),
             vec![1_000_000_000e18 as Balance, 1_000_000_000e18 as Balance],
         );
 
@@ -2948,7 +2948,7 @@ fn meta_check_arithmetic_in_remove_liquidity_should_successfully() {
 
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3045,7 +3045,7 @@ fn meta_check_arithmetic_in_remove_liquidity_one_currency_should_successfully() 
         let pool = StableAmm::pools(meta_pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3137,7 +3137,7 @@ fn meta_check_arithmetic_in_remove_liquidity_imbalance_should_successfully() {
         let pool = StableAmm::pools(meta_pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3236,7 +3236,7 @@ fn meta_check_arithmetic_in_swap_should_successfully() {
         let pool = StableAmm::pools(meta_pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3347,7 +3347,7 @@ fn meta_check_arithmetic_in_add_liquidity_with_admin_fee_should_successfully() {
         let pool = StableAmm::pools(meta_pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3400,7 +3400,7 @@ fn meta_check_arithmetic_in_remove_liquidity_with_admin_fee_should_successfully(
         let pool = StableAmm::pools(meta_pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3475,7 +3475,7 @@ fn meta_check_arithmetic_in_remove_liquidity_one_currency_with_admin_fee_should_
         let pool = StableAmm::pools(meta_pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3555,7 +3555,7 @@ fn meta_check_arithmetic_in_remove_liquidity_imbalance_with_admin_fee_should_suc
         let pool = StableAmm::pools(meta_pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 
@@ -3633,7 +3633,7 @@ fn meta_check_arithmetic_in_swap_imbalance_with_admin_fee_should_successfully() 
         let pool = StableAmm::pools(meta_pool_id).unwrap().get_pool_info();
         mint_more_currencies(
             vec![BOB, CHARLIE],
-            pool.currency_ids.clone(),
+            pool.currency_ids.clone().to_vec(),
             vec![10_000_000_000e18 as Balance, 10_000_000_000e18 as Balance],
         );
 

--- a/crates/dex-stable/src/mock.rs
+++ b/crates/dex-stable/src/mock.rs
@@ -37,6 +37,7 @@ parameter_types! {
     pub const MaxReserves: u32 = 50;
     pub const MaxLocks:u32 = 50;
     pub const MinimumPeriod: Moment = SLOT_DURATION / 2;
+    pub const PoolCurrencyLimit: u32 = 10;
     pub const PoolCurrencySymbolLimit: u32 = 50;
 }
 
@@ -166,6 +167,7 @@ impl Config for Test {
     type EnsurePoolAsset = EnsurePoolAssetImpl<Tokens>;
     type LpGenerate = PoolLpGenerate;
     type TimeProvider = Timestamp;
+    type PoolCurrencyLimit = PoolCurrencyLimit;
     type PoolCurrencySymbolLimit = PoolCurrencySymbolLimit;
     type PalletId = StableAmmPalletId;
     type WeightInfo = ();
@@ -321,10 +323,10 @@ pub fn get_user_balance(currency_id: CurrencyId, user: &AccountId) -> Balance {
     <Test as Config>::MultiCurrency::free_balance(currency_id, user)
 }
 
-pub type MockPool = Pool<PoolId, CurrencyId, AccountId, BoundedVec<u8, PoolCurrencySymbolLimit>>;
+pub type MockPool = Pool<PoolId, CurrencyId, AccountId, PoolCurrencyLimit, PoolCurrencySymbolLimit>;
 
 impl MockPool {
-    pub fn get_pool_info(&self) -> BasePool<CurrencyId, AccountId, BoundedVec<u8, PoolCurrencySymbolLimit>> {
+    pub fn get_pool_info(&self) -> BasePool<CurrencyId, AccountId, PoolCurrencyLimit, PoolCurrencySymbolLimit> {
         match self {
             MockPool::Base(bp) => (*bp).clone(),
             MockPool::Meta(mp) => mp.info.clone(),

--- a/crates/dex-stable/src/rpc.rs
+++ b/crates/dex-stable/src/rpc.rs
@@ -37,7 +37,7 @@ impl<T: Config> Pallet<T> {
 
     pub fn get_currencies(pool_id: T::PoolId) -> Vec<T::CurrencyId> {
         if let Some(pool) = Self::pools(pool_id) {
-            return pool.get_currency_ids();
+            return pool.get_currency_ids().to_vec();
         };
         Vec::new()
     }
@@ -72,14 +72,14 @@ impl<T: Config> Pallet<T> {
 
     pub fn get_currency_precision_multipliers(pool_id: T::PoolId) -> Vec<Balance> {
         if let Some(pool) = Self::pools(pool_id) {
-            return pool.get_token_multipliers();
+            return pool.get_token_multipliers().to_vec();
         };
         Vec::new()
     }
 
     pub fn get_currency_balances(pool_id: T::PoolId) -> Vec<Balance> {
         if let Some(pool) = Self::pools(pool_id) {
-            return pool.get_balances();
+            return pool.get_balances().to_vec();
         };
         Vec::new()
     }

--- a/crates/dex-stable/src/utils.rs
+++ b/crates/dex-stable/src/utils.rs
@@ -60,7 +60,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn get_y(
-        pool: &BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         in_index: usize,
         out_index: usize,
         in_balance: Balance,
@@ -111,7 +111,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn get_yd(
-        pool: &BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
         a: Balance,
         index: u32,
         xp: &[Balance],
@@ -188,7 +188,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn get_a_precise(
-        pool: &BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
     ) -> Option<Number> {
         let now = T::TimeProvider::now().as_secs() as Number;
 
@@ -224,7 +224,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn get_pool_virtual_price(
-        pool: &Pool<T::PoolId, T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &Pool<T::PoolId, T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
     ) -> Option<Balance> {
         match pool {
             Pool::Base(bp) => Self::calculate_base_virtual_price(bp),
@@ -233,7 +233,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub(crate) fn calculate_fee_per_token(
-        pool: &BasePool<T::CurrencyId, T::AccountId, BoundedVec<u8, T::PoolCurrencySymbolLimit>>,
+        pool: &BasePool<T::CurrencyId, T::AccountId, T::PoolCurrencyLimit, T::PoolCurrencySymbolLimit>,
     ) -> Option<Balance> {
         let n_pooled_currency = Balance::from(pool.currency_ids.len() as u64);
 

--- a/crates/dex-swap-router/src/mock.rs
+++ b/crates/dex-swap-router/src/mock.rs
@@ -34,6 +34,7 @@ parameter_types! {
     pub const MaxReserves: u32 = 50;
     pub const MaxLocks:u32 = 50;
     pub const MinimumPeriod: Moment = SLOT_DURATION / 2;
+    pub const PoolCurrencyLimit: u32 = 10;
     pub const PoolCurrencySymbolLimit: u32 = 50;
 }
 
@@ -172,6 +173,7 @@ impl dex_stable::Config for Test {
     type EnsurePoolAsset = EnsurePoolAssetImpl<Tokens>;
     type LpGenerate = PoolLpGenerate;
     type TimeProvider = Timestamp;
+    type PoolCurrencyLimit = PoolCurrencyLimit;
     type PoolCurrencySymbolLimit = PoolCurrencySymbolLimit;
     type PalletId = DexStablePalletId;
     type WeightInfo = ();

--- a/parachain/runtime/kintsugi/src/dex.rs
+++ b/parachain/runtime/kintsugi/src/dex.rs
@@ -9,6 +9,7 @@ pub use dex_stable::traits::{StablePoolLpCurrencyIdGenerate, ValidateCurrency};
 parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stbl");
+    pub const CurrencyLimit: u32 = 10;
     pub const StringLimit: u32 = 50;
     pub const MaxSwaps:u16 = 4;
     pub const MaxBootstrapRewards: u32 = 1000;
@@ -63,6 +64,7 @@ impl dex_stable::Config for Runtime {
     type TimeProvider = Timestamp;
     type EnsurePoolAsset = StableAmmVerifyPoolAsset;
     type LpGenerate = PoolLpGenerate;
+    type PoolCurrencyLimit = CurrencyLimit;
     type PoolCurrencySymbolLimit = StringLimit;
     type PalletId = DexStablePalletId;
     type WeightInfo = weights::dex_stable::WeightInfo<Runtime>;

--- a/parachain/runtime/testnet-interlay/src/dex.rs
+++ b/parachain/runtime/testnet-interlay/src/dex.rs
@@ -9,6 +9,7 @@ pub use dex_stable::traits::{StablePoolLpCurrencyIdGenerate, ValidateCurrency};
 parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stab");
+    pub const CurrencyLimit: u32 = 10;
     pub const StringLimit: u32 = 50;
     pub const MaxSwaps:u16 = 4;
     pub const MaxBootstrapRewards: u32 = 1000;
@@ -63,6 +64,7 @@ impl dex_stable::Config for Runtime {
     type TimeProvider = Timestamp;
     type EnsurePoolAsset = StableAmmVerifyPoolAsset;
     type LpGenerate = PoolLpGenerate;
+    type PoolCurrencyLimit = CurrencyLimit;
     type PoolCurrencySymbolLimit = StringLimit;
     type PalletId = DexStablePalletId;
     type WeightInfo = weights::dex_stable::WeightInfo<Runtime>;

--- a/parachain/runtime/testnet-kintsugi/src/dex.rs
+++ b/parachain/runtime/testnet-kintsugi/src/dex.rs
@@ -9,6 +9,7 @@ pub use dex_stable::traits::{StablePoolLpCurrencyIdGenerate, ValidateCurrency};
 parameter_types! {
     pub const DexGeneralPalletId: PalletId = PalletId(*b"dex/genr");
     pub const DexStablePalletId: PalletId = PalletId(*b"dex/stbl");
+    pub const CurrencyLimit: u32 = 10;
     pub const StringLimit: u32 = 50;
     pub const MaxSwaps:u16 = 4;
     pub const MaxBootstrapRewards: u32 = 1000;
@@ -63,6 +64,7 @@ impl dex_stable::Config for Runtime {
     type TimeProvider = Timestamp;
     type EnsurePoolAsset = StableAmmVerifyPoolAsset;
     type LpGenerate = PoolLpGenerate;
+    type PoolCurrencyLimit = CurrencyLimit;
     type PoolCurrencySymbolLimit = StringLimit;
     type PalletId = DexStablePalletId;
     type WeightInfo = weights::dex_stable::WeightInfo<Runtime>;


### PR DESCRIPTION
So we can remove `without_storage_info` annotation