### PR TITLE
chore: fix srtool github action

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -25,6 +25,7 @@ jobs:
           package: ${{ matrix.runtime }}-runtime-parachain
           runtime_dir: ./parachain/runtime/${{ matrix.runtime }}
           chain: ${{ matrix.runtime }}
+          workdir: ${{ github.workspace }}
       - name: Store srtool digest to disk
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.runtime }}_srtool_output.json


### PR DESCRIPTION
[chevdor/srtool-actions@v0.8.0](https://github.com/chevdor/srtool-actions/commit/462c61a95012e26a248075d34a2d7f33ec403c54#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6) introduced a default value for `workdir` which breaks the docker.

This change reverts to the old behavior of using `github.workspace` for WORKDIR.
