### PR TITLE
refactor: deduplicate escrow reward rate runtime-api and add sanity test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7889,6 +7889,7 @@ dependencies = [
  "replace",
  "replace-rpc-runtime-api",
  "reward",
+ "reward-rpc-runtime-api",
  "runtime-common",
  "scale-info",
  "security",

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -1670,18 +1670,7 @@ impl_runtime_apis! {
             amount: Option<Balance>,
             lock_time: Option<BlockNumber>,
         ) -> Result<UnsignedFixedPoint, DispatchError> {
-            // withdraw previous rewards
-            <EscrowRewards as reward::RewardsApi<(), AccountId, Balance>>::withdraw_reward(&(), &account_id, NATIVE_CURRENCY_ID)?;
-            // increase amount and/or lock_time
-            Escrow::round_height_and_deposit_for(&account_id, amount.unwrap_or_default(), lock_time.unwrap_or_default())?;
-            // distribute rewards accrued over block count
-            let reward = EscrowAnnuity::min_reward_per_block().saturating_mul(YEARS.into());
-            <EscrowRewards as reward::RewardsApi<(), AccountId, Balance>>::distribute_reward(&(), NATIVE_CURRENCY_ID, reward)?;
-            let received = <EscrowRewards as reward::RewardsApi<(), AccountId, Balance>>::compute_reward(&(), &account_id, NATIVE_CURRENCY_ID)?;
-            // NOTE: total_locked is same currency as rewards
-            let total_locked = Escrow::locked_balance(&account_id).amount;
-            // rate is received / total_locked
-            Ok(UnsignedFixedPoint::checked_from_rational(received, total_locked).unwrap_or_default())
+            runtime_common::estimate_escrow_reward_rate::<Runtime, EscrowAnnuityInstance, EscrowRewards, _>(account_id, amount, lock_time)
         }
 
         fn estimate_farming_reward(

--- a/parachain/runtime/runtime-tests/Cargo.toml
+++ b/parachain/runtime/runtime-tests/Cargo.toml
@@ -129,6 +129,7 @@ vault-registry-rpc-runtime-api = { path = "../../../crates/vault-registry/rpc/ru
 issue-rpc-runtime-api = { path = "../../../crates/issue/rpc/runtime-api" }
 redeem-rpc-runtime-api = { path = "../../../crates/redeem/rpc/runtime-api" }
 replace-rpc-runtime-api = { path = "../../../crates/replace/rpc/runtime-api" }
+reward-rpc-runtime-api = { path = "../../../crates/reward/rpc/runtime-api" }
 
 # Orml dependencies
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "dc39cfddefb10ef0de23655e2c3dcdab66a19404" }

--- a/parachain/runtime/runtime-tests/src/parachain/escrow.rs
+++ b/parachain/runtime/runtime-tests/src/parachain/escrow.rs
@@ -132,3 +132,47 @@ fn integration_test_escrow_reward_stake() {
         ensure_reward_stake_is_escrow_balance(current_height);
     });
 }
+
+#[test]
+fn integration_test_escrow_reward_rate() {
+    use reward_rpc_runtime_api::runtime_decl_for_reward_api::RewardApiV1;
+
+    ExtBuilder::build().execute_with(|| {
+        let max_period = <Runtime as escrow::Config>::MaxPeriod::get();
+        let current_height = SystemPallet::block_number();
+        let create_lock_amount = 100_000_000_000;
+        let increase_amount = 100_000;
+        let new_free = create_lock_amount + increase_amount;
+        let unlock_height = current_height + max_period;
+
+        set_balance(
+            EscrowAnnuityPallet::account_id(),
+            DEFAULT_NATIVE_CURRENCY,
+            100_000_000_000_000,
+        );
+        EscrowAnnuityPallet::update_reward_per_block();
+
+        set_balance(account_of(ALICE), DEFAULT_NATIVE_CURRENCY, new_free);
+        assert_ok!(RuntimeCall::Escrow(EscrowCall::create_lock {
+            amount: create_lock_amount,
+            unlock_height,
+        })
+        .dispatch(origin_of(account_of(ALICE))));
+
+        assert_eq!(
+            Runtime::estimate_escrow_reward_rate(account_of(ALICE), None, None)
+                .unwrap()
+                .truncate_to_inner()
+                .unwrap(),
+            999 // ~100_000%
+        );
+
+        assert_eq!(
+            Runtime::estimate_escrow_reward_rate(account_of(BOB), Some(create_lock_amount), Some(unlock_height))
+                .unwrap()
+                .truncate_to_inner()
+                .unwrap(),
+            499 // ~50_000%
+        );
+    });
+}

--- a/parachain/runtime/runtime-tests/src/utils.rs
+++ b/parachain/runtime/runtime-tests/src/utils.rs
@@ -11,7 +11,8 @@ pub use mocktopus::mocking::*;
 pub use orml_tokens::CurrencyAdapter;
 pub use primitives::{
     CurrencyId::{ForeignAsset, LendToken, Token},
-    Rate, Ratio, VaultCurrencyPair, VaultId as PrimitiveVaultId, DOT, IBTC, INTR, KBTC, KINT, KSM,
+    Rate, Ratio, TruncateFixedPointToInt, VaultCurrencyPair, VaultId as PrimitiveVaultId, DOT, IBTC, INTR, KBTC, KINT,
+    KSM,
 };
 use redeem::RedeemRequestStatus;
 use staking::DefaultVaultCurrencyPair;
@@ -180,6 +181,7 @@ pub type LoansPallet = loans::Pallet<Runtime>;
 pub type AuraPallet = pallet_aura::Pallet<Runtime>;
 
 pub type VaultAnnuityPallet = annuity::Pallet<Runtime, VaultAnnuityInstance>;
+pub type EscrowAnnuityPallet = annuity::Pallet<Runtime, EscrowAnnuityInstance>;
 
 pub const LEND_DOT: CurrencyId = LendToken(1);
 pub const LEND_KINT: CurrencyId = LendToken(2);


### PR DESCRIPTION
Related: https://github.com/interlay/interbtc/issues/843