### PR TITLE
fix: don't mint kbtc in cancel_redeem for liquidated vault

### DIFF
--- a/parachain/runtime/runtime-tests/src/parachain/redeem.rs
+++ b/parachain/runtime/runtime-tests/src/parachain/redeem.rs
@@ -963,16 +963,14 @@ mod spec_based_tests {
                         // to-be-redeemed decreased, forwarding to liquidation vault
                         vault.to_be_redeemed -= redeem.amount_btc() + redeem.transfer_fee_btc();
                         liquidation_vault.to_be_redeemed -= redeem.amount_btc() + redeem.transfer_fee_btc();
+                        liquidation_vault.issued -= redeem.amount_btc() + redeem.transfer_fee_btc();
 
                         *fee_pool.rewards_for(&vault_id) += redeem.fee();
 
                         // the collateral that remained with the vault to back this redeem is now transferred to the
-                        // liquidation vault
+                        // user
                         let collateral_for_this_redeem = collateral_vault / 4;
                         vault.liquidated_collateral -= collateral_for_this_redeem;
-
-                        *vault.free_balance.get_mut(&vault_id.wrapped_currency()).unwrap() +=
-                            redeem.amount_btc() + redeem.transfer_fee_btc();
 
                         // user's tokens get unlocked
                         (*user.balances.get_mut(&vault_id.wrapped_currency()).unwrap()).locked -=
@@ -1780,10 +1778,12 @@ fn integration_test_redeem_wrapped_cancel_liquidated_reimburse() {
                 // to-be-redeemed decreased, forwarding to liquidation vault
                 vault.to_be_redeemed -= redeem.amount_btc() + redeem.transfer_fee_btc();
                 liquidation_vault.to_be_redeemed -= redeem.amount_btc() + redeem.transfer_fee_btc();
+                // decrease issued tokens on the liquidation vault by the same amount, s.t. the
+                // effective exchange rate (i.e. the one accounting for to_be_redeemed tokens)
+                // of the liquidation vault does not change.
+                liquidation_vault.issued -= redeem.amount_btc() + redeem.transfer_fee_btc();
 
                 // tokens are given to the vault, minus a fee that is given to the fee pool
-                *vault.free_balance.get_mut(&vault_id.wrapped_currency()).unwrap() +=
-                    redeem.amount_btc() + redeem.transfer_fee_btc();
                 *fee_pool.rewards_for(&vault_id) += redeem.fee();
 
                 // the collateral that remained with the vault to back this redeem is transferred to the user


### PR DESCRIPTION
On `cancel_redeem` we have two branches:
- **Retry**: Vault loses 10% collateral
- **Reimburse**: Vault loses 110% collateral, to get it back to 10% effective loss they get to have the equivalent of 100% in KBTC

Unfortunately this doesn't account for the case when the Vault is liquidated, which on reimburse would still send them the "to-be-burned" KBTC. However because the Vault is already liquidated there is insufficient collateral to back these tokens, they should be burned and the accounting on the liquidation vault should be updated to reflect the decreased issued tokens.