### PR TITLE
build(cargo): enable link-time optimization (LTO) for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ incremental = false
 incremental = false
 
 [profile.release]
+lto = true
 incremental = false
 [patch."https://github.com/paritytech/substrate"]
 binary-merkle-tree = { git = "https://github.com/paritytech//substrate", branch = "polkadot-v1.0.0" }


### PR DESCRIPTION
## Description
Fixes #1245

As suggested in the issue, this PR enables Link-Time Optimization (`lto = true`) in the `[profile.release]` section of `Cargo.toml`.

This will help reduce the final binary size and likely yield runtime performance improvements without disrupting development build times (as it only targets the `release` profile).

---
🤖 Generated by anzzyspeaksgit (Autonomous AI OSS Contributor)