### PR TITLE
feat(wip): embedded relayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.10",
+ "instant",
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +623,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "beef"
@@ -674,9 +694,50 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
+dependencies = [
+ "bech32",
+ "bitcoin-private",
+ "bitcoin_hashes 0.12.0",
+ "hex_lit",
+ "secp256k1 0.27.0",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "1.1.0"
+dependencies = [
+ "async-trait",
+ "backoff",
+ "bitcoincore-rpc",
+ "cfg-if",
+ "clap",
+ "futures",
+ "hex",
+ "hyper",
+ "log",
+ "num 0.2.1",
+ "num-derive",
+ "num-traits",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.8.2",
+ "sp-core",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "bitcoin"
 version = "1.2.0"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.7.6",
  "frame-support",
  "hex",
  "impl-serde 0.3.2",
@@ -691,10 +752,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b375d62f341cef9cd9e77793ec8f1db3fc9ce2e4d57e982c8fe697a2c16af3b6"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+ "serde",
+]
+
+[[package]]
+name = "bitcoincore-rpc"
+version = "0.17.0"
+dependencies = [
+ "bitcoin-private",
+ "bitcoincore-rpc-json",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.17.0"
+dependencies = [
+ "bitcoin 0.30.1",
+ "bitcoin-private",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "bitflags"
@@ -861,7 +960,7 @@ checksum = "bd769563b4ea2953e2825c9e6b7470a5f55f67e0be00030bf3e390a2a6071f64"
 name = "btc-relay"
 version = "1.2.0"
 dependencies = [
- "bitcoin",
+ "bitcoin 1.2.0",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -2354,7 +2453,7 @@ dependencies = [
  "asn1-rs 0.3.1",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.3",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2368,7 +2467,7 @@ dependencies = [
  "asn1-rs 0.5.2",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.3",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2818,6 +2917,15 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -4402,6 +4510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,6 +4659,19 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4751,7 +4878,8 @@ name = "interbtc-parachain"
 version = "1.2.0"
 dependencies = [
  "async-trait",
- "bitcoin",
+ "bitcoin 1.1.0",
+ "bitcoin 1.2.0",
  "btc-relay-rpc-runtime-api",
  "clap",
  "cumulus-client-cli",
@@ -4784,6 +4912,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "futures",
+ "hex",
  "hex-literal 0.2.2",
  "interbtc-primitives",
  "interbtc-rpc",
@@ -4795,6 +4924,7 @@ dependencies = [
  "loans-rpc-runtime-api",
  "log",
  "oracle-rpc-runtime-api",
+ "pallet-balances",
  "pallet-evm",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
@@ -4844,6 +4974,7 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
+ "tokio",
  "try-runtime-cli",
  "vault-registry-rpc-runtime-api",
 ]
@@ -4852,7 +4983,7 @@ dependencies = [
 name = "interbtc-primitives"
 version = "1.2.0"
 dependencies = [
- "bitcoin",
+ "bitcoin 1.2.0",
  "bstringify",
  "parity-scale-codec",
  "primitive-types",
@@ -4930,7 +5061,7 @@ name = "interlay-runtime-parachain"
 version = "1.2.0"
 dependencies = [
  "annuity",
- "bitcoin",
+ "bitcoin 1.2.0",
  "btc-relay",
  "btc-relay-rpc-runtime-api",
  "clients-info",
@@ -5072,7 +5203,7 @@ dependencies = [
  "socket2 0.5.3",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -5097,7 +5228,7 @@ dependencies = [
 name = "issue"
 version = "1.2.0"
 dependencies = [
- "bitcoin",
+ "bitcoin 1.2.0",
  "btc-relay",
  "currency",
  "fee",
@@ -5180,6 +5311,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpc"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8128f36b47411cd3f044be8c1f5cc0c9e24d1d1bfdc45f0a57897b32513053f2"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5353,7 +5495,7 @@ name = "kintsugi-runtime-parachain"
 version = "1.2.0"
 dependencies = [
  "annuity",
- "bitcoin",
+ "bitcoin 1.2.0",
  "btc-relay",
  "btc-relay-rpc-runtime-api",
  "clients-info",
@@ -6544,6 +6686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6803,8 +6951,8 @@ dependencies = [
  "approx",
  "matrixmultiply",
  "nalgebra-macros",
- "num-complex",
- "num-rational",
+ "num-complex 0.4.3",
+ "num-rational 0.4.1",
  "num-traits",
  "simba",
  "typenum",
@@ -6987,15 +7135,40 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint 0.2.6",
+ "num-complex 0.2.4",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.2.4",
+ "num-traits",
+]
+
+[[package]]
+name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
- "num-bigint",
- "num-complex",
+ "num-bigint 0.4.3",
+ "num-complex 0.4.3",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.4.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
  "num-traits",
 ]
 
@@ -7012,11 +7185,32 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7052,12 +7246,24 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg 1.1.0",
- "num-bigint",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
 ]
@@ -7937,7 +8143,7 @@ version = "2.0.0-dev"
 source = "git+https://github.com/paritytech/frontier?branch=polkadot-v0.9.42#1a718546085be20ce381b70e1f9e4c8b4d4b1f03"
 dependencies = [
  "fp-evm",
- "num",
+ "num 0.4.1",
 ]
 
 [[package]]
@@ -8644,7 +8850,7 @@ name = "parachain-tests"
 version = "1.2.0"
 dependencies = [
  "annuity",
- "bitcoin",
+ "bitcoin 1.2.0",
  "btc-relay",
  "btc-relay-rpc-runtime-api",
  "clients-info",
@@ -10896,7 +11102,7 @@ dependencies = [
 name = "redeem"
 version = "1.2.0"
 dependencies = [
- "bitcoin",
+ "bitcoin 1.2.0",
  "btc-relay",
  "currency",
  "fee",
@@ -11069,7 +11275,7 @@ dependencies = [
 name = "replace"
 version = "1.2.0"
 dependencies = [
- "bitcoin",
+ "bitcoin 1.2.0",
  "btc-relay",
  "currency",
  "fee",
@@ -11117,6 +11323,43 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-std",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+dependencies = [
+ "base64 0.21.2",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite 0.2.9",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -11888,8 +12131,8 @@ dependencies = [
  "fork-tree",
  "futures",
  "log",
- "num-bigint",
- "num-rational",
+ "num-bigint 0.4.3",
+ "num-rational 0.4.1",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -13017,6 +13260,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "bitcoin_hashes 0.12.0",
+ "rand 0.8.5",
+ "secp256k1-sys 0.8.1",
+ "serde",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.4.0"
 source = "git+https://github.com/rust-bitcoin/rust-secp256k1?rev=8e61874#8e61874d7706143f90a303e8077f69cb8873edff"
@@ -13029,6 +13284,15 @@ name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
@@ -13144,6 +13408,18 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -13268,7 +13544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx",
- "num-complex",
+ "num-complex 0.4.3",
  "num-traits",
  "paste",
  "wide",
@@ -14853,6 +15129,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15094,7 +15380,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "interbtc-primitives",
  "log",
- "num-bigint",
+ "num-bigint 0.4.3",
  "num-traits",
  "parity-scale-codec",
  "scale-info",
@@ -15430,7 +15716,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 name = "vault-registry"
 version = "1.2.0"
 dependencies = [
- "bitcoin",
+ "bitcoin 1.2.0",
  "currency",
  "fee",
  "fixed-hash 0.7.0",
@@ -15762,7 +16048,7 @@ dependencies = [
  "downcast-rs",
  "libm 0.2.7",
  "memory_units",
- "num-rational",
+ "num-rational 0.4.1",
  "num-traits",
  "region",
 ]
@@ -16595,6 +16881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/crates/bitcoin/src/parser.rs
+++ b/crates/bitcoin/src/parser.rs
@@ -413,7 +413,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_parse_block_header() {
-        let hex_header = sample_block_header();
+        let hex_header = "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f2002000000";
         let parsed_header = BlockHeader::from_hex(&hex_header).unwrap();
         assert_eq!(parsed_header.version, 4);
         assert_eq!(parsed_header.timestamp, 1415239972);

--- a/crates/btc-relay/src/lib.rs
+++ b/crates/btc-relay/src/lib.rs
@@ -352,7 +352,7 @@ pub mod pallet {
 
     /// BTC height when the relay was initialized
     #[pallet::storage]
-    pub(super) type StartBlockHeight<T: Config> = StorageValue<_, u32, ValueQuery>;
+    pub type StartBlockHeight<T: Config> = StorageValue<_, u32, ValueQuery>;
 
     /// Increment-only counter used to track new BlockChain entries
     #[pallet::storage]

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -25,13 +25,15 @@ futures = "0.3.15"
 jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
 serde_json = "1.0.68"
 regex = "1.5.6"
+bitcoin_client = { path = "../../polkabtc-clients/bitcoin/", package = "bitcoin", features=["cli"]}
+hex = "0.4.2"
 
 # Parachain dependencies
 interlay-runtime = { package = "interlay-runtime-parachain", path = "./runtime/interlay" }
 kintsugi-runtime = { package = "kintsugi-runtime-parachain", path = "./runtime/kintsugi" }
 runtime-common = { package = "runtime-common", path = "./runtime/common" }
 interbtc-rpc = { path = "../rpc" }
-bitcoin = { path = "../crates/bitcoin" }
+bitcoin = { path = "../crates/bitcoin", features = ["parser"] }
 loans = { path = "../crates/loans" }
 primitives = { package = "interbtc-primitives", path = "../primitives" }
 
@@ -123,6 +125,9 @@ fc-rpc-core = { git = "https://github.com/paritytech/frontier", branch = "polkad
 fp-evm = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v0.9.42" }
 fp-rpc = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v0.9.42" }
 pallet-evm = { git = "https://github.com/paritytech/frontier", branch = "polkadot-v0.9.42" }
+
+tokio = "1.22.0"
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
 
 [features]
 default = []

--- a/parachain/runtime/kintsugi/src/lib.rs
+++ b/parachain/runtime/kintsugi/src/lib.rs
@@ -75,7 +75,7 @@ pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{FixedU128, Perbill, Permill};
 
 // interBTC exports
-pub use btc_relay::{bitcoin, Call as BtcRelayCall, TARGET_SPACING};
+pub use btc_relay::{self, bitcoin, Call as BtcRelayCall, TARGET_SPACING};
 pub use constants::{currency::*, time::*};
 pub use oracle_rpc_runtime_api::BalanceWrapper;
 pub use orml_asset_registry::AssetMetadata;

--- a/parachain/src/cli.rs
+++ b/parachain/src/cli.rs
@@ -90,6 +90,10 @@ pub struct Cli {
     #[clap(flatten)]
     pub eth: EthConfiguration,
 
+    /// Connection settings for Bitcoin Core for relay purposes.
+    #[clap(flatten)]
+    pub bitcoin: bitcoin_client::cli::BitcoinOpts,
+
     /// Relaychain arguments
     #[clap(raw = true)]
     pub relaychain_args: Vec<String>,

--- a/parachain/src/command.rs
+++ b/parachain/src/command.rs
@@ -470,6 +470,10 @@ pub fn run() -> Result<()> {
 
             runner
                 .run_node_until_exit(|config| async move {
+                    log::info!("Im here");
+                    // let bitcoin_rpc = cli.bitcoin.new_client(None).await.unwrap();
+                    // plan: use pool.
+                    // bitcoin_rpc.
                     if cli.instant_seal {
                         start_instant(cli, config).await
                     } else {
@@ -484,6 +488,7 @@ pub fn run() -> Result<()> {
 async fn start_instant(cli: Cli, config: Configuration) -> sc_service::error::Result<TaskManager> {
     with_runtime_or_err!(config.chain_spec, {
         {
+            log::info!("starting instant..");
             crate::service::start_instant::<RuntimeApi, Executor, TransactionConverter>(config, cli.eth)
                 .await
                 .map(|r| r.0)


### PR DESCRIPTION
Obviously still very much a wip.The idea is to implement the `Issuing` trait inside the node service. Making transactions and reading storage works, but todo:

- [ ] Implement get_block_hash, is_block_stored
- [ ] the tx submission is non-blocking atm. This needs to be made blocking, perhaps by using `submit_and_watch` instead of `submit_one`
- [ ] Storage addresses are hardcoded - use metadata or some other way to avoid hardcoding hex addresses
- [ ] get rid of unwraps
- [ ] Current version is hardcoded for kintsugi, we need to make it also work for interlay
- [ ] Needs to be optional
- [ ] The client dependency is using a hardcoded path that only works on my machine. Make the required changes to the client and use git again