### PR TITLE
fix: only adjust kintsugi mainnet slot duration

### DIFF
--- a/parachain/runtime/interlay/src/lib.rs
+++ b/parachain/runtime/interlay/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("interlay-parachain"),
     impl_name: create_runtime_str!("interlay-parachain"),
     authoring_version: 1,
-    spec_version: 1025000,
+    spec_version: 1025001,
     impl_version: 1,
     transaction_version: 4,
     apis: RUNTIME_API_VERSIONS,

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("kintsugi-parachain"),
     impl_name: create_runtime_str!("kintsugi-parachain"),
     authoring_version: 1,
-    spec_version: 1025000,
+    spec_version: 1025001,
     impl_version: 1,
     transaction_version: 4,
     apis: RUNTIME_API_VERSIONS,

--- a/parachain/src/eth.rs
+++ b/parachain/src/eth.rs
@@ -1,5 +1,4 @@
 use crate::service::{FullBackend, FullClient};
-use cumulus_client_consensus_common::ParachainBlockImportMarker;
 pub use fc_consensus::FrontierBlockImport;
 use fc_rpc::{EthTask, OverrideHandle};
 pub use fc_rpc_core::types::{FeeHistoryCache, FeeHistoryCacheLimit, FilterPool};
@@ -7,14 +6,11 @@ use fp_rpc::EthereumRuntimeRPCApi;
 use futures::{future, prelude::*};
 use primitives::Block;
 use sc_client_api::{BlockchainEvents, StateBackendFor};
-use sc_consensus::{BlockCheckParams, BlockImport as BlockImportT, BlockImportParams, ImportResult};
 use sc_executor::NativeExecutionDispatch;
 use sc_network_sync::SyncingService;
 use sc_service::{error::Error as ServiceError, BasePath, Configuration, TaskManager};
 use sc_transaction_pool::{ChainApi, Pool};
 use sp_api::{ConstructRuntimeApi, ProvideRuntimeApi};
