### PR TITLE
chore: feature gate sp-runtime in primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4386,14 +4386,12 @@ dependencies = [
  "bitcoin",
  "bstringify",
  "parity-scale-codec",
+ "primitive-types",
  "scale-decode",
  "scale-encode",
  "scale-info",
  "serde",
- "sp-core",
  "sp-runtime",
- "sp-std",
- "xcm",
 ]
 
 [[package]]

--- a/crates/annuity/Cargo.toml
+++ b/crates/annuity/Cargo.toml
@@ -31,7 +31,6 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
 reward = { path = "../reward", default-features = false }
-primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/currency/src/mock.rs
+++ b/crates/currency/src/mock.rs
@@ -88,7 +88,7 @@ parameter_type_with_key! {
 impl orml_tokens::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type Balance = Balance;
-    type Amount = primitives::Amount;
+    type Amount = primitives::SignedBalance;
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;

--- a/crates/escrow/Cargo.toml
+++ b/crates/escrow/Cargo.toml
@@ -31,8 +31,6 @@ rand = "0.8.3"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
-primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
-
 [features]
 default = ["std"]
 std = [

--- a/crates/farming/Cargo.toml
+++ b/crates/farming/Cargo.toml
@@ -35,8 +35,6 @@ rand = "0.8.3"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
-primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
-
 [features]
 default = ["std"]
 std = [

--- a/crates/farming/src/mock.rs
+++ b/crates/farming/src/mock.rs
@@ -83,7 +83,7 @@ parameter_type_with_key! {
 impl orml_tokens::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type Balance = Balance;
-    type Amount = primitives::Amount;
+    type Amount = primitives::SignedBalance;
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;

--- a/crates/fee/Cargo.toml
+++ b/crates/fee/Cargo.toml
@@ -44,9 +44,6 @@ currency = { path = "../currency", features = ["testing-utils"] }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "dc39cfddefb10ef0de23655e2c3dcdab66a19404", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "dc39cfddefb10ef0de23655e2c3dcdab66a19404", default-features = false }
 
-# Parachain dependencies
-primitives = { package = "interbtc-primitives", path = "../../primitives"}
-
 [features]
 default = ["std"]
 std = [

--- a/crates/multi-transaction-payment/Cargo.toml
+++ b/crates/multi-transaction-payment/Cargo.toml
@@ -35,7 +35,6 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
-primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/oracle/src/mock.rs
+++ b/crates/oracle/src/mock.rs
@@ -100,7 +100,7 @@ parameter_type_with_key! {
 impl orml_tokens::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type Balance = Balance;
-    type Amount = primitives::Amount;
+    type Amount = primitives::SignedBalance;
     type CurrencyId = CurrencyId;
     type WeightInfo = ();
     type ExistentialDeposits = ExistentialDeposits;

--- a/crates/reward/Cargo.toml
+++ b/crates/reward/Cargo.toml
@@ -12,7 +12,7 @@ codec = { package = "parity-scale-codec", version = "3.1.5", default-features = 
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
 
 # Parachain dependencies
-primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
+primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false, features = ["substrate-compat"] }
 
 # Substrate dependencies
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
@@ -30,8 +30,6 @@ mocktopus = "0.8.0"
 rand = "0.8.3"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
-
-primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/staking/Cargo.toml
+++ b/crates/staking/Cargo.toml
@@ -35,8 +35,6 @@ rand = "0.8.3"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
-primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
-
 [features]
 default = ["std"]
 std = [

--- a/crates/supply/Cargo.toml
+++ b/crates/supply/Cargo.toml
@@ -30,8 +30,6 @@ rand = "0.8.3"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
 
-primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
-
 [features]
 default = ["std"]
 std = [

--- a/crates/traits/Cargo.toml
+++ b/crates/traits/Cargo.toml
@@ -30,7 +30,7 @@ frame-support = { git = "https://github.com/paritytech/substrate.git", branch = 
 frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.31", default-features = false }
 
 # Parachain dependencies
-primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false }
+primitives = { package = "interbtc-primitives", path = "../../primitives", default-features = false, features = ["substrate-compat"] }
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.31" }

--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -212,7 +212,7 @@ impl frame_system::Config for Runtime {
     /// The hashing algorithm used.
     type Hashing = BlakeTwo256;
     /// The header type.
-    type Header = generic::Header<BlockNumber, BlakeTwo256>;
+    type Header = Header;
     /// The ubiquitous event type.
     type RuntimeEvent = RuntimeEvent;
     /// The ubiquitous origin type.
@@ -692,7 +692,7 @@ where
 impl orml_tokens::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Balance = Balance;
-    type Amount = primitives::Amount;
+    type Amount = primitives::SignedBalance;
     type CurrencyId = CurrencyId;
     type WeightInfo = weights::orml_tokens::WeightInfo<Runtime>;
     type ExistentialDeposits = ExistentialDeposits;
@@ -1269,8 +1269,6 @@ construct_runtime! {
     }
 }
 
-/// The address format for describing accounts.
-pub type Address = AccountId;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.
@@ -1290,7 +1288,7 @@ pub type SignedExtra = (
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<AccountId, RuntimeCall, Signature, SignedExtra>;
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
 /// Executive: handles dispatch to the various modules.

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -210,7 +210,7 @@ impl frame_system::Config for Runtime {
     /// The hashing algorithm used.
     type Hashing = BlakeTwo256;
     /// The header type.
-    type Header = generic::Header<BlockNumber, BlakeTwo256>;
+    type Header = Header;
     /// The ubiquitous event type.
     type RuntimeEvent = RuntimeEvent;
     /// The ubiquitous origin type.
@@ -691,7 +691,7 @@ where
 impl orml_tokens::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Balance = Balance;
-    type Amount = primitives::Amount;
+    type Amount = primitives::SignedBalance;
     type CurrencyId = CurrencyId;
     type WeightInfo = weights::orml_tokens::WeightInfo<Runtime>;
     type ExistentialDeposits = ExistentialDeposits;
@@ -1269,8 +1269,6 @@ construct_runtime! {
     }
 }
 
-/// The address format for describing accounts.
-pub type Address = AccountId;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.
@@ -1290,7 +1288,7 @@ pub type SignedExtra = (
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<AccountId, RuntimeCall, Signature, SignedExtra>;
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
 /// Executive: handles dispatch to the various modules.

--- a/parachain/src/service.rs
+++ b/parachain/src/service.rs
@@ -25,6 +25,7 @@ use sp_consensus_aura::{
     sr25519::{AuthorityId as AuraId, AuthorityPair as AuraPair},
     SlotDuration,
 };
+use sp_core::H256;
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::BlakeTwo256;
 use std::{sync::Arc, time::Duration};

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -8,30 +8,30 @@ version = "1.2.0"
 bstringify = "0.1.2"
 serde = { version = "1.0.130", optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+primitive-types = { version = "0.12.1", default-features = false, features = ["codec", "scale-info"] }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
-
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false }
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.31", default-features = false }
 scale-decode = { version = "0.7.0", default-features = false, features = ["derive"], optional = true }
 scale-encode = { version = "0.3.0", default-features = false, features = ["derive"], optional = true }
+
+# Substrate dependencies
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.31", default-features = false, optional = true }
 
 # Parachain dependencies
 bitcoin = { path = "../crates/bitcoin", default-features = false }
 
 [features]
-default = ["std"]
+default = ["std", "substrate-compat"]
 std = [
     "serde",
     "codec/std",
+	"primitive-types/std",
+	"primitive-types/serde",
     "scale-decode",
     "scale-encode",
 
-    "sp-core/std",
-    "sp-std/std",
-    "sp-runtime/std",
+    "sp-runtime?/std",
 
     "bitcoin/std",
 ]
 runtime-benchmarks = []
+substrate-compat = ["sp-runtime"]


### PR DESCRIPTION
Adds `substrate-compat` feature so `interbtc-primitives` can be used downstream without pulling in `sp-runtime`.