### PR TITLE
chore: fix remaining benchmarks

### DIFF
--- a/crates/democracy/src/benchmarking.rs
+++ b/crates/democracy/src/benchmarking.rs
@@ -363,7 +363,7 @@ pub mod benchmarks {
     #[benchmark]
     fn spend_from_treasury() {
         let beneficiary: T::AccountId = account("beneficiary", 0, 0);
-        T::Currency::make_free_balance_be(&T::TreasuryAccount::get(), 100u32.into());
+        T::TreasuryCurrency::make_free_balance_be(&T::TreasuryAccount::get(), 100u32.into());
         let value = 100u32.into();
 
         #[extrinsic_call]

--- a/crates/tx-pause/src/benchmarking.rs
+++ b/crates/tx-pause/src/benchmarking.rs
@@ -19,7 +19,7 @@
 
 use super::{Pallet as TxPause, *};
 
-use frame_benchmarking::v2::{account, benchmarks, impl_benchmark_test_suite};
+use frame_benchmarking::v2::*;
 
 #[benchmarks]
 pub mod benchmarks {

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -416,6 +416,9 @@ impl orml_vesting::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = NativeCurrency;
     type MinVestedTransfer = MinVestedTransfer;
+    #[cfg(feature = "runtime-benchmarks")]
+    type VestedTransferOrigin = frame_system::EnsureSigned<AccountId>;
+    #[cfg(not(feature = "runtime-benchmarks"))]
     type VestedTransferOrigin = EnsureKintsugiLabs;
     type WeightInfo = weights::orml_vesting::WeightInfo<Runtime>;
     type MaxVestingSchedules = MaxVestingSchedules;

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -418,6 +418,9 @@ impl orml_vesting::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = NativeCurrency;
     type MinVestedTransfer = MinVestedTransfer;
+    #[cfg(feature = "runtime-benchmarks")]
+    type VestedTransferOrigin = frame_system::EnsureSigned<AccountId>;
+    #[cfg(not(feature = "runtime-benchmarks"))]
     type VestedTransferOrigin = EnsureKintsugiLabs;
     type WeightInfo = weights::orml_vesting::WeightInfo<Runtime>;
     type MaxVestingSchedules = MaxVestingSchedules;


### PR DESCRIPTION
Tested all `interlay` and `kintsugi` benchmarks, `democracy` and `orml-vesting` were the only failures