### PR TITLE
feat: add scale encode and decode as traits to CurrencyId.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,8 @@ dependencies = [
  "bitcoin",
  "bstringify",
  "parity-scale-codec",
+ "scale-decode",
+ "scale-encode",
  "scale-info",
  "serde",
  "sp-core",
@@ -11975,6 +11977,69 @@ dependencies = [
  "parking_lot 0.12.1",
  "prometheus",
  "sp-arithmetic",
+]
+
+[[package]]
+name = "scale-bits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd7aca73785181cc41f0bbe017263e682b585ca660540ba569133901d013ecf"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0459d00b0dbd2e765009924a78ef36b2ff7ba116292d732f00eb0ed8e465d15"
+dependencies = [
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-decode-derive",
+ "scale-info",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "scale-decode-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4391f0dfbb6690f035f6d2a15d6a12f88cc5395c36bcc056db07ffa2a90870ec"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "scale-encode"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0401b7cdae8b8aa33725f3611a051358d5b32887ecaa0fda5953a775b2d4d76"
+dependencies = [
+ "parity-scale-codec",
+ "scale-encode-derive",
+ "scale-info",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "scale-encode-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316e0fb10ec0fee266822bd641bab5e332a4ab80ef8c5b5ff35e5401a394f5a6"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -14,6 +14,8 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.31", default-features = false }
+scale-decode = { version = "0.7.0", default-features = false, features = ["derive"], optional = true }
+scale-encode = { version = "0.3.0", default-features = false, features = ["derive"], optional = true }
 
 # Parachain dependencies
 bitcoin = { path = "../crates/bitcoin", default-features = false }
@@ -23,6 +25,8 @@ default = ["std"]
 std = [
     "serde",
     "codec/std",
+    "scale-decode",
+    "scale-encode",
 
     "sp-core/std",
     "sp-std/std",

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -3,6 +3,8 @@
 use bitcoin::{Address as BtcAddress, PublicKey as BtcPublicKey};
 use bstringify::bstringify;
 use codec::{Decode, Encode, MaxEncodedLen};
+use scale_decode::DecodeAsType;
+use scale_encode::EncodeAsType;
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -467,6 +469,7 @@ macro_rules! create_currency_id {
 create_currency_id! {
     #[derive(Encode, Decode, Eq, Hash, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo, MaxEncodedLen)]
     #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "std", derive(EncodeAsType,DecodeAsType))]
     #[repr(u8)]
     pub enum TokenSymbol {
         DOT("Polkadot", 10) = 0,
@@ -482,6 +485,7 @@ create_currency_id! {
 #[derive(Encode, Decode, Eq, Hash, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "std", derive(EncodeAsType, DecodeAsType))]
 pub enum LpToken {
     Token(TokenSymbol),
     ForeignAsset(ForeignAssetId),
@@ -491,6 +495,7 @@ pub enum LpToken {
 #[derive(Encode, Decode, Eq, Hash, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "std", derive(EncodeAsType, DecodeAsType))]
 pub enum CurrencyId {
     Token(TokenSymbol),
     ForeignAsset(ForeignAssetId),

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -3,7 +3,9 @@
 use bitcoin::{Address as BtcAddress, PublicKey as BtcPublicKey};
 use bstringify::bstringify;
 use codec::{Decode, Encode, MaxEncodedLen};
+#[cfg(feature = "std")]
 use scale_decode::DecodeAsType;
+#[cfg(feature = "std")]
 use scale_encode::EncodeAsType;
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]


### PR DESCRIPTION
The Pr adds the following things, 
- [x] scale encode and decode as a trait to `CurrencyId`, it is a dependency for PR [#483](https://github.com/interlay/interbtc-clients/pull/483), so that `Static` type wrapping can be avoided for `CurrenctId`
