### PR TITLE
chore: deprecate testnet runtimes

### DIFF
--- a/parachain/src/chain_spec/interlay.rs
+++ b/parachain/src/chain_spec/interlay.rs
@@ -123,7 +123,7 @@ pub fn interlay_mainnet_config() -> InterlayChainSpec {
     )
 }
 
-fn interlay_mainnet_genesis(
+pub fn interlay_mainnet_genesis(
     invulnerables: Vec<(AccountId, AuraId)>,
     authorized_oracles: Vec<(AccountId, interlay_runtime::OracleName)>,
     endowed_accounts: Vec<AccountId>,

--- a/parachain/src/chain_spec/kintsugi.rs
+++ b/parachain/src/chain_spec/kintsugi.rs
@@ -4,7 +4,7 @@ use primitives::Rate;
 
 pub const PARA_ID: u32 = 2092;
 
-fn kintsugi_properties() -> Map<String, Value> {
+pub fn kintsugi_properties() -> Map<String, Value> {
     let mut properties = Map::new();
     let mut token_symbol: Vec<String> = vec![];
     let mut token_decimals: Vec<u32> = vec![];
@@ -127,7 +127,7 @@ pub fn kintsugi_mainnet_config() -> KintsugiChainSpec {
     )
 }
 
-fn kintsugi_mainnet_genesis(
+pub fn kintsugi_mainnet_genesis(
     invulnerables: Vec<(AccountId, AuraId)>,
     authorized_oracles: Vec<(AccountId, kintsugi_runtime::OracleName)>,
     endowed_accounts: Vec<AccountId>,

--- a/parachain/src/chain_spec/testnet_interlay.rs
+++ b/parachain/src/chain_spec/testnet_interlay.rs
@@ -2,6 +2,7 @@ use primitives::Rate;
 use testnet_interlay_runtime::LoansConfig;
 
 use super::*;
+use crate::chain_spec::interlay::interlay_mainnet_genesis;
 
 fn testnet_properties(bitcoin_network: &str) -> Map<String, Value> {
     let mut properties = Map::new();
@@ -274,4 +275,76 @@ fn testnet_genesis(
             min_exchange_rate: Rate::from_inner(loans::DEFAULT_MIN_EXCHANGE_RATE),
         },
     }
+}
+
+pub fn staging_mainnet_config(benchmarking: bool) -> InterlayChainSpec {
+    InterlayChainSpec::from_genesis(
+        "interBTC",
+        "staging_testnet",
+        ChainType::Live,
+        move || {
+            let mut genesis = interlay_mainnet_genesis(
+                vec![
+                    // 5EqCiRZGFZ88JCK9FNmak2SkRHSohWpEFpx28vwo5c1m98Xe (//authority/1)
+                    get_authority_keys_from_public_key(hex![
+                        "7a6868acf544dc5c3f2f9f6f9a5952017bbefb51da41819307fc21cf3efb554d"
+                    ]),
+                    // 5DbwRgYTAtjJ8Mys8ta8RXxWPcSmiyx4dPRsvU1k4TYyk4jq (//authority/2)
+                    get_authority_keys_from_public_key(hex![
+                        "440e84dd3604be606f3110c21f93a0e981fb93b28288270dcdce8a43c68ff36e"
+                    ]),
+                    // 5GVtSRJmnFxVcFz7jejbCrY2SREhZJZUHuJkm2KS75bTqRF2 (//authority/3)
+                    get_authority_keys_from_public_key(hex![
+                        "c425b0d9fed64d3bd5be0a6d06053d2bfb72f4983146788f5684aec9f5eb0c7f"
+                    ]),
+                ],
+                vec![(
+                    // 5ECj4iBBi3h8kYzhqLFmzVLafC64UpsXvK7H4ZZyXoVQJdJq (//oracle/1)
+                    get_account_id_from_string("5ECj4iBBi3h8kYzhqLFmzVLafC64UpsXvK7H4ZZyXoVQJdJq"),
+                    BoundedVec::truncate_from("Interlay".as_bytes().to_vec()),
+                )],
+                vec![
+                    // 5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv (//sudo/1)
+                    get_account_id_from_string("5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv"),
+                    // 5ECj4iBBi3h8kYzhqLFmzVLafC64UpsXvK7H4ZZyXoVQJdJq (//oracle/1)
+                    get_account_id_from_string("5ECj4iBBi3h8kYzhqLFmzVLafC64UpsXvK7H4ZZyXoVQJdJq"),
+                    // 5FgWDuxgS8VasP6KtvESHUuuDn6L8BTCqbYyFW9mDwAaLtbY (//account/1)
+                    get_account_id_from_string("5FgWDuxgS8VasP6KtvESHUuuDn6L8BTCqbYyFW9mDwAaLtbY"),
+                    // 5H3n25VshwPeMzKhn4gnVEjCEndFsjt85ydW2Vvo8ysy7CnZ (//account/2)
+                    get_account_id_from_string("5H3n25VshwPeMzKhn4gnVEjCEndFsjt85ydW2Vvo8ysy7CnZ"),
+                    // 5GKciEHZWSGxtAihqGjXC6XpXSGNoudDxACuDLbYF1ipygZj (//account/3)
+                    get_account_id_from_string("5GKciEHZWSGxtAihqGjXC6XpXSGNoudDxACuDLbYF1ipygZj"),
+                    // 5GjJ26ffHApgUFLgxKWpWL5T5ppxWjSRJe42PjPNATLvjcJK (//account/4)
+                    get_account_id_from_string("5GjJ26ffHApgUFLgxKWpWL5T5ppxWjSRJe42PjPNATLvjcJK"),
+                    // 5DqzGaydetDXGya818gyuHA7GAjEWRsQN6UWNKpvfgq2KyM7 (//account/5)
+                    get_account_id_from_string("5DqzGaydetDXGya818gyuHA7GAjEWRsQN6UWNKpvfgq2KyM7"),
+                ]
+                .into_iter()
+                .chain(if benchmarking {
+                    vec![get_account_id_from_seed::<sr25519::Public>("Alice")]
+                } else {
+                    vec![]
+                })
+                .collect(),
+                crate::chain_spec::interlay::PARA_ID.into(),
+                DEFAULT_BITCOIN_CONFIRMATIONS,
+            );
+
+            // 5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv (//sudo/1)
+            genesis.sudo.key = Some(get_account_id_from_string(
+                "5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv",
+            ));
+
+            genesis
+        },
+        Vec::new(),
+        None,
+        None,
+        None,
+        Some(testnet_properties(BITCOIN_TESTNET)),
+        Extensions {
+            relay_chain: "staging".into(),
+            para_id: crate::chain_spec::interlay::PARA_ID.into(),
+        },
+    )
 }

--- a/parachain/src/chain_spec/testnet_kintsugi.rs
+++ b/parachain/src/chain_spec/testnet_kintsugi.rs
@@ -2,6 +2,7 @@ use primitives::Rate;
 use testnet_kintsugi_runtime::LoansConfig;
 
 use super::*;
+use crate::chain_spec::kintsugi::kintsugi_mainnet_genesis;
 
 fn testnet_properties(bitcoin_network: &str) -> Map<String, Value> {
     let mut properties = Map::new();
@@ -468,4 +469,78 @@ fn testnet_genesis(
             min_exchange_rate: Rate::from_inner(loans::DEFAULT_MIN_EXCHANGE_RATE),
         },
     }
+}
+
+pub fn staging_mainnet_config(benchmarking: bool) -> KintsugiChainSpec {
+    KintsugiChainSpec::from_genesis(
+        "interBTC",
+        "staging_testnet",
+        ChainType::Live,
+        move || {
+            let mut genesis = kintsugi_mainnet_genesis(
+                // // 5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv (//sudo/1)
+                // get_account_id_from_string("5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv"),
+                vec![
+                    // 5EqCiRZGFZ88JCK9FNmak2SkRHSohWpEFpx28vwo5c1m98Xe (//authority/1)
+                    get_authority_keys_from_public_key(hex![
+                        "7a6868acf544dc5c3f2f9f6f9a5952017bbefb51da41819307fc21cf3efb554d"
+                    ]),
+                    // 5DbwRgYTAtjJ8Mys8ta8RXxWPcSmiyx4dPRsvU1k4TYyk4jq (//authority/2)
+                    get_authority_keys_from_public_key(hex![
+                        "440e84dd3604be606f3110c21f93a0e981fb93b28288270dcdce8a43c68ff36e"
+                    ]),
+                    // 5GVtSRJmnFxVcFz7jejbCrY2SREhZJZUHuJkm2KS75bTqRF2 (//authority/3)
+                    get_authority_keys_from_public_key(hex![
+                        "c425b0d9fed64d3bd5be0a6d06053d2bfb72f4983146788f5684aec9f5eb0c7f"
+                    ]),
+                ],
+                vec![(
+                    // 5ECj4iBBi3h8kYzhqLFmzVLafC64UpsXvK7H4ZZyXoVQJdJq (//oracle/1)
+                    get_account_id_from_string("5ECj4iBBi3h8kYzhqLFmzVLafC64UpsXvK7H4ZZyXoVQJdJq"),
+                    BoundedVec::truncate_from("Interlay".as_bytes().to_vec()),
+                )],
+                vec![
+                    // 5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv (//sudo/1)
+                    get_account_id_from_string("5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv"),
+                    // 5ECj4iBBi3h8kYzhqLFmzVLafC64UpsXvK7H4ZZyXoVQJdJq (//oracle/1)
+                    get_account_id_from_string("5ECj4iBBi3h8kYzhqLFmzVLafC64UpsXvK7H4ZZyXoVQJdJq"),
+                    // 5FgWDuxgS8VasP6KtvESHUuuDn6L8BTCqbYyFW9mDwAaLtbY (//account/1)
+                    get_account_id_from_string("5FgWDuxgS8VasP6KtvESHUuuDn6L8BTCqbYyFW9mDwAaLtbY"),
+                    // 5H3n25VshwPeMzKhn4gnVEjCEndFsjt85ydW2Vvo8ysy7CnZ (//account/2)
+                    get_account_id_from_string("5H3n25VshwPeMzKhn4gnVEjCEndFsjt85ydW2Vvo8ysy7CnZ"),
+                    // 5GKciEHZWSGxtAihqGjXC6XpXSGNoudDxACuDLbYF1ipygZj (//account/3)
+                    get_account_id_from_string("5GKciEHZWSGxtAihqGjXC6XpXSGNoudDxACuDLbYF1ipygZj"),
+                    // 5GjJ26ffHApgUFLgxKWpWL5T5ppxWjSRJe42PjPNATLvjcJK (//account/4)
+                    get_account_id_from_string("5GjJ26ffHApgUFLgxKWpWL5T5ppxWjSRJe42PjPNATLvjcJK"),
+                    // 5DqzGaydetDXGya818gyuHA7GAjEWRsQN6UWNKpvfgq2KyM7 (//account/5)
+                    get_account_id_from_string("5DqzGaydetDXGya818gyuHA7GAjEWRsQN6UWNKpvfgq2KyM7"),
+                ]
+                .into_iter()
+                .chain(if benchmarking {
+                    vec![get_account_id_from_seed::<sr25519::Public>("Alice")]
+                } else {
+                    vec![]
+                })
+                .collect(),
+                crate::chain_spec::kintsugi::PARA_ID.into(),
+                DEFAULT_BITCOIN_CONFIRMATIONS,
+            );
+
+            // 5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv (//sudo/1)
+            genesis.sudo.key = Some(get_account_id_from_string(
+                "5Ec37KSdjSbGKoQN4evLXrZskjc7jxXYrowPHEtH2MzRC7mv",
+            ));
+
+            genesis
+        },
+        Vec::new(),
+        None,
+        None,
+        None,
+        Some(testnet_properties(BITCOIN_TESTNET)),
+        Extensions {
+            relay_chain: "staging".into(),
+            para_id: crate::chain_spec::kintsugi::PARA_ID.into(),
+        },
+    )
 }

--- a/parachain/src/command.rs
+++ b/parachain/src/command.rs
@@ -120,6 +120,8 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, St
             DEFAULT_PARA_ID.into(),
             false,
         )),
+        "kintsugi-staging" => Box::new(chain_spec::testnet_kintsugi::staging_mainnet_config(false)),
+        "interlay-staging" => Box::new(chain_spec::testnet_interlay::staging_mainnet_config(false)),
         "moonbase-alpha" => Box::new(chain_spec::testnet_kintsugi::staging_testnet_config(1002.into(), false)),
         path => {
             if let Some(matches) = Regex::new(r"^rococo-local-([0-9]+)$").unwrap().captures(path) {


### PR DESCRIPTION
Adds a new runtime selector (`kintsugi-staging` and `interlay-staging`), which uses the mainnet runtimes, but with:
- a sudo key set in the chainspec
- bitcoin testnet in the properties
- prefunded accounts
- different relaychain 