-use sp_block_builder::BlockBuilder as BlockBuilderApi;
-use sp_consensus::Error as ConsensusError;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
 use std::{
     collections::BTreeMap,
@@ -200,7 +196,7 @@ pub async fn spawn_frontier_tasks<RuntimeApi, Executor>(
                     overrides.clone(),
                     Arc::new(b),
                     3,
-                    0,
+                    0, // TODO: update when deployed
                     fc_mapping_sync::SyncStrategy::Normal,
                     sync,
                     pubsub_notification_sinks,
@@ -247,48 +243,6 @@ pub async fn spawn_frontier_tasks<RuntimeApi, Executor>(
         EthTask::fee_history_task(client, overrides, fee_history_cache, fee_history_cache_limit),
     );
 }
-
-#[derive(Clone)]
-pub struct BlockImport<B: BlockT, I: BlockImportT<B>, C>(FrontierBlockImport<B, I, C>);
-
-impl<B, I, C> BlockImport<B, I, C>
-where
-    B: BlockT,
-    I: BlockImportT<B, Transaction = sp_api::TransactionFor<C, B>>,
-    I::Error: Into<ConsensusError>,
-    C: ProvideRuntimeApi<B>,
-    C::Api: BlockBuilderApi<B> + EthereumRuntimeRPCApi<B>,
-{
-    pub fn new(inner: I, client: Arc<C>) -> Self {
-        Self(FrontierBlockImport::new(inner, client))
-    }
-}
-
-#[async_trait::async_trait]
-impl<B, I, C> BlockImportT<B> for BlockImport<B, I, C>
-where
-    B: BlockT,
-    I: BlockImportT<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync,
-    I::Error: Into<ConsensusError>,
-    C: ProvideRuntimeApi<B> + Send + Sync,
-    C::Api: BlockBuilderApi<B> + EthereumRuntimeRPCApi<B>,
-{
-    type Error = ConsensusError;
-    type Transaction = sp_api::TransactionFor<C, B>;
-
-    async fn check_block(&mut self, block: BlockCheckParams<B>) -> Result<ImportResult, Self::Error> {
-        self.0.check_block(block).await
-    }
-
-    async fn import_block(
-        &mut self,
-        block: BlockImportParams<B, Self::Transaction>,
-    ) -> Result<ImportResult, Self::Error> {
-        self.0.import_block(block).await
-    }
-}
-
-impl<B: BlockT, I: BlockImportT<B>, C> ParachainBlockImportMarker for BlockImport<B, I, C> {}
 
 pub fn new_eth_deps<C, P, A: ChainApi, CT>(
     client: Arc<C>,

--- a/parachain/src/service.rs
+++ b/parachain/src/service.rs
@@ -189,6 +189,12 @@ type MaybeFullSelectChain = Option<LongestChain<FullBackend, Block>>;
 type ParachainBlockImport<RuntimeApi, ExecutorDispatch> =
     TParachainBlockImport<Block, Arc<FullClient<RuntimeApi, ExecutorDispatch>>, FullBackend>;
 
+// 0x9af9a64e6e4da8e3073901c3ff0cc4c3aad9563786d89daf6ad820b6e14a0b8b
+const KINTSUGI_GENESIS_HASH: H256 = H256([
+    154, 249, 166, 78, 110, 77, 168, 227, 7, 57, 1, 195, 255, 12, 196, 195, 170, 217, 86, 55, 134, 216, 157, 175, 106,
+    216, 32, 182, 225, 74, 11, 139,
+]);
+
 fn import_slot_duration<C>(client: &C) -> SlotDuration
 where
     C: sc_client_api::backend::AuxStore
@@ -198,7 +204,11 @@ where
     C::Api: sp_consensus_aura::AuraApi<Block, AuraId>,
 {
     match client.runtime_version_at(client.usage_info().chain.best_hash) {
-        Ok(x) if x.spec_name.starts_with("kintsugi") && client.usage_info().chain.best_number < 1983993 => {
+        Ok(x)
+            if x.spec_name.starts_with("kintsugi")
+                && client.usage_info().chain.genesis_hash == KINTSUGI_GENESIS_HASH
+                && client.usage_info().chain.best_number < 1983993 =>
+        {
             // the kintsugi runtime was misconfigured at genesis to use a slot duration of 6s
             // which stalled collators when we upgraded to polkadot-v0.9.16 and subsequently
             // broke mainnet when we introduced the aura timestamp hook, collators should only

--- a/parachain/src/service.rs
+++ b/parachain/src/service.rs
@@ -203,22 +203,19 @@ where
         + sp_api::CallApiAt<Block>,
     C::Api: sp_consensus_aura::AuraApi<Block, AuraId>,
 {
-    match client.runtime_version_at(client.usage_info().chain.best_hash) {
-        Ok(x)
-            if x.spec_name.starts_with("kintsugi")
-                && client.usage_info().chain.genesis_hash == KINTSUGI_GENESIS_HASH
-                && client.usage_info().chain.best_number < 1983993 =>
-        {
-            // the kintsugi runtime was misconfigured at genesis to use a slot duration of 6s
-            // which stalled collators when we upgraded to polkadot-v0.9.16 and subsequently
-            // broke mainnet when we introduced the aura timestamp hook, collators should only
-            // switch when syncing after the (failed) 1.20.0 upgrade
-            SlotDuration::from_millis(6000)
-        }
+    if client.usage_info().chain.genesis_hash == KINTSUGI_GENESIS_HASH
+        && client.usage_info().chain.best_number < 1983993
+    {
+        // the kintsugi runtime was misconfigured at genesis to use a slot duration of 6s
+        // which stalled collators when we upgraded to polkadot-v0.9.16 and subsequently
+        // broke mainnet when we introduced the aura timestamp hook, collators should only
+        // switch when syncing after the (failed) 1.20.0 upgrade
+        SlotDuration::from_millis(6000)
+    } else {
         // this is pallet_timestamp::MinimumPeriod * 2 at the current height
         // on kintsugi we increased MinimumPeriod from 3_000 to 6_000 at 16_593
         // but the interlay runtime has always used 6_000
-        _ => sc_consensus_aura::slot_duration(&*client).unwrap(),
+        sc_consensus_aura::slot_duration(&*client).unwrap()
     }
 }
 


### PR DESCRIPTION
Caused the testnet deployment to fail because it was trying to use the 6s slot duration configured for old kintsugi mainnet imports.

Also ran into [this issue](https://github.com/paritytech/frontier/issues/603) when trying to sync, solved by removing the `FrontierBlockImport` wrapper.