### PR TITLE
chore: update benchmark workflow to trim too long output

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -83,7 +83,8 @@ jobs:
           script: |
             const fs = require('fs')
             const id = `${{steps.comment.outputs.result}}`
-            const body = fs.readFileSync('${{runner.temp}}/out.txt').toString()
+            // trim body to fit within max allowed payload of 65536 characters
+            const body = fs.readFileSync('${{runner.temp}}/out.txt').toString().substring(0, 64000)
             github.rest.issues.updateComment({
               comment_id: id,
               owner: context.repo.owner,


### PR DESCRIPTION
The output of the benchmark script can be too long - more than the allowed 65536 characters for a github PR comment.
This change will trim the output so it can be accepted by the Github PR API. The full output remains available in the github action run log.