### PR TITLE
fix: swap_assets_for_exact_assets validation for tiny amounts

### DIFF
--- a/crates/dex-general/src/swap/mod.rs
+++ b/crates/dex-general/src/swap/mod.rs
@@ -468,7 +468,7 @@ impl<T: Config> Pallet<T> {
 
             let fee_rate = Self::pair_status(Self::sort_asset_id(path[i], path[i - 1])).fee_rate();
             let amount = Self::get_amount_in(out_vec[len - 1 - i], reserve_1, reserve_0, fee_rate)?;
-            ensure!(amount > One::one(), Error::<T>::InvalidPath);
+            ensure!(amount >= One::one(), Error::<T>::InvalidPath);
 
             // check K
             let invariant_before_swap: U256 = U256::from(reserve_0)


### PR DESCRIPTION
Without this, swapping would fail if the input amount was 1 satoshi/planck, which happened in the bring-your-own-fees usecase