### PR TITLE
fix: unsafe usage of unwrap in supply

### DIFF
--- a/crates/supply/src/benchmarking.rs
+++ b/crates/supply/src/benchmarking.rs
@@ -5,7 +5,7 @@ use super::*;
 use frame_benchmarking::v2::{benchmarks, impl_benchmark_test_suite};
 use frame_support::traits::OnInitialize;
 use frame_system::{self, RawOrigin as SystemOrigin};
-use sp_runtime::traits::One;
+use sp_runtime::traits::{One, Zero};
 use sp_std::prelude::*;
 
 #[benchmarks]

--- a/crates/supply/src/lib.rs
+++ b/crates/supply/src/lib.rs
@@ -26,10 +26,7 @@ use frame_system::ensure_root;
 use primitives::TruncateFixedPointToInt;
 use scale_info::TypeInfo;
 use sp_arithmetic::ArithmeticError;
-use sp_runtime::{
-    traits::{AccountIdConversion, Saturating},
-    FixedPointNumber,
-};
+use sp_runtime::{traits::AccountIdConversion, FixedPointNumber};
 
 mod default_weights;
 pub use default_weights::WeightInfo;
@@ -174,12 +171,9 @@ impl<T: Config> Pallet<T> {
             <StartHeight<T>>::put(end_height);
 
             let total_supply = T::Currency::total_issuance();
-            let total_supply_as_fixed =
-                T::UnsignedFixedPoint::checked_from_integer(total_supply).ok_or(ArithmeticError::Overflow)?;
-            let total_inflation = total_supply_as_fixed
-                .saturating_mul(<Inflation<T>>::get())
-                .truncate_to_inner()
-                .unwrap_or_default();
+            let total_inflation = <Inflation<T>>::get()
+                .checked_mul_int(total_supply)
+                .ok_or(ArithmeticError::Overflow)?;
 
             <LastEmission<T>>::put(total_inflation);
             let supply_account_id = Self::account_id();

--- a/crates/supply/src/mock.rs
+++ b/crates/supply/src/mock.rs
@@ -4,13 +4,12 @@ use frame_support::{
     traits::{Everything, GenesisBuild},
     PalletId,
 };
-pub use primitives::CurrencyId;
-use primitives::UnsignedFixedPoint;
+pub use primitives::{CurrencyId, UnsignedFixedPoint};
 use sp_core::H256;
+pub use sp_runtime::FixedPointNumber;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
-    FixedPointNumber,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;

--- a/crates/supply/src/tests.rs
+++ b/crates/supply/src/tests.rs
@@ -1,19 +1,40 @@
 /// Tests for Supply
 use crate::mock::*;
+use frame_support::{assert_err, assert_ok, traits::Currency};
+use sp_arithmetic::ArithmeticError;
 
 #[test]
 fn should_inflate_supply_from_start_height() {
     run_test(|| {
-        Supply::begin_block(0);
+        assert_ok!(Supply::begin_block(0));
         let mut start_height = 100;
         assert_eq!(Supply::start_height(), Some(start_height));
         assert_eq!(Supply::last_emission(), 0);
 
         for emission in [200_000, 204_000] {
-            Supply::begin_block(start_height);
+            assert_ok!(Supply::begin_block(start_height));
             start_height += YEARS;
             assert_eq!(Supply::start_height(), Some(start_height));
             assert_eq!(Supply::last_emission(), emission);
         }
+    })
+}
+
+#[test]
+fn should_not_inflate_total_supply() {
+    run_test(|| {
+        Balances::make_free_balance_be(&Supply::account_id(), u128::MAX);
+
+        let start_height = 100;
+        assert_ok!(Supply::set_start_height_and_inflation(
+            RuntimeOrigin::root(),
+            start_height,
+            UnsignedFixedPoint::checked_from_rational(2, 100).unwrap()
+        ));
+        assert_eq!(Supply::start_height(), Some(start_height));
+        assert_eq!(Supply::last_emission(), 0);
+
+        assert_err!(Supply::begin_block(start_height), ArithmeticError::Overflow);
+        assert_eq!(Balances::total_issuance(), u128::MAX);
     })
 }

--- a/crates/supply/src/tests.rs
+++ b/crates/supply/src/tests.rs
@@ -29,7 +29,7 @@ fn should_not_inflate_total_supply() {
         assert_ok!(Supply::set_start_height_and_inflation(
             RuntimeOrigin::root(),
             start_height,
-            UnsignedFixedPoint::checked_from_rational(2, 100).unwrap()
+            UnsignedFixedPoint::checked_from_rational(110, 100).unwrap()
         ));
         assert_eq!(Supply::start_height(), Some(start_height));
         assert_eq!(Supply::last_emission(), 0);


### PR DESCRIPTION
As reported by SRLabs:

## [High] Unsafe usage of unwrap() in supply::begin_block
### Summary

The conversion of `total_supply` to `FixedPointNumber` exceeds accuracy and returns None, which crashes the blockchain once `unwrap()` is called.

### Issue details

The [begin_block](https://github.com/interlay/interbtc/blob/76deccd239191d89812ea4db566be5776e56359d/crates/supply/src/lib.rs#L166) function from pallet **supply** will increase the Currency total_issuance based on the inflation rate, using [deposit_creating](https://github.com/interlay/interbtc/blob/76deccd239191d89812ea4db566be5776e56359d/crates/supply/src/lib.rs#L181).

Because total_supply can become too large, [checked_from_integer](https://github.com/interlay/interbtc/blob/76deccd239191d89812ea4db566be5776e56359d/crates/supply/src/lib.rs#L173) will return None and the a panic is being raised because of the [unwrap()](https://github.com/interlay/interbtc/blob/76deccd239191d89812ea4db566be5776e56359d/crates/supply/src/lib.rs#L173).

We tested the possibility of the crash by using the following values for the genesis of pallet supply:

```
supply::GenesisConfig::<Runtime> {
    initial_supply: 10_000_000,
    start_height: 100,
    inflation: UnsignedFixedPoint::checked_from_rational(2, 100).unwrap(), // 2%
}
```

By calling any extrinsic after 100 blocks (the value of `start_height`), the `unwrap()` call might fail, potentially causing nodes to panic.

### Risk
Once the blockchain reaches the start_height block, if the inflation rate is too high, the chain will crash.

### Mitigation

Review the logic of [begin_block](https://github.com/interlay/interbtc/blob/76deccd239191d89812ea4db566be5776e56359d/crates/supply/src/lib.rs#L166) and replace the [checked_from_integer](https://github.com/interlay/interbtc/blob/76deccd239191d89812ea4db566be5776e56359d/crates/supply/src/lib.rs#L173) function with an arithmetic safe function